### PR TITLE
Add assignee filtering for watched issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For each watched repository:
 
 ## Commands
 
-### `vigilante watch <path>`
+### `vigilante watch [--assignee <value>] <path>`
 
 Register a local repository for issue monitoring.
 
@@ -55,12 +55,17 @@ Expected behavior:
 - expands `~` and resolves the absolute path
 - validates the folder is a git repository
 - discovers the GitHub remote from git config
+- defaults the assignee filter to `me` unless overridden
 - stores the target in `~/.vigilante/watchlist.json`
 
 Example:
 
 ```sh
 vigilante watch ~/hello-world-app
+```
+
+```sh
+vigilante watch --assignee nicobistolfi ~/hello-world-app
 ```
 
 ### `vigilante watch -d <path>`
@@ -175,6 +180,7 @@ Suggested `watchlist.json` shape:
     "path": "/Users/example/hello-world-app",
     "repo": "owner/hello-world-app",
     "branch": "main",
+    "assignee": "me",
     "daemon_enabled": true,
     "last_scan_at": "2026-03-10T12:00:00Z"
   }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -25,6 +25,7 @@ import (
 )
 
 const defaultScanInterval = 5 * time.Minute
+const defaultAssigneeFilter = "me"
 
 type App struct {
 	stdout io.Writer
@@ -96,13 +97,14 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 		daemon := fs.Bool("d", false, "install and start daemon service")
 		var labels stringListFlag
 		fs.Var(&labels, "label", "allow only issues with this label; repeatable")
+		assignee := fs.String("assignee", "", "issue assignee filter (defaults to me)")
 		if err := fs.Parse(args[1:]); err != nil {
 			return err
 		}
 		if fs.NArg() != 1 {
-			return errors.New("usage: vigilante watch [-d] [--label value] <path>")
+			return errors.New("usage: vigilante watch [-d] [--label value] [--assignee value] <path>")
 		}
-		return a.Watch(ctx, fs.Arg(0), *daemon, labels)
+		return a.Watch(ctx, fs.Arg(0), *daemon, labels, *assignee)
 	case "unwatch":
 		if len(args) != 2 {
 			return errors.New("usage: vigilante unwatch <path>")
@@ -154,8 +156,8 @@ func (a *App) Setup(ctx context.Context, installDaemon bool) error {
 	return nil
 }
 
-func (a *App) Watch(ctx context.Context, rawPath string, daemon bool, labels []string) error {
-	a.state.AppendDaemonLog("watch start raw_path=%q daemon=%t", rawPath, daemon)
+func (a *App) Watch(ctx context.Context, rawPath string, daemon bool, labels []string, assignee string) error {
+	a.state.AppendDaemonLog("watch start raw_path=%q daemon=%t assignee=%q", rawPath, daemon, assignee)
 	if err := a.state.EnsureLayout(); err != nil {
 		return err
 	}
@@ -183,6 +185,11 @@ func (a *App) Watch(ctx context.Context, rawPath string, daemon bool, labels []s
 			targets[i].Repo = info.Repo
 			targets[i].Branch = info.Branch
 			targets[i].Labels = labels
+			if assignee != "" {
+				targets[i].Assignee = assignee
+			} else if targets[i].Assignee == "" {
+				targets[i].Assignee = defaultAssigneeFilter
+			}
 			targets[i].DaemonEnabled = daemon
 			updated = true
 			break
@@ -195,6 +202,7 @@ func (a *App) Watch(ctx context.Context, rawPath string, daemon bool, labels []s
 			Repo:          info.Repo,
 			Branch:        info.Branch,
 			Labels:        labels,
+			Assignee:      assigneeOrDefault(assignee),
 			DaemonEnabled: daemon,
 			AddedAt:       a.clock().Format(time.RFC3339),
 		}
@@ -214,10 +222,10 @@ func (a *App) Watch(ctx context.Context, rawPath string, daemon bool, labels []s
 	}
 
 	if updated {
-		a.state.AppendDaemonLog("watch updated path=%s repo=%s branch=%s daemon=%t", info.Path, info.Repo, info.Branch, daemon)
+		a.state.AppendDaemonLog("watch updated path=%s repo=%s branch=%s assignee=%s daemon=%t", info.Path, info.Repo, info.Branch, assigneeOrDefault(findWatchTargetAssignee(targets, info.Path)), daemon)
 		fmt.Fprintln(a.stdout, "updated", info.Path)
 	} else {
-		a.state.AppendDaemonLog("watch added path=%s repo=%s branch=%s daemon=%t", info.Path, info.Repo, info.Branch, daemon)
+		a.state.AppendDaemonLog("watch added path=%s repo=%s branch=%s assignee=%s daemon=%t", info.Path, info.Repo, info.Branch, assigneeOrDefault(assignee), daemon)
 		fmt.Fprintln(a.stdout, "watching", info.Path)
 	}
 	return nil
@@ -329,8 +337,9 @@ func (a *App) ScanOnce(ctx context.Context) error {
 
 		for i := range targets {
 			target := &targets[i]
+			target.Assignee = assigneeOrDefault(target.Assignee)
 			a.state.AppendDaemonLog("scan repo start repo=%s path=%s", target.Repo, target.Path)
-			issues, err := ghcli.ListOpenIssues(ctx, a.env.Runner, target.Repo)
+			issues, err := ghcli.ListOpenIssues(ctx, a.env.Runner, target.Repo, target.Assignee)
 			target.LastScanAt = a.clock().Format(time.RFC3339)
 			if err != nil {
 				if saveErr := a.state.SaveWatchTargets(targets); saveErr != nil {
@@ -463,7 +472,7 @@ func (a *App) ensureTooling(ctx context.Context) error {
 func (a *App) printUsage() {
 	fmt.Fprintln(a.stderr, "usage:")
 	fmt.Fprintln(a.stderr, "  vigilante setup [-d]")
-	fmt.Fprintln(a.stderr, "  vigilante watch [-d] [--label value] <path>")
+	fmt.Fprintln(a.stderr, "  vigilante watch [-d] [--label value] [--assignee value] <path>")
 	fmt.Fprintln(a.stderr, "  vigilante unwatch <path>")
 	fmt.Fprintln(a.stderr, "  vigilante list")
 	fmt.Fprintln(a.stderr, "  vigilante daemon run [--once] [--interval duration]")
@@ -498,6 +507,13 @@ func ExpandPath(raw string) (string, error) {
 	return filepath.Abs(raw)
 }
 
+func assigneeOrDefault(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return defaultAssigneeFilter
+	}
+	return value
+}
+
 func normalizeLabels(labels []string) []string {
 	if len(labels) == 0 {
 		return nil
@@ -506,16 +522,26 @@ func normalizeLabels(labels []string) []string {
 	seen := make(map[string]bool, len(labels))
 	normalized := make([]string, 0, len(labels))
 	for _, label := range labels {
-		trimmed := strings.TrimSpace(label)
-		if trimmed == "" || seen[trimmed] {
+		label = strings.TrimSpace(label)
+		if label == "" || seen[label] {
 			continue
 		}
-		seen[trimmed] = true
-		normalized = append(normalized, trimmed)
+		seen[label] = true
+		normalized = append(normalized, label)
 	}
-	sort.Strings(normalized)
+
 	if len(normalized) == 0 {
 		return nil
 	}
+	sort.Strings(normalized)
 	return normalized
+}
+
+func findWatchTargetAssignee(targets []state.WatchTarget, path string) string {
+	for _, target := range targets {
+		if target.Path == path {
+			return target.Assignee
+		}
+	}
+	return ""
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -66,7 +66,7 @@ func TestWatchListAndUnwatch(t *testing.T) {
 		},
 	}
 
-	if err := app.Watch(context.Background(), repoPath, false, []string{"to-do", "good first issue"}); err != nil {
+	if err := app.Watch(context.Background(), repoPath, false, []string{"to-do", "good first issue"}, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -79,6 +79,9 @@ func TestWatchListAndUnwatch(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "\"labels\": [") || !strings.Contains(stdout.String(), "\"to-do\"") {
 		t.Fatalf("expected labels in list output: %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "\"assignee\": \"me\"") {
+		t.Fatalf("expected default assignee in list output: %s", stdout.String())
 	}
 
 	if err := app.Unwatch(repoPath); err != nil {
@@ -116,12 +119,12 @@ func TestWatchUpdatesExistingTarget(t *testing.T) {
 		},
 	}
 
-	if err := app.Watch(context.Background(), repoPath, false, nil); err != nil {
+	if err := app.Watch(context.Background(), repoPath, false, nil, "nicobistolfi"); err != nil {
 		t.Fatal(err)
 	}
 
 	stdout.Reset()
-	if err := app.Watch(context.Background(), repoPath, true, []string{"vibe-code", "vibe-code"}); err != nil {
+	if err := app.Watch(context.Background(), repoPath, true, []string{"vibe-code", "vibe-code"}, ""); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(stdout.String(), "updated "+repoPath) {
@@ -141,6 +144,9 @@ func TestWatchUpdatesExistingTarget(t *testing.T) {
 	if len(targets[0].Labels) != 1 || targets[0].Labels[0] != "vibe-code" {
 		t.Fatalf("expected labels to be updated: %#v", targets[0])
 	}
+	if targets[0].Assignee != "nicobistolfi" {
+		t.Fatalf("expected assignee to be preserved: %#v", targets[0])
+	}
 }
 
 func TestScanOnceSelectsEligibleIssueAndPersistsSession(t *testing.T) {
@@ -157,7 +163,7 @@ func TestScanOnceSelectsEligibleIssueAndPersistsSession(t *testing.T) {
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: map[string]string{
 			"gh auth status": "ok",
-			"gh issue list --repo owner/repo --state open --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[{"name":"to-do"}]}]`,
+			"gh issue list --repo owner/repo --state open --assignee me --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[{"name":"to-do"}]}]`,
 			"git worktree prune": "ok",
 			"git worktree add -b vigilante/issue-1 " + worktreePath + " main":                                                                                       "ok",
 			"gh issue comment --repo owner/repo 1 --body Vigilante started a Codex session for this issue in `" + worktreePath + "` on branch `vigilante/issue-1`.": "ok",
@@ -167,7 +173,7 @@ func TestScanOnceSelectsEligibleIssueAndPersistsSession(t *testing.T) {
 	if err := app.state.EnsureLayout(); err != nil {
 		t.Fatal(err)
 	}
-	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"}}); err != nil {
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main", Assignee: "me", Labels: []string{"to-do"}}}); err != nil {
 		t.Fatal(err)
 	}
 	if err := app.ScanOnce(context.Background()); err != nil {
@@ -197,13 +203,13 @@ func TestScanOncePrintsNoEligibleIssues(t *testing.T) {
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: map[string]string{
-			"gh issue list --repo owner/repo --state open --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]}]`,
+			"gh issue list --repo owner/repo --state open --assignee me --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]}]`,
 		},
 	}
 	if err := app.state.EnsureLayout(); err != nil {
 		t.Fatal(err)
 	}
-	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"}}); err != nil {
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main", Assignee: "me", Labels: []string{"to-do"}}}); err != nil {
 		t.Fatal(err)
 	}
 	if err := app.state.SaveSessions([]state.Session{{Repo: "owner/repo", IssueNumber: 1, Status: state.SessionStatusRunning}}); err != nil {
@@ -234,7 +240,7 @@ func TestScanOnceCleansUpMergedIssueSession(t *testing.T) {
 			"git worktree list --porcelain":                              "worktree /tmp/repo\nHEAD abcdef\nbranch refs/heads/main\n",
 			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": "ok",
 			"git branch -D vigilante/issue-1":                            "Deleted branch vigilante/issue-1\n",
-			"gh issue list --repo owner/repo --state open --json number,title,createdAt,url,labels": "[]",
+			"gh issue list --repo owner/repo --state open --assignee me --json number,title,createdAt,url,labels": "[]",
 		},
 	}
 	if err := app.state.EnsureLayout(); err != nil {
@@ -282,35 +288,6 @@ func TestScanOnceCleansUpMergedIssueSession(t *testing.T) {
 	}
 }
 
-func TestScanOnceSkipsIssuesWithoutConfiguredLabels(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
-	t.Setenv("HOME", home)
-
-	var stdout bytes.Buffer
-	app := New()
-	app.stdout = &stdout
-	app.stderr = testutil.IODiscard{}
-	app.env.Runner = testutil.FakeRunner{
-		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
-		Outputs: map[string]string{
-			"gh issue list --repo owner/repo --state open --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[{"name":"bug"}]}]`,
-		},
-	}
-	if err := app.state.EnsureLayout(); err != nil {
-		t.Fatal(err)
-	}
-	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main", Labels: []string{"to-do"}}}); err != nil {
-		t.Fatal(err)
-	}
-	if err := app.ScanOnce(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	if got := stdout.String(); !strings.Contains(got, "repo: owner/repo no eligible issues (1 open)") {
-		t.Fatalf("unexpected output: %s", got)
-	}
-}
-
 func TestScanOnceSkipsWhenAnotherProcessHoldsScanLock(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
@@ -337,6 +314,35 @@ func TestScanOnceSkipsWhenAnotherProcessHoldsScanLock(t *testing.T) {
 		t.Fatal("expected outer lock to be acquired")
 	}
 	if got := stdout.String(); !strings.Contains(got, "scan skipped: another vigilante daemon is already scanning") {
+		t.Fatalf("unexpected output: %s", got)
+	}
+}
+
+func TestScanOnceUsesExplicitAssigneeFilter(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	var stdout bytes.Buffer
+	app := New()
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main", Assignee: "nicobistolfi"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "repo: owner/repo no eligible issues (0 open)") {
 		t.Fatalf("unexpected output: %s", got)
 	}
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -30,8 +30,14 @@ type PullRequest struct {
 	MergedAt *time.Time `json:"mergedAt"`
 }
 
-func ListOpenIssues(ctx context.Context, runner environment.Runner, repo string) ([]Issue, error) {
-	output, err := runner.Run(ctx, "", "gh", "issue", "list", "--repo", repo, "--state", "open", "--json", "number,title,createdAt,url,labels")
+func ListOpenIssues(ctx context.Context, runner environment.Runner, repo string, assignee string) ([]Issue, error) {
+	args := []string{"issue", "list", "--repo", repo, "--state", "open"}
+	if assignee != "" {
+		args = append(args, "--assignee", assignee)
+	}
+	args = append(args, "--json", "number,title,createdAt,url,labels")
+	output, err := runner.Run(ctx, "", "gh", args...)
+
 	if err != nil {
 		return nil, err
 	}

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -12,17 +12,17 @@ import (
 func TestListOpenIssuesAndSelectNext(t *testing.T) {
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{
-			"gh issue list --repo owner/repo --state open --json number,title,createdAt,url,labels": `[{"number":2,"title":"newer","createdAt":"2026-03-10T12:00:00Z","url":"u2","labels":[{"name":"to-do"}]},{"number":1,"title":"older","createdAt":"2026-03-09T12:00:00Z","url":"u1","labels":[{"name":"bug"}]}]`,
+			"gh issue list --repo owner/repo --state open --assignee me --json number,title,createdAt,url,labels": `[{"number":2,"title":"newer","createdAt":"2026-03-10T12:00:00Z","url":"u2","labels":[{"name":"to-do"}]},{"number":1,"title":"older","createdAt":"2026-03-09T12:00:00Z","url":"u1","labels":[{"name":"bug"}]}]`,
 		},
 	}
-	issues, err := ListOpenIssues(context.Background(), runner, "owner/repo")
+	issues, err := ListOpenIssues(context.Background(), runner, "owner/repo", "me")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if issues[0].Number != 1 {
 		t.Fatalf("expected oldest issue first: %#v", issues)
 	}
-	next := SelectNextIssue(issues, []state.Session{{Repo: "owner/repo", IssueNumber: 1, Status: state.SessionStatusRunning}}, state.WatchTarget{Repo: "owner/repo"})
+	next := SelectNextIssue(issues, []state.Session{{Repo: "owner/repo", IssueNumber: 1, Status: state.SessionStatusRunning}}, state.WatchTarget{Repo: "owner/repo", Labels: []string{"to-do"}})
 	if next == nil || next.Number != 2 {
 		t.Fatalf("unexpected next issue: %#v", next)
 	}
@@ -48,6 +48,38 @@ func TestSelectNextIssueRespectsConfiguredLabels(t *testing.T) {
 	next = SelectNextIssue(issues, nil, state.WatchTarget{Repo: "owner/repo", Labels: []string{"vibe-code"}})
 	if next != nil {
 		t.Fatalf("expected no matching issue, got %#v", next)
+	}
+}
+
+func TestListOpenIssuesSupportsExplicitAssignee(t *testing.T) {
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":3,"title":"mine","createdAt":"2026-03-08T12:00:00Z","url":"u3","labels":[]}]`,
+		},
+	}
+
+	issues, err := ListOpenIssues(context.Background(), runner, "owner/repo", "nicobistolfi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(issues) != 1 || issues[0].Number != 3 {
+		t.Fatalf("unexpected issues: %#v", issues)
+	}
+}
+
+func TestListOpenIssuesAllowsNoAssigneeFilter(t *testing.T) {
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh issue list --repo owner/repo --state open --json number,title,createdAt,url,labels": `[{"number":4,"title":"unassigned","createdAt":"2026-03-08T12:00:00Z","url":"u4","labels":[]}]`,
+		},
+	}
+
+	issues, err := ListOpenIssues(context.Background(), runner, "owner/repo", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(issues) != 1 || issues[0].Number != 4 {
+		t.Fatalf("unexpected issues: %#v", issues)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -16,6 +16,7 @@ type WatchTarget struct {
 	Repo          string   `json:"repo"`
 	Branch        string   `json:"branch"`
 	Labels        []string `json:"labels,omitempty"`
+	Assignee      string   `json:"assignee,omitempty"`
 	DaemonEnabled bool     `json:"daemon_enabled"`
 	LastScanAt    string   `json:"last_scan_at,omitempty"`
 	AddedAt       string   `json:"added_at,omitempty"`


### PR DESCRIPTION
## Summary
- add persisted watch-target assignee configuration with `me` as the default
- pass the assignee filter through `vigilante watch`, `vigilante list`, and daemon issue queries
- cover default, explicit username, and no-match behavior in tests

Closes #15

## Validation
- go test ./...
