### PR TITLE
Use local timezone in Vigilante logs

### DIFF
--- a/internal/logtime/logtime.go
+++ b/internal/logtime/logtime.go
@@ -1,0 +1,8 @@
+package logtime
+
+import "time"
+
+// FormatLocal renders human-facing log timestamps in the user's local timezone.
+func FormatLocal(t time.Time) string {
+	return t.In(time.Local).Format(time.RFC3339)
+}

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nicobistolfi/vigilante/internal/environment"
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
+	"github.com/nicobistolfi/vigilante/internal/logtime"
 	"github.com/nicobistolfi/vigilante/internal/skill"
 	"github.com/nicobistolfi/vigilante/internal/state"
 )
@@ -97,7 +98,7 @@ func appendSessionLog(path string, event string, session state.Session, details 
 	defer f.Close()
 
 	_, _ = fmt.Fprintf(f, "[%s] %s issue=%d branch=%s worktree=%s status=%s\n",
-		time.Now().UTC().Format(time.RFC3339),
+		logtime.FormatLocal(time.Now()),
 		event,
 		session.IssueNumber,
 		session.Branch,

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nicobistolfi/vigilante/internal/environment"
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
@@ -103,5 +104,33 @@ func TestRunConflictResolutionSessionFailureCommentsOnIssue(t *testing.T) {
 	)
 	if err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestAppendSessionLogUsesLocalTimezone(t *testing.T) {
+	originalLocal := time.Local
+	time.Local = time.FixedZone("TEST", -8*60*60)
+	t.Cleanup(func() {
+		time.Local = originalLocal
+	})
+
+	path := filepath.Join(t.TempDir(), "issue-7.log")
+	appendSessionLog(path, "session started", state.Session{
+		IssueNumber:  7,
+		Branch:       "vigilante/issue-7",
+		WorktreePath: "/tmp/worktree",
+		Status:       state.SessionStatusRunning,
+	}, "")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "-08:00] session started") {
+		t.Fatalf("expected local timezone offset in session log entry, got %q", text)
+	}
+	if strings.Contains(text, "Z] session started") {
+		t.Fatalf("expected local timezone log entry, got %q", text)
 	}
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/nicobistolfi/vigilante/internal/logtime"
 )
 
 type WatchTarget struct {
@@ -189,7 +191,7 @@ func appendLogFile(path string, message string) {
 		return
 	}
 	defer f.Close()
-	_, _ = fmt.Fprintf(f, "[%s] %s\n", time.Now().UTC().Format(time.RFC3339), strings.TrimSpace(message))
+	_, _ = fmt.Fprintf(f, "[%s] %s\n", logtime.FormatLocal(time.Now()), strings.TrimSpace(message))
 }
 
 func (s *Store) TryWithScanLock(fn func() error) (bool, error) {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,8 +1,11 @@
 package state
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestTryWithScanLockIsExclusive(t *testing.T) {
@@ -30,5 +33,28 @@ func TestTryWithScanLockIsExclusive(t *testing.T) {
 	}
 	if !locked {
 		t.Fatal("expected first scan lock acquisition to succeed")
+	}
+}
+
+func TestAppendLogFileUsesLocalTimezone(t *testing.T) {
+	originalLocal := time.Local
+	time.Local = time.FixedZone("TEST", -8*60*60)
+	t.Cleanup(func() {
+		time.Local = originalLocal
+	})
+
+	path := filepath.Join(t.TempDir(), "vigilante.log")
+	appendLogFile(path, "daemon run start")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "-08:00] daemon run start") {
+		t.Fatalf("expected local timezone offset in log entry, got %q", text)
+	}
+	if strings.Contains(text, "Z] daemon run start") {
+		t.Fatalf("expected local timezone log entry, got %q", text)
 	}
 }


### PR DESCRIPTION
## Summary
- switch human-facing daemon and session logs to RFC3339 timestamps in the local machine timezone
- keep machine-readable session/state timestamps unchanged in UTC
- add focused tests that verify log files no longer force UTC

Closes #26

## Validation
- go test ./...
- go vet ./...
- go build ./...