### PR TITLE
Clean up local worktrees and issue branches after PR merge

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -297,6 +297,13 @@ func (a *App) ScanOnce(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		sessions, err = a.cleanupMergedSessions(ctx, sessions)
+		if err != nil {
+			return err
+		}
+		if err := a.state.SaveSessions(sessions); err != nil {
+			return err
+		}
 		startedCount := 0
 
 		for i := range targets {
@@ -367,6 +374,57 @@ func (a *App) ScanOnce(ctx context.Context) error {
 		return nil
 	}
 	return nil
+}
+
+func (a *App) cleanupMergedSessions(ctx context.Context, sessions []state.Session) ([]state.Session, error) {
+	for i := range sessions {
+		session := &sessions[i]
+		if session.Status != state.SessionStatusSuccess || session.CleanupCompletedAt != "" {
+			continue
+		}
+
+		pr, err := ghcli.FindPullRequestForBranch(ctx, a.env.Runner, session.Repo, session.Branch)
+		if err != nil {
+			session.CleanupError = err.Error()
+			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			a.state.AppendDaemonLog("cleanup pr lookup failed repo=%s issue=%d branch=%s err=%v", session.Repo, session.IssueNumber, session.Branch, err)
+			continue
+		}
+		if pr == nil {
+			continue
+		}
+
+		session.PullRequestNumber = pr.Number
+		session.PullRequestURL = pr.URL
+		if pr.MergedAt == nil {
+			session.CleanupError = ""
+			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			continue
+		}
+
+		session.PullRequestMergedAt = pr.MergedAt.UTC().Format(time.RFC3339)
+		if err := worktree.CleanupIssueArtifacts(ctx, a.env.Runner, session.RepoPath, session.WorktreePath, session.Branch); err != nil {
+			session.CleanupError = err.Error()
+			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			a.state.AppendDaemonLog("cleanup failed repo=%s issue=%d branch=%s worktree=%s err=%v", session.Repo, session.IssueNumber, session.Branch, session.WorktreePath, err)
+			continue
+		}
+
+		session.CleanupCompletedAt = a.clock().Format(time.RFC3339)
+		session.CleanupError = ""
+		session.UpdatedAt = session.CleanupCompletedAt
+		a.state.AppendDaemonLog(
+			"cleanup complete repo=%s issue=%d pr=%d branch=%s worktree=%s merged_at=%s",
+			session.Repo,
+			session.IssueNumber,
+			session.PullRequestNumber,
+			session.Branch,
+			session.WorktreePath,
+			session.PullRequestMergedAt,
+		)
+	}
+
+	return sessions, nil
 }
 
 func (a *App) ensureTooling(ctx context.Context) error {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -211,6 +211,71 @@ func TestScanOncePrintsNoEligibleIssues(t *testing.T) {
 	}
 }
 
+func TestScanOnceCleansUpMergedIssueSession(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	var stdout bytes.Buffer
+	app := New()
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","mergedAt":"2026-03-10T15:00:00Z"}]`,
+			"git worktree prune":                                                             "ok",
+			"git worktree list --porcelain":                                                  "worktree /tmp/repo\nHEAD abcdef\nbranch refs/heads/main\n",
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1":                     "ok",
+			"git branch -D vigilante/issue-1":                                                "Deleted branch vigilante/issue-1\n",
+			"gh issue list --repo owner/repo --state open --json number,title,createdAt,url": "[]",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:     "/tmp/repo",
+		Repo:         "owner/repo",
+		IssueNumber:  1,
+		Branch:       "vigilante/issue-1",
+		WorktreePath: filepath.Join("/tmp/repo", ".worktrees", "vigilante", "issue-1"),
+		Status:       state.SessionStatusSuccess,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if sessions[0].PullRequestNumber != 31 || sessions[0].PullRequestURL != "https://github.com/owner/repo/pull/31" {
+		t.Fatalf("expected pull request to be tracked: %#v", sessions[0])
+	}
+	if sessions[0].PullRequestMergedAt != "2026-03-10T15:00:00Z" {
+		t.Fatalf("expected merged time to be tracked: %#v", sessions[0])
+	}
+	if sessions[0].CleanupCompletedAt == "" {
+		t.Fatalf("expected cleanup to complete: %#v", sessions[0])
+	}
+	if sessions[0].CleanupError != "" {
+		t.Fatalf("unexpected cleanup error: %#v", sessions[0])
+	}
+	if got := stdout.String(); !strings.Contains(got, "repo: owner/repo no eligible issues (0 open)") {
+		t.Fatalf("unexpected output: %s", got)
+	}
+}
+
 func TestScanOnceSkipsWhenAnotherProcessHoldsScanLock(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -19,6 +19,12 @@ type Issue struct {
 	URL       string    `json:"url"`
 }
 
+type PullRequest struct {
+	Number   int        `json:"number"`
+	URL      string     `json:"url"`
+	MergedAt *time.Time `json:"mergedAt"`
+}
+
 func ListOpenIssues(ctx context.Context, runner environment.Runner, repo string) ([]Issue, error) {
 	output, err := runner.Run(ctx, "", "gh", "issue", "list", "--repo", repo, "--state", "open", "--json", "number,title,createdAt,url")
 	if err != nil {
@@ -52,4 +58,20 @@ func SelectNextIssue(issues []Issue, sessions []state.Session, repo string) *Iss
 func CommentOnIssue(ctx context.Context, runner environment.Runner, repo string, number int, body string) error {
 	_, err := runner.Run(ctx, "", "gh", "issue", "comment", "--repo", repo, fmt.Sprintf("%d", number), "--body", body)
 	return err
+}
+
+func FindPullRequestForBranch(ctx context.Context, runner environment.Runner, repo string, branch string) (*PullRequest, error) {
+	output, err := runner.Run(ctx, "", "gh", "pr", "list", "--repo", repo, "--head", branch, "--state", "all", "--json", "number,url,mergedAt")
+	if err != nil {
+		return nil, err
+	}
+
+	var prs []PullRequest
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &prs); err != nil {
+		return nil, fmt.Errorf("parse gh pr list output: %w", err)
+	}
+	if len(prs) == 0 {
+		return nil, nil
+	}
+	return &prs[0], nil
 }

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -3,6 +3,7 @@ package ghcli
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/nicobistolfi/vigilante/internal/state"
 	"github.com/nicobistolfi/vigilante/internal/testutil"
@@ -24,5 +25,27 @@ func TestListOpenIssuesAndSelectNext(t *testing.T) {
 	next := SelectNextIssue(issues, []state.Session{{Repo: "owner/repo", IssueNumber: 1, Status: state.SessionStatusRunning}}, "owner/repo")
 	if next == nil || next.Number != 2 {
 		t.Fatalf("unexpected next issue: %#v", next)
+	}
+}
+
+func TestFindPullRequestForBranch(t *testing.T) {
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh pr list --repo owner/repo --head vigilante/issue-7 --state all --json number,url,mergedAt": `[{"number":17,"url":"https://github.com/owner/repo/pull/17","mergedAt":"2026-03-10T14:00:00Z"}]`,
+		},
+	}
+
+	pr, err := FindPullRequestForBranch(context.Background(), runner, "owner/repo", "vigilante/issue-7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pr == nil {
+		t.Fatal("expected pull request")
+	}
+	if pr.Number != 17 || pr.URL != "https://github.com/owner/repo/pull/17" {
+		t.Fatalf("unexpected pull request: %#v", pr)
+	}
+	if pr.MergedAt == nil || !pr.MergedAt.Equal(time.Date(2026, 3, 10, 14, 0, 0, 0, time.UTC)) {
+		t.Fatalf("unexpected merged time: %#v", pr.MergedAt)
 	}
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -29,18 +29,23 @@ const (
 )
 
 type Session struct {
-	RepoPath     string        `json:"repo_path"`
-	Repo         string        `json:"repo"`
-	IssueNumber  int           `json:"issue_number"`
-	IssueTitle   string        `json:"issue_title,omitempty"`
-	IssueURL     string        `json:"issue_url,omitempty"`
-	Branch       string        `json:"branch"`
-	WorktreePath string        `json:"worktree_path"`
-	Status       SessionStatus `json:"status"`
-	StartedAt    string        `json:"started_at,omitempty"`
-	EndedAt      string        `json:"ended_at,omitempty"`
-	UpdatedAt    string        `json:"updated_at,omitempty"`
-	LastError    string        `json:"last_error,omitempty"`
+	RepoPath            string        `json:"repo_path"`
+	Repo                string        `json:"repo"`
+	IssueNumber         int           `json:"issue_number"`
+	IssueTitle          string        `json:"issue_title,omitempty"`
+	IssueURL            string        `json:"issue_url,omitempty"`
+	Branch              string        `json:"branch"`
+	WorktreePath        string        `json:"worktree_path"`
+	Status              SessionStatus `json:"status"`
+	PullRequestNumber   int           `json:"pull_request_number,omitempty"`
+	PullRequestURL      string        `json:"pull_request_url,omitempty"`
+	PullRequestMergedAt string        `json:"pull_request_merged_at,omitempty"`
+	CleanupCompletedAt  string        `json:"cleanup_completed_at,omitempty"`
+	CleanupError        string        `json:"cleanup_error,omitempty"`
+	StartedAt           string        `json:"started_at,omitempty"`
+	EndedAt             string        `json:"ended_at,omitempty"`
+	UpdatedAt           string        `json:"updated_at,omitempty"`
+	LastError           string        `json:"last_error,omitempty"`
 }
 
 type Store struct {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -2,9 +2,11 @@ package worktree
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/nicobistolfi/vigilante/internal/environment"
 	"github.com/nicobistolfi/vigilante/internal/state"
@@ -45,7 +47,74 @@ func Remove(ctx context.Context, runner environment.Runner, repoPath string, wor
 	return err
 }
 
+func Prune(ctx context.Context, runner environment.Runner, repoPath string) error {
+	_, err := runner.Run(ctx, repoPath, "git", "worktree", "prune")
+	return err
+}
+
+func CleanupIssueArtifacts(ctx context.Context, runner environment.Runner, repoPath string, worktreePath string, branch string) error {
+	if err := Prune(ctx, runner, repoPath); err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(worktreePath); err == nil {
+		if err := Remove(ctx, runner, repoPath, worktreePath); err != nil {
+			return err
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	if err := Prune(ctx, runner, repoPath); err != nil {
+		return err
+	}
+
+	attached, err := branchAttachedToWorktree(ctx, runner, repoPath, branch)
+	if err != nil {
+		return err
+	}
+	if attached {
+		return nil
+	}
+
+	exists, err := branchExistsWithError(ctx, runner, repoPath, branch)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
+	_, err = runner.Run(ctx, repoPath, "git", "branch", "-D", branch)
+	return err
+}
+
 func branchExists(ctx context.Context, runner environment.Runner, repoPath string, branch string) bool {
 	_, err := runner.Run(ctx, repoPath, "git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
 	return err == nil
+}
+
+func branchExistsWithError(ctx context.Context, runner environment.Runner, repoPath string, branch string) (bool, error) {
+	_, err := runner.Run(ctx, repoPath, "git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+	if err == nil {
+		return true, nil
+	}
+	if strings.Contains(err.Error(), "exit status 1") {
+		return false, nil
+	}
+	return false, err
+}
+
+func branchAttachedToWorktree(ctx context.Context, runner environment.Runner, repoPath string, branch string) (bool, error) {
+	output, err := runner.Run(ctx, repoPath, "git", "worktree", "list", "--porcelain")
+	if err != nil {
+		return false, err
+	}
+	needle := "branch refs/heads/" + branch
+	for _, line := range strings.Split(output, "\n") {
+		if strings.TrimSpace(line) == needle {
+			return true, nil
+		}
+	}
+	return false, nil
 }


### PR DESCRIPTION
## Summary
- track the pull request associated with a successful issue session in persisted session state
- add a daemon cleanup pass that detects merged PRs, prunes stale worktree metadata, removes the local issue worktree, and deletes the local issue branch when safe
- add focused tests for PR lookup and merged-session cleanup

Closes #11

## Validation
- go test ./...