### PR TITLE
Support label-based issue selection for watched repositories

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -34,6 +34,21 @@ type App struct {
 	env    *environment.Environment
 }
 
+type stringListFlag []string
+
+func (f *stringListFlag) String() string {
+	return strings.Join(*f, ",")
+}
+
+func (f *stringListFlag) Set(value string) error {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return errors.New("label cannot be empty")
+	}
+	*f = append(*f, trimmed)
+	return nil
+}
+
 func New() *App {
 	store := state.NewStore()
 	return &App{
@@ -79,13 +94,15 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 		fs := flag.NewFlagSet("watch", flag.ContinueOnError)
 		fs.SetOutput(a.stderr)
 		daemon := fs.Bool("d", false, "install and start daemon service")
+		var labels stringListFlag
+		fs.Var(&labels, "label", "allow only issues with this label; repeatable")
 		if err := fs.Parse(args[1:]); err != nil {
 			return err
 		}
 		if fs.NArg() != 1 {
-			return errors.New("usage: vigilante watch [-d] <path>")
+			return errors.New("usage: vigilante watch [-d] [--label value] <path>")
 		}
-		return a.Watch(ctx, fs.Arg(0), *daemon)
+		return a.Watch(ctx, fs.Arg(0), *daemon, labels)
 	case "unwatch":
 		if len(args) != 2 {
 			return errors.New("usage: vigilante unwatch <path>")
@@ -137,7 +154,7 @@ func (a *App) Setup(ctx context.Context, installDaemon bool) error {
 	return nil
 }
 
-func (a *App) Watch(ctx context.Context, rawPath string, daemon bool) error {
+func (a *App) Watch(ctx context.Context, rawPath string, daemon bool, labels []string) error {
 	a.state.AppendDaemonLog("watch start raw_path=%q daemon=%t", rawPath, daemon)
 	if err := a.state.EnsureLayout(); err != nil {
 		return err
@@ -158,11 +175,14 @@ func (a *App) Watch(ctx context.Context, rawPath string, daemon bool) error {
 		return err
 	}
 
+	labels = normalizeLabels(labels)
+
 	updated := false
 	for i, target := range targets {
 		if target.Path == info.Path {
 			targets[i].Repo = info.Repo
 			targets[i].Branch = info.Branch
+			targets[i].Labels = labels
 			targets[i].DaemonEnabled = daemon
 			updated = true
 			break
@@ -174,6 +194,7 @@ func (a *App) Watch(ctx context.Context, rawPath string, daemon bool) error {
 			Path:          info.Path,
 			Repo:          info.Repo,
 			Branch:        info.Branch,
+			Labels:        labels,
 			DaemonEnabled: daemon,
 			AddedAt:       a.clock().Format(time.RFC3339),
 		}
@@ -319,7 +340,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 			}
 			a.state.AppendDaemonLog("scan repo issues repo=%s open_issues=%d", target.Repo, len(issues))
 
-			next := ghcli.SelectNextIssue(issues, sessions, target.Repo)
+			next := ghcli.SelectNextIssue(issues, sessions, *target)
 			if next == nil {
 				a.state.AppendDaemonLog("scan repo no eligible issues repo=%s", target.Repo)
 				fmt.Fprintf(a.stdout, "repo: %s no eligible issues (%d open)\n", target.Repo, len(issues))
@@ -442,7 +463,7 @@ func (a *App) ensureTooling(ctx context.Context) error {
 func (a *App) printUsage() {
 	fmt.Fprintln(a.stderr, "usage:")
 	fmt.Fprintln(a.stderr, "  vigilante setup [-d]")
-	fmt.Fprintln(a.stderr, "  vigilante watch [-d] <path>")
+	fmt.Fprintln(a.stderr, "  vigilante watch [-d] [--label value] <path>")
 	fmt.Fprintln(a.stderr, "  vigilante unwatch <path>")
 	fmt.Fprintln(a.stderr, "  vigilante list")
 	fmt.Fprintln(a.stderr, "  vigilante daemon run [--once] [--interval duration]")
@@ -475,4 +496,26 @@ func ExpandPath(raw string) (string, error) {
 		}
 	}
 	return filepath.Abs(raw)
+}
+
+func normalizeLabels(labels []string) []string {
+	if len(labels) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]bool, len(labels))
+	normalized := make([]string, 0, len(labels))
+	for _, label := range labels {
+		trimmed := strings.TrimSpace(label)
+		if trimmed == "" || seen[trimmed] {
+			continue
+		}
+		seen[trimmed] = true
+		normalized = append(normalized, trimmed)
+	}
+	sort.Strings(normalized)
+	if len(normalized) == 0 {
+		return nil
+	}
+	return normalized
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -66,7 +66,7 @@ func TestWatchListAndUnwatch(t *testing.T) {
 		},
 	}
 
-	if err := app.Watch(context.Background(), repoPath, false); err != nil {
+	if err := app.Watch(context.Background(), repoPath, false, []string{"to-do", "good first issue"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -76,6 +76,9 @@ func TestWatchListAndUnwatch(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "\"repo\": \"nicobistolfi/vigilante\"") {
 		t.Fatalf("unexpected list output: %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "\"labels\": [") || !strings.Contains(stdout.String(), "\"to-do\"") {
+		t.Fatalf("expected labels in list output: %s", stdout.String())
 	}
 
 	if err := app.Unwatch(repoPath); err != nil {
@@ -113,12 +116,12 @@ func TestWatchUpdatesExistingTarget(t *testing.T) {
 		},
 	}
 
-	if err := app.Watch(context.Background(), repoPath, false); err != nil {
+	if err := app.Watch(context.Background(), repoPath, false, nil); err != nil {
 		t.Fatal(err)
 	}
 
 	stdout.Reset()
-	if err := app.Watch(context.Background(), repoPath, true); err != nil {
+	if err := app.Watch(context.Background(), repoPath, true, []string{"vibe-code", "vibe-code"}); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(stdout.String(), "updated "+repoPath) {
@@ -134,6 +137,9 @@ func TestWatchUpdatesExistingTarget(t *testing.T) {
 	}
 	if !targets[0].DaemonEnabled {
 		t.Fatalf("expected daemon_enabled to be updated: %#v", targets[0])
+	}
+	if len(targets[0].Labels) != 1 || targets[0].Labels[0] != "vibe-code" {
+		t.Fatalf("expected labels to be updated: %#v", targets[0])
 	}
 }
 
@@ -151,7 +157,7 @@ func TestScanOnceSelectsEligibleIssueAndPersistsSession(t *testing.T) {
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: map[string]string{
 			"gh auth status": "ok",
-			"gh issue list --repo owner/repo --state open --json number,title,createdAt,url": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1"}]`,
+			"gh issue list --repo owner/repo --state open --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[{"name":"to-do"}]}]`,
 			"git worktree prune": "ok",
 			"git worktree add -b vigilante/issue-1 " + worktreePath + " main":                                                                                       "ok",
 			"gh issue comment --repo owner/repo 1 --body Vigilante started a Codex session for this issue in `" + worktreePath + "` on branch `vigilante/issue-1`.": "ok",
@@ -191,7 +197,7 @@ func TestScanOncePrintsNoEligibleIssues(t *testing.T) {
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: map[string]string{
-			"gh issue list --repo owner/repo --state open --json number,title,createdAt,url": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1"}]`,
+			"gh issue list --repo owner/repo --state open --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]}]`,
 		},
 	}
 	if err := app.state.EnsureLayout(); err != nil {
@@ -224,11 +230,11 @@ func TestScanOnceCleansUpMergedIssueSession(t *testing.T) {
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: map[string]string{
 			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","mergedAt":"2026-03-10T15:00:00Z"}]`,
-			"git worktree prune":                                                             "ok",
-			"git worktree list --porcelain":                                                  "worktree /tmp/repo\nHEAD abcdef\nbranch refs/heads/main\n",
-			"git show-ref --verify --quiet refs/heads/vigilante/issue-1":                     "ok",
-			"git branch -D vigilante/issue-1":                                                "Deleted branch vigilante/issue-1\n",
-			"gh issue list --repo owner/repo --state open --json number,title,createdAt,url": "[]",
+			"git worktree prune":                                         "ok",
+			"git worktree list --porcelain":                              "worktree /tmp/repo\nHEAD abcdef\nbranch refs/heads/main\n",
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": "ok",
+			"git branch -D vigilante/issue-1":                            "Deleted branch vigilante/issue-1\n",
+			"gh issue list --repo owner/repo --state open --json number,title,createdAt,url,labels": "[]",
 		},
 	}
 	if err := app.state.EnsureLayout(); err != nil {
@@ -272,6 +278,35 @@ func TestScanOnceCleansUpMergedIssueSession(t *testing.T) {
 		t.Fatalf("unexpected cleanup error: %#v", sessions[0])
 	}
 	if got := stdout.String(); !strings.Contains(got, "repo: owner/repo no eligible issues (0 open)") {
+		t.Fatalf("unexpected output: %s", got)
+	}
+}
+
+func TestScanOnceSkipsIssuesWithoutConfiguredLabels(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	var stdout bytes.Buffer
+	app := New()
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh issue list --repo owner/repo --state open --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[{"name":"bug"}]}]`,
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main", Labels: []string{"to-do"}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "repo: owner/repo no eligible issues (1 open)") {
 		t.Fatalf("unexpected output: %s", got)
 	}
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -17,6 +17,11 @@ type Issue struct {
 	Title     string    `json:"title"`
 	CreatedAt time.Time `json:"createdAt"`
 	URL       string    `json:"url"`
+	Labels    []Label   `json:"labels"`
+}
+
+type Label struct {
+	Name string `json:"name"`
 }
 
 type PullRequest struct {
@@ -26,7 +31,7 @@ type PullRequest struct {
 }
 
 func ListOpenIssues(ctx context.Context, runner environment.Runner, repo string) ([]Issue, error) {
-	output, err := runner.Run(ctx, "", "gh", "issue", "list", "--repo", repo, "--state", "open", "--json", "number,title,createdAt,url")
+	output, err := runner.Run(ctx, "", "gh", "issue", "list", "--repo", repo, "--state", "open", "--json", "number,title,createdAt,url,labels")
 	if err != nil {
 		return nil, err
 	}
@@ -40,19 +45,38 @@ func ListOpenIssues(ctx context.Context, runner environment.Runner, repo string)
 	return issues, nil
 }
 
-func SelectNextIssue(issues []Issue, sessions []state.Session, repo string) *Issue {
+func SelectNextIssue(issues []Issue, sessions []state.Session, target state.WatchTarget) *Issue {
 	active := map[int]bool{}
 	for _, session := range sessions {
-		if session.Repo == repo && session.Status == state.SessionStatusRunning {
+		if session.Repo == target.Repo && session.Status == state.SessionStatusRunning {
 			active[session.IssueNumber] = true
 		}
 	}
 	for i := range issues {
-		if !active[issues[i].Number] {
-			return &issues[i]
+		if active[issues[i].Number] {
+			continue
 		}
+		if !matchesLabelAllowlist(issues[i], target.Labels) {
+			continue
+		}
+		return &issues[i]
 	}
 	return nil
+}
+
+func matchesLabelAllowlist(issue Issue, allowlist []string) bool {
+	if len(allowlist) == 0 {
+		return true
+	}
+
+	for _, configured := range allowlist {
+		for _, label := range issue.Labels {
+			if label.Name == configured {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func CommentOnIssue(ctx context.Context, runner environment.Runner, repo string, number int, body string) error {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -12,7 +12,7 @@ import (
 func TestListOpenIssuesAndSelectNext(t *testing.T) {
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{
-			"gh issue list --repo owner/repo --state open --json number,title,createdAt,url": `[{"number":2,"title":"newer","createdAt":"2026-03-10T12:00:00Z","url":"u2"},{"number":1,"title":"older","createdAt":"2026-03-09T12:00:00Z","url":"u1"}]`,
+			"gh issue list --repo owner/repo --state open --json number,title,createdAt,url,labels": `[{"number":2,"title":"newer","createdAt":"2026-03-10T12:00:00Z","url":"u2","labels":[{"name":"to-do"}]},{"number":1,"title":"older","createdAt":"2026-03-09T12:00:00Z","url":"u1","labels":[{"name":"bug"}]}]`,
 		},
 	}
 	issues, err := ListOpenIssues(context.Background(), runner, "owner/repo")
@@ -22,9 +22,32 @@ func TestListOpenIssuesAndSelectNext(t *testing.T) {
 	if issues[0].Number != 1 {
 		t.Fatalf("expected oldest issue first: %#v", issues)
 	}
-	next := SelectNextIssue(issues, []state.Session{{Repo: "owner/repo", IssueNumber: 1, Status: state.SessionStatusRunning}}, "owner/repo")
+	next := SelectNextIssue(issues, []state.Session{{Repo: "owner/repo", IssueNumber: 1, Status: state.SessionStatusRunning}}, state.WatchTarget{Repo: "owner/repo"})
 	if next == nil || next.Number != 2 {
 		t.Fatalf("unexpected next issue: %#v", next)
+	}
+}
+
+func TestSelectNextIssueRespectsConfiguredLabels(t *testing.T) {
+	issues := []Issue{
+		{Number: 1, Labels: []Label{{Name: "bug"}}},
+		{Number: 2, Labels: []Label{{Name: "to-do"}}},
+		{Number: 3, Labels: []Label{{Name: "good first issue"}, {Name: "help wanted"}}},
+	}
+
+	next := SelectNextIssue(issues, nil, state.WatchTarget{Repo: "owner/repo", Labels: []string{"to-do", "good first issue"}})
+	if next == nil || next.Number != 2 {
+		t.Fatalf("unexpected next issue: %#v", next)
+	}
+
+	next = SelectNextIssue(issues, nil, state.WatchTarget{Repo: "owner/repo", Labels: []string{"good first issue"}})
+	if next == nil || next.Number != 3 {
+		t.Fatalf("unexpected next issue for second label match: %#v", next)
+	}
+
+	next = SelectNextIssue(issues, nil, state.WatchTarget{Repo: "owner/repo", Labels: []string{"vibe-code"}})
+	if next != nil {
+		t.Fatalf("expected no matching issue, got %#v", next)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -12,12 +12,13 @@ import (
 )
 
 type WatchTarget struct {
-	Path          string `json:"path"`
-	Repo          string `json:"repo"`
-	Branch        string `json:"branch"`
-	DaemonEnabled bool   `json:"daemon_enabled"`
-	LastScanAt    string `json:"last_scan_at,omitempty"`
-	AddedAt       string `json:"added_at,omitempty"`
+	Path          string   `json:"path"`
+	Repo          string   `json:"repo"`
+	Branch        string   `json:"branch"`
+	Labels        []string `json:"labels,omitempty"`
+	DaemonEnabled bool     `json:"daemon_enabled"`
+	LastScanAt    string   `json:"last_scan_at,omitempty"`
+	AddedAt       string   `json:"added_at,omitempty"`
 }
 
 type SessionStatus string


### PR DESCRIPTION
## Summary
- add repeatable `--label` support to `vigilante watch` and persist configured labels in watch targets
- request GitHub issue labels during polling and apply OR-style label filtering during selection
- cover configured-label, non-matching-label, and no-label behavior with tests

## Validation
- go test ./...

Closes #12