### PR TITLE
Make installed skills self-contained

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Expected behavior:
 - creates `~/.vigilante/`
 - initializes `watchlist.json`
 - verifies `git`, `gh`, and `codex`
-- installs the Codex issue implementation skill from the repo `skills/` folder if missing, including any companion files under that skill directory
+- installs the bundled Codex skills for regular runtime use, including any companion files under each skill directory
 - installs or updates the daemon definition when requested
 
 ## Development Mode
@@ -155,7 +155,8 @@ go build -o /Users/$USER/.local/bin/vigilante ./cmd/vigilante
 Notes:
 
 - foreground runs are the quickest way to iterate on scheduler, worktree, and Codex execution behavior
-- `setup` refreshes the installed skill from the repo `skills/` folder
+- when `vigilante` runs from a repository checkout, `setup` refreshes installed skills from the local repo `skills/` folder so skill edits are picked up immediately
+- when `vigilante` runs as an installed binary outside the repo checkout, `setup` uses skills embedded in the binary so it works from any directory without depending on the source tree
 - after changing service installation logic on macOS, rerun `setup -d` so the `launchd` plist is regenerated with the current shell-derived PATH
 - the CLI entrypoint lives in `cmd/vigilante/`, while non-exported implementation packages live under `internal/`
 

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -3,10 +3,12 @@ package skill
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 
+	skillassets "github.com/nicobistolfi/vigilante"
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
 	"github.com/nicobistolfi/vigilante/internal/state"
 )
@@ -17,14 +19,14 @@ const VigilanteConflictResolution = "vigilante-conflict-resolution"
 func EnsureInstalled(codexHome string) error {
 	for _, name := range []string{VigilanteIssueImplementation, VigilanteConflictResolution} {
 		skillDir := filepath.Join(codexHome, "skills", name)
-		sourceDir := repoSkillDir(name)
-		if _, err := os.Stat(filepath.Join(sourceDir, "SKILL.md")); err != nil {
+		source, err := resolveSkillSource(name)
+		if err != nil {
 			return err
 		}
 		if err := os.RemoveAll(skillDir); err != nil {
 			return err
 		}
-		if err := copyDir(sourceDir, skillDir); err != nil {
+		if err := source.install(skillDir); err != nil {
 			return err
 		}
 	}
@@ -70,6 +72,38 @@ func repoSkillPath(name string) string {
 
 func repoSkillDir(name string) string {
 	return filepath.Join(repoRoot(), "skills", name)
+}
+
+type skillSource interface {
+	install(dst string) error
+}
+
+type dirSkillSource string
+
+func (s dirSkillSource) install(dst string) error {
+	return copyDir(string(s), dst)
+}
+
+type embeddedSkillSource struct {
+	root string
+	fs   fs.FS
+}
+
+func (s embeddedSkillSource) install(dst string) error {
+	return copyFS(s.fs, s.root, dst)
+}
+
+func resolveSkillSource(name string) (skillSource, error) {
+	sourceDir := repoSkillDir(name)
+	if _, err := os.Stat(filepath.Join(sourceDir, "SKILL.md")); err == nil {
+		return dirSkillSource(sourceDir), nil
+	}
+
+	root := filepath.ToSlash(filepath.Join("skills", name))
+	if _, err := fs.Stat(skillassets.Skills, pathJoin(root, "SKILL.md")); err != nil {
+		return nil, err
+	}
+	return embeddedSkillSource{root: root, fs: skillassets.Skills}, nil
 }
 
 func repoRoot() string {
@@ -121,6 +155,52 @@ func copyDir(src string, dst string) error {
 	})
 }
 
+func copyFS(source fs.FS, root string, dst string) error {
+	return fs.WalkDir(source, root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(filepath.FromSlash(root), filepath.FromSlash(path))
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if entry.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		return copyFSFile(source, path, target, info.Mode())
+	})
+}
+
+func copyFSFile(source fs.FS, src string, dst string, mode os.FileMode) error {
+	in, err := source.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Close()
+}
+
 func copyFile(src string, dst string, mode os.FileMode) error {
 	in, err := os.Open(src)
 	if err != nil {
@@ -142,4 +222,8 @@ func copyFile(src string, dst string, mode os.FileMode) error {
 		return err
 	}
 	return out.Close()
+}
+
+func pathJoin(parts ...string) string {
+	return strings.Join(parts, "/")
 }

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -1,16 +1,18 @@
 package skill
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	skillassets "github.com/nicobistolfi/vigilante"
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
 	"github.com/nicobistolfi/vigilante/internal/state"
 )
 
-func TestEnsureInstalled(t *testing.T) {
+func TestEnsureInstalledPrefersRepoSkillsWhenAvailable(t *testing.T) {
 	dir := t.TempDir()
 	repoRoot := t.TempDir()
 	for _, name := range []string{VigilanteIssueImplementation, VigilanteConflictResolution} {
@@ -57,6 +59,71 @@ func TestEnsureInstalled(t *testing.T) {
 		}
 		if string(agentData) != "interface:\n  display_name: test\n" {
 			t.Fatalf("unexpected agent body: %s", string(agentData))
+		}
+	}
+}
+
+func TestResolveSkillSourceFallsBackToEmbeddedAssets(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	outside := t.TempDir()
+	if err := os.Chdir(outside); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.Chdir(wd)
+	}()
+
+	for _, name := range []string{VigilanteIssueImplementation, VigilanteConflictResolution} {
+		source, err := resolveSkillSource(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		embedded, ok := source.(embeddedSkillSource)
+		if !ok {
+			t.Fatalf("expected embedded skill source for %s, got %T", name, source)
+		}
+
+		bodyPath := pathJoin(embedded.root, "SKILL.md")
+		expected, err := fs.ReadFile(skillassets.Skills, bodyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		actual, err := fs.ReadFile(embedded.fs, bodyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(actual) != string(expected) {
+			t.Fatalf("unexpected embedded body for %s", name)
+		}
+	}
+}
+
+func TestEnsureInstalledUsesEmbeddedAssetsOutsideRepo(t *testing.T) {
+	dir := t.TempDir()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	outside := t.TempDir()
+	if err := os.Chdir(outside); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.Chdir(wd)
+	}()
+
+	if err := EnsureInstalled(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{VigilanteIssueImplementation, VigilanteConflictResolution} {
+		path := filepath.Join(dir, "skills", name, "SKILL.md")
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected %s to exist: %v", path, err)
 		}
 	}
 }

--- a/skillassets.go
+++ b/skillassets.go
@@ -1,0 +1,8 @@
+package skillassets
+
+import "embed"
+
+// Skills contains built-in runtime skill files for installed binaries.
+//
+//go:embed skills/vigilante-issue-implementation skills/vigilante-conflict-resolution
+var Skills embed.FS


### PR DESCRIPTION
## Summary
- embed the built-in Vigilante skills into the binary for installed/runtime use
- keep preferring repo-local `skills/` content when running from a checkout so development stays fast
- document the resolution split and cover both paths with tests

Closes #23.

## Validation
- go test ./...
- go build ./...