### PR TITLE
Add PR maintenance and conflict resolution

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -326,7 +326,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		sessions, err = a.cleanupMergedSessions(ctx, sessions)
+		sessions, err = a.maintainPullRequests(ctx, sessions)
 		if err != nil {
 			return err
 		}
@@ -406,18 +406,18 @@ func (a *App) ScanOnce(ctx context.Context) error {
 	return nil
 }
 
-func (a *App) cleanupMergedSessions(ctx context.Context, sessions []state.Session) ([]state.Session, error) {
+func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session) ([]state.Session, error) {
 	for i := range sessions {
 		session := &sessions[i]
-		if session.Status != state.SessionStatusSuccess || session.CleanupCompletedAt != "" {
+		if session.Status != state.SessionStatusSuccess || session.CleanupCompletedAt != "" || session.MonitoringStoppedAt != "" {
 			continue
 		}
 
 		pr, err := ghcli.FindPullRequestForBranch(ctx, a.env.Runner, session.Repo, session.Branch)
 		if err != nil {
-			session.CleanupError = err.Error()
+			session.LastMaintenanceError = err.Error()
 			session.UpdatedAt = a.clock().Format(time.RFC3339)
-			a.state.AppendDaemonLog("cleanup pr lookup failed repo=%s issue=%d branch=%s err=%v", session.Repo, session.IssueNumber, session.Branch, err)
+			a.state.AppendDaemonLog("pr lookup failed repo=%s issue=%d branch=%s err=%v", session.Repo, session.IssueNumber, session.Branch, err)
 			continue
 		}
 		if pr == nil {
@@ -426,9 +426,28 @@ func (a *App) cleanupMergedSessions(ctx context.Context, sessions []state.Sessio
 
 		session.PullRequestNumber = pr.Number
 		session.PullRequestURL = pr.URL
+		session.PullRequestState = pr.State
 		if pr.MergedAt == nil {
-			session.CleanupError = ""
-			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			if pr.State != "OPEN" {
+				session.MonitoringStoppedAt = a.clock().Format(time.RFC3339)
+				session.LastMaintenanceError = ""
+				session.UpdatedAt = session.MonitoringStoppedAt
+				a.state.AppendDaemonLog("monitoring stopped repo=%s issue=%d pr=%d branch=%s state=%s", session.Repo, session.IssueNumber, pr.Number, session.Branch, pr.State)
+				continue
+			}
+			if err := a.maintainOpenPullRequest(ctx, session, *pr); err != nil {
+				session.UpdatedAt = a.clock().Format(time.RFC3339)
+				a.state.AppendDaemonLog("pr maintenance failed repo=%s issue=%d pr=%d branch=%s err=%v", session.Repo, session.IssueNumber, pr.Number, session.Branch, err)
+				if shouldCommentMaintenanceFailure(*session, err) {
+					body := fmt.Sprintf("Vigilante could not keep PR #%d merge-ready on `%s`: %s", pr.Number, session.Branch, summarizeMaintenanceError(err))
+					if commentErr := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); commentErr != nil {
+						a.state.AppendDaemonLog("pr maintenance failure comment failed repo=%s issue=%d pr=%d err=%v", session.Repo, session.IssueNumber, pr.Number, commentErr)
+					}
+					session.LastMaintenanceError = err.Error()
+				}
+				continue
+			}
+			session.LastMaintenanceError = ""
 			continue
 		}
 
@@ -455,6 +474,75 @@ func (a *App) cleanupMergedSessions(ctx context.Context, sessions []state.Sessio
 	}
 
 	return sessions, nil
+}
+
+func (a *App) maintainOpenPullRequest(ctx context.Context, session *state.Session, pr ghcli.PullRequest) error {
+	if _, err := a.env.Runner.Run(ctx, session.WorktreePath, "git", "fetch", "origin", "main"); err != nil {
+		return err
+	}
+
+	statusOutput, err := a.env.Runner.Run(ctx, session.WorktreePath, "git", "status", "--porcelain")
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(statusOutput) != "" {
+		return errors.New("worktree is not clean before PR maintenance")
+	}
+
+	rebaseOutput, err := a.env.Runner.Run(ctx, session.WorktreePath, "git", "rebase", "origin/main")
+	rebased := rebaseChangedHistory(rebaseOutput)
+	if err != nil {
+		if !isRebaseConflict(rebaseOutput, err) {
+			return err
+		}
+		body := fmt.Sprintf("Vigilante hit rebase conflicts while updating PR #%d onto the latest `origin/main`. Launching the dedicated conflict-resolution skill in `%s`.", pr.Number, session.WorktreePath)
+		if commentErr := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); commentErr != nil {
+			a.state.AppendDaemonLog("pr conflict comment failed repo=%s issue=%d pr=%d err=%v", session.Repo, session.IssueNumber, pr.Number, commentErr)
+		}
+		target := state.WatchTarget{Path: session.RepoPath, Repo: session.Repo, Branch: "main"}
+		if conflictErr := issuerunner.RunConflictResolutionSession(ctx, a.env, a.state, target, *session, pr); conflictErr != nil {
+			return conflictErr
+		}
+		rebased = true
+	}
+
+	session.LastMaintainedAt = a.clock().Format(time.RFC3339)
+	session.UpdatedAt = session.LastMaintainedAt
+	if !rebased {
+		return nil
+	}
+
+	if _, err := a.env.Runner.Run(ctx, session.WorktreePath, "go", "test", "./..."); err != nil {
+		return err
+	}
+	if _, err := a.env.Runner.Run(ctx, session.WorktreePath, "git", "push", "--force-with-lease", "origin", "HEAD:"+session.Branch); err != nil {
+		return err
+	}
+
+	body := fmt.Sprintf("Vigilante rebased PR #%d onto the latest `origin/main`, reran `go test ./...`, and pushed `%s`.", pr.Number, session.Branch)
+	return ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body)
+}
+
+func rebaseChangedHistory(output string) bool {
+	text := strings.ToLower(strings.TrimSpace(output))
+	return text != "" && !strings.Contains(text, "up to date")
+}
+
+func isRebaseConflict(output string, err error) bool {
+	text := strings.ToLower(strings.TrimSpace(output + "\n" + err.Error()))
+	return strings.Contains(text, "conflict") || strings.Contains(text, "could not apply")
+}
+
+func shouldCommentMaintenanceFailure(session state.Session, err error) bool {
+	return strings.TrimSpace(session.LastMaintenanceError) != strings.TrimSpace(err.Error())
+}
+
+func summarizeMaintenanceError(err error) string {
+	text := strings.TrimSpace(err.Error())
+	if len(text) > 400 {
+		return text[:400]
+	}
+	return text
 }
 
 func (a *App) ensureTooling(ctx context.Context) error {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -38,6 +38,7 @@ func TestSetupCreatesStateLayoutAndSkill(t *testing.T) {
 		filepath.Join(app.state.Root(), "sessions.json"),
 		filepath.Join(app.state.Root(), "logs"),
 		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteIssueImplementation, "SKILL.md"),
+		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteConflictResolution, "SKILL.md"),
 	} {
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("expected %s to exist: %v", path, err)
@@ -235,7 +236,7 @@ func TestScanOnceCleansUpMergedIssueSession(t *testing.T) {
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: map[string]string{
-			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","mergedAt":"2026-03-10T15:00:00Z"}]`,
+			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"MERGED","mergedAt":"2026-03-10T15:00:00Z"}]`,
 			"git worktree prune":                                         "ok",
 			"git worktree list --porcelain":                              "worktree /tmp/repo\nHEAD abcdef\nbranch refs/heads/main\n",
 			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": "ok",
@@ -274,6 +275,9 @@ func TestScanOnceCleansUpMergedIssueSession(t *testing.T) {
 	if sessions[0].PullRequestNumber != 31 || sessions[0].PullRequestURL != "https://github.com/owner/repo/pull/31" {
 		t.Fatalf("expected pull request to be tracked: %#v", sessions[0])
 	}
+	if sessions[0].PullRequestState != "MERGED" {
+		t.Fatalf("expected merged pull request state to be tracked: %#v", sessions[0])
+	}
 	if sessions[0].PullRequestMergedAt != "2026-03-10T15:00:00Z" {
 		t.Fatalf("expected merged time to be tracked: %#v", sessions[0])
 	}
@@ -285,6 +289,69 @@ func TestScanOnceCleansUpMergedIssueSession(t *testing.T) {
 	}
 	if got := stdout.String(); !strings.Contains(got, "repo: owner/repo no eligible issues (0 open)") {
 		t.Fatalf("unexpected output: %s", got)
+	}
+}
+
+func TestScanOnceMaintainsOpenPullRequest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	var stdout bytes.Buffer
+	app := New()
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
+			"git fetch origin main":  "ok",
+			"git status --porcelain": "",
+			"git rebase origin/main": "Successfully rebased and updated refs/heads/vigilante/issue-1.\n",
+			"go test ./...":          "ok",
+			"git push --force-with-lease origin HEAD:vigilante/issue-1": "ok",
+			"gh issue comment --repo owner/repo 1 --body Vigilante rebased PR #31 onto the latest `origin/main`, reran `go test ./...`, and pushed `vigilante/issue-1`.": "ok",
+			"gh issue list --repo owner/repo --state open --assignee me --json number,title,createdAt,url,labels":                                                        "[]",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:     "/tmp/repo",
+		Repo:         "owner/repo",
+		IssueNumber:  1,
+		IssueTitle:   "first",
+		IssueURL:     "https://github.com/owner/repo/issues/1",
+		Branch:       "vigilante/issue-1",
+		WorktreePath: filepath.Join("/tmp/repo", ".worktrees", "vigilante", "issue-1"),
+		Status:       state.SessionStatusSuccess,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if sessions[0].PullRequestNumber != 31 || sessions[0].PullRequestState != "OPEN" {
+		t.Fatalf("expected open pull request tracking: %#v", sessions[0])
+	}
+	if sessions[0].LastMaintainedAt == "" {
+		t.Fatalf("expected maintenance timestamp: %#v", sessions[0])
+	}
+	if sessions[0].LastMaintenanceError != "" {
+		t.Fatalf("unexpected maintenance error: %#v", sessions[0])
 	}
 }
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -27,6 +27,7 @@ type Label struct {
 type PullRequest struct {
 	Number   int        `json:"number"`
 	URL      string     `json:"url"`
+	State    string     `json:"state"`
 	MergedAt *time.Time `json:"mergedAt"`
 }
 
@@ -91,7 +92,7 @@ func CommentOnIssue(ctx context.Context, runner environment.Runner, repo string,
 }
 
 func FindPullRequestForBranch(ctx context.Context, runner environment.Runner, repo string, branch string) (*PullRequest, error) {
-	output, err := runner.Run(ctx, "", "gh", "pr", "list", "--repo", repo, "--head", branch, "--state", "all", "--json", "number,url,mergedAt")
+	output, err := runner.Run(ctx, "", "gh", "pr", "list", "--repo", repo, "--head", branch, "--state", "all", "--json", "number,url,state,mergedAt")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -86,7 +86,7 @@ func TestListOpenIssuesAllowsNoAssigneeFilter(t *testing.T) {
 func TestFindPullRequestForBranch(t *testing.T) {
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{
-			"gh pr list --repo owner/repo --head vigilante/issue-7 --state all --json number,url,mergedAt": `[{"number":17,"url":"https://github.com/owner/repo/pull/17","mergedAt":"2026-03-10T14:00:00Z"}]`,
+			"gh pr list --repo owner/repo --head vigilante/issue-7 --state all --json number,url,state,mergedAt": `[{"number":17,"url":"https://github.com/owner/repo/pull/17","state":"MERGED","mergedAt":"2026-03-10T14:00:00Z"}]`,
 		},
 	}
 
@@ -99,6 +99,9 @@ func TestFindPullRequestForBranch(t *testing.T) {
 	}
 	if pr.Number != 17 || pr.URL != "https://github.com/owner/repo/pull/17" {
 		t.Fatalf("unexpected pull request: %#v", pr)
+	}
+	if pr.State != "MERGED" {
+		t.Fatalf("unexpected pull request state: %#v", pr)
 	}
 	if pr.MergedAt == nil || !pr.MergedAt.Equal(time.Date(2026, 3, 10, 14, 0, 0, 0, time.UTC)) {
 		t.Fatalf("unexpected merged time: %#v", pr.MergedAt)

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -53,6 +53,31 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 	return session
 }
 
+func RunConflictResolutionSession(ctx context.Context, env *environment.Environment, store *state.Store, target state.WatchTarget, session state.Session, pr ghcli.PullRequest) error {
+	logPath := store.SessionLogPath(session.IssueNumber)
+	appendSessionLog(logPath, "conflict resolution started", session, fmt.Sprintf("pr=%d url=%s", pr.Number, pr.URL))
+
+	prompt := skill.BuildConflictResolutionPrompt(target, session, pr)
+	output, err := env.Runner.Run(
+		ctx,
+		"",
+		"codex",
+		"exec",
+		"--cd", session.WorktreePath,
+		"--dangerously-bypass-approvals-and-sandbox",
+		prompt,
+	)
+	if err != nil {
+		appendSessionLog(logPath, "conflict resolution failed", session, combineLogDetails(output, err.Error()))
+		body := fmt.Sprintf("Vigilante conflict-resolution session failed for PR #%d on branch `%s`: %s", pr.Number, session.Branch, summarizeError(err))
+		_ = ghcli.CommentOnIssue(ctx, env.Runner, target.Repo, session.IssueNumber, body)
+		return err
+	}
+
+	appendSessionLog(logPath, "conflict resolution succeeded", session, output)
+	return nil
+}
+
 func summarizeError(err error) string {
 	text := strings.TrimSpace(err.Error())
 	if len(text) > 400 {

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -75,3 +75,33 @@ func TestRunIssueSessionFailureCommentsOnIssue(t *testing.T) {
 		t.Fatalf("unexpected log: %s", string(data))
 	}
 }
+
+func TestRunConflictResolutionSessionFailureCommentsOnIssue(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh issue comment --repo owner/repo 7 --body Vigilante conflict-resolution session failed for PR #17 on branch `vigilante/issue-7`: codex exec [--cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox prompt]: exit status 1": "ok",
+		},
+		Errors: map[string]error{
+			"codex exec --cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox Use the `vigilante-conflict-resolution` skill for this task.\nRepository: owner/repo\nLocal repository path: /tmp/repo\nIssue: #7 - Demo\nIssue URL: https://github.com/owner/repo/issues/7\nPull Request: #17\nPull Request URL: https://github.com/owner/repo/pull/17\nWorktree path: /tmp/worktree\nBranch: vigilante/issue-7\nBase branch: origin/main\nResolve the current rebase conflicts in the assigned worktree, use `gh issue comment` for progress and failures, rerun `go test ./...` after conflict resolution if the rebase succeeds, and push the updated branch when finished.\nKeep the changes minimal and focused on getting the PR back to a merge-ready state.": errors.New("codex exec [--cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox prompt]: exit status 1"),
+		},
+	}
+	env := &environment.Environment{OS: "darwin", Runner: runner}
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := RunConflictResolutionSession(
+		context.Background(),
+		env,
+		store,
+		state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"},
+		state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, IssueTitle: "Demo", IssueURL: "https://github.com/owner/repo/issues/7", WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7"},
+		ghcli.PullRequest{Number: 17, URL: "https://github.com/owner/repo/pull/17"},
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -12,17 +12,23 @@ import (
 )
 
 const VigilanteIssueImplementation = "vigilante-issue-implementation"
+const VigilanteConflictResolution = "vigilante-conflict-resolution"
 
 func EnsureInstalled(codexHome string) error {
-	skillDir := filepath.Join(codexHome, "skills", VigilanteIssueImplementation)
-	sourceDir := repoSkillDir()
-	if _, err := os.Stat(filepath.Join(sourceDir, "SKILL.md")); err != nil {
-		return err
+	for _, name := range []string{VigilanteIssueImplementation, VigilanteConflictResolution} {
+		skillDir := filepath.Join(codexHome, "skills", name)
+		sourceDir := repoSkillDir(name)
+		if _, err := os.Stat(filepath.Join(sourceDir, "SKILL.md")); err != nil {
+			return err
+		}
+		if err := os.RemoveAll(skillDir); err != nil {
+			return err
+		}
+		if err := copyDir(sourceDir, skillDir); err != nil {
+			return err
+		}
 	}
-	if err := os.RemoveAll(skillDir); err != nil {
-		return err
-	}
-	return copyDir(sourceDir, skillDir)
+	return nil
 }
 
 func BuildIssuePrompt(target state.WatchTarget, issue ghcli.Issue, session state.Session) string {
@@ -40,12 +46,30 @@ func BuildIssuePrompt(target state.WatchTarget, issue ghcli.Issue, session state
 	return strings.Join(lines, "\n")
 }
 
-func repoSkillPath() string {
-	return filepath.Join(repoRoot(), "skills", VigilanteIssueImplementation, "SKILL.md")
+func BuildConflictResolutionPrompt(target state.WatchTarget, session state.Session, pr ghcli.PullRequest) string {
+	lines := []string{
+		fmt.Sprintf("Use the `%s` skill for this task.", VigilanteConflictResolution),
+		fmt.Sprintf("Repository: %s", target.Repo),
+		fmt.Sprintf("Local repository path: %s", target.Path),
+		fmt.Sprintf("Issue: #%d - %s", session.IssueNumber, session.IssueTitle),
+		fmt.Sprintf("Issue URL: %s", session.IssueURL),
+		fmt.Sprintf("Pull Request: #%d", pr.Number),
+		fmt.Sprintf("Pull Request URL: %s", pr.URL),
+		fmt.Sprintf("Worktree path: %s", session.WorktreePath),
+		fmt.Sprintf("Branch: %s", session.Branch),
+		"Base branch: origin/main",
+		"Resolve the current rebase conflicts in the assigned worktree, use `gh issue comment` for progress and failures, rerun `go test ./...` after conflict resolution if the rebase succeeds, and push the updated branch when finished.",
+		"Keep the changes minimal and focused on getting the PR back to a merge-ready state.",
+	}
+	return strings.Join(lines, "\n")
 }
 
-func repoSkillDir() string {
-	return filepath.Join(repoRoot(), "skills", VigilanteIssueImplementation)
+func repoSkillPath(name string) string {
+	return filepath.Join(repoRoot(), "skills", name, "SKILL.md")
+}
+
+func repoSkillDir(name string) string {
+	return filepath.Join(repoRoot(), "skills", name)
 }
 
 func repoRoot() string {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -13,20 +13,20 @@ import (
 func TestEnsureInstalled(t *testing.T) {
 	dir := t.TempDir()
 	repoRoot := t.TempDir()
-	skillSourceDir := filepath.Join(repoRoot, "skills", VigilanteIssueImplementation)
-	if err := os.MkdirAll(skillSourceDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	sourceBody := "# repo skill\n"
-	if err := os.WriteFile(filepath.Join(skillSourceDir, "SKILL.md"), []byte(sourceBody), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Join(skillSourceDir, "agents"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	agentBody := "interface:\n  display_name: test\n"
-	if err := os.WriteFile(filepath.Join(skillSourceDir, "agents", "openai.yaml"), []byte(agentBody), 0o644); err != nil {
-		t.Fatal(err)
+	for _, name := range []string{VigilanteIssueImplementation, VigilanteConflictResolution} {
+		skillSourceDir := filepath.Join(repoRoot, "skills", name)
+		if err := os.MkdirAll(skillSourceDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(skillSourceDir, "SKILL.md"), []byte("# repo skill\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(skillSourceDir, "agents"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(skillSourceDir, "agents", "openai.yaml"), []byte("interface:\n  display_name: test\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
 	}
 	wd, err := os.Getwd()
 	if err != nil {
@@ -42,20 +42,22 @@ func TestEnsureInstalled(t *testing.T) {
 	if err := EnsureInstalled(dir); err != nil {
 		t.Fatal(err)
 	}
-	path := filepath.Join(dir, "skills", VigilanteIssueImplementation, "SKILL.md")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(data) != sourceBody {
-		t.Fatalf("unexpected skill body: %s", string(data))
-	}
-	agentData, err := os.ReadFile(filepath.Join(dir, "skills", VigilanteIssueImplementation, "agents", "openai.yaml"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(agentData) != agentBody {
-		t.Fatalf("unexpected agent body: %s", string(agentData))
+	for _, name := range []string{VigilanteIssueImplementation, VigilanteConflictResolution} {
+		path := filepath.Join(dir, "skills", name, "SKILL.md")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != "# repo skill\n" {
+			t.Fatalf("unexpected skill body: %s", string(data))
+		}
+		agentData, err := os.ReadFile(filepath.Join(dir, "skills", name, "agents", "openai.yaml"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(agentData) != "interface:\n  display_name: test\n" {
+			t.Fatalf("unexpected agent body: %s", string(agentData))
+		}
 	}
 }
 
@@ -65,6 +67,18 @@ func TestBuildIssuePrompt(t *testing.T) {
 	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12"}
 	prompt := BuildIssuePrompt(target, issue, session)
 	for _, text := range []string{"Use the `vigilante-issue-implementation` skill", "Issue: #12 - Fix bug", "Worktree path: /tmp/worktree", "gh issue comment", "implementation plan", "open a pull request"} {
+		if !strings.Contains(prompt, text) {
+			t.Fatalf("prompt missing %q: %s", text, prompt)
+		}
+	}
+}
+
+func TestBuildConflictResolutionPrompt(t *testing.T) {
+	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
+	session := state.Session{IssueNumber: 12, IssueTitle: "Fix bug", IssueURL: "https://example.com/issues/12", WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12"}
+	pr := ghcli.PullRequest{Number: 88, URL: "https://example.com/pull/88"}
+	prompt := BuildConflictResolutionPrompt(target, session, pr)
+	for _, text := range []string{"Use the `vigilante-conflict-resolution` skill", "Pull Request: #88", "Base branch: origin/main", "go test ./...", "merge-ready state"} {
 		if !strings.Contains(prompt, text) {
 			t.Fatalf("prompt missing %q: %s", text, prompt)
 		}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -31,23 +31,27 @@ const (
 )
 
 type Session struct {
-	RepoPath            string        `json:"repo_path"`
-	Repo                string        `json:"repo"`
-	IssueNumber         int           `json:"issue_number"`
-	IssueTitle          string        `json:"issue_title,omitempty"`
-	IssueURL            string        `json:"issue_url,omitempty"`
-	Branch              string        `json:"branch"`
-	WorktreePath        string        `json:"worktree_path"`
-	Status              SessionStatus `json:"status"`
-	PullRequestNumber   int           `json:"pull_request_number,omitempty"`
-	PullRequestURL      string        `json:"pull_request_url,omitempty"`
-	PullRequestMergedAt string        `json:"pull_request_merged_at,omitempty"`
-	CleanupCompletedAt  string        `json:"cleanup_completed_at,omitempty"`
-	CleanupError        string        `json:"cleanup_error,omitempty"`
-	StartedAt           string        `json:"started_at,omitempty"`
-	EndedAt             string        `json:"ended_at,omitempty"`
-	UpdatedAt           string        `json:"updated_at,omitempty"`
-	LastError           string        `json:"last_error,omitempty"`
+	RepoPath             string        `json:"repo_path"`
+	Repo                 string        `json:"repo"`
+	IssueNumber          int           `json:"issue_number"`
+	IssueTitle           string        `json:"issue_title,omitempty"`
+	IssueURL             string        `json:"issue_url,omitempty"`
+	Branch               string        `json:"branch"`
+	WorktreePath         string        `json:"worktree_path"`
+	Status               SessionStatus `json:"status"`
+	PullRequestNumber    int           `json:"pull_request_number,omitempty"`
+	PullRequestURL       string        `json:"pull_request_url,omitempty"`
+	PullRequestState     string        `json:"pull_request_state,omitempty"`
+	PullRequestMergedAt  string        `json:"pull_request_merged_at,omitempty"`
+	LastMaintainedAt     string        `json:"last_maintained_at,omitempty"`
+	LastMaintenanceError string        `json:"last_maintenance_error,omitempty"`
+	MonitoringStoppedAt  string        `json:"monitoring_stopped_at,omitempty"`
+	CleanupCompletedAt   string        `json:"cleanup_completed_at,omitempty"`
+	CleanupError         string        `json:"cleanup_error,omitempty"`
+	StartedAt            string        `json:"started_at,omitempty"`
+	EndedAt              string        `json:"ended_at,omitempty"`
+	UpdatedAt            string        `json:"updated_at,omitempty"`
+	LastError            string        `json:"last_error,omitempty"`
 }
 
 type Store struct {

--- a/skills/vigilante-conflict-resolution/SKILL.md
+++ b/skills/vigilante-conflict-resolution/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: vigilante-conflict-resolution
+description: Resolve rebase and merge conflicts for an already-open Vigilante pull request, keep the branch validated, and report progress back to GitHub.
+---
+
+# Vigilante Conflict Resolution
+
+## Overview
+Use this skill after Vigilante has already opened a pull request and a follow-up rebase onto `origin/main` hits conflicts. Work only inside the assigned worktree, resolve the conflicts with the smallest safe change, rerun validation, push the updated branch, and keep the linked GitHub issue informed.
+
+## Workflow
+1. Inspect the current rebase state in the assigned worktree.
+2. Read repository instructions that affect the touched files before editing.
+3. Comment on the issue when conflict resolution begins and again for meaningful milestones or failures.
+4. Resolve only the conflicts needed to complete the rebase cleanly.
+5. Rerun the requested validation after the rebase succeeds.
+6. Push the updated branch back to GitHub.
+7. Report the final result clearly on the issue, including any remaining blocker if the conflicts cannot be resolved safely.
+
+## Guardrails
+- Stay inside the provided worktree.
+- Do not broaden the change beyond the conflicting files unless required to restore build or test health.
+- Do not claim the branch is merge-ready unless the requested validation actually passed.
+- Report blockers immediately with `gh issue comment`.

--- a/skills/vigilante-conflict-resolution/agents/openai.yaml
+++ b/skills/vigilante-conflict-resolution/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: Vigilante Conflict Resolution
+model: gpt-5
+behavior:
+  default_prompt: "Use $vigilante-conflict-resolution to resolve the current rebase conflicts in the provided worktree, rerun validation, push the branch, and comment progress or failures back to the linked GitHub issue."


### PR DESCRIPTION
## Summary
- add and install a dedicated `vigilante-conflict-resolution` skill for post-PR rebase conflicts
- keep successful Vigilante sessions under PR maintenance so daemon scans revisit open PRs and rebase them onto `origin/main`
- rerun `go test ./...`, push updated branches, and persist PR maintenance state for ongoing monitoring

Closes #18

## Validation
- go test ./...
