### PR TITLE
Resolve assignee me before issue queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Expected behavior:
 - validates the folder is a git repository
 - discovers the GitHub remote from git config
 - defaults the assignee filter to `me` unless overridden
+- resolves `me` to the authenticated GitHub login at runtime before issue queries
 - stores the target in `~/.vigilante/watchlist.json`
 
 Example:

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -209,8 +209,9 @@ func TestScanOnceSelectsEligibleIssueAndPersistsSession(t *testing.T) {
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: map[string]string{
-			"gh auth status": "ok",
-			"gh issue list --repo owner/repo --state open --assignee me --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[{"name":"to-do"}]}]`,
+			"gh auth status":          "ok",
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[{"name":"to-do"}]}]`,
 			"git worktree prune": "ok",
 			"git worktree add -b vigilante/issue-1 " + worktreePath + " main":                                                                                       "ok",
 			"gh issue comment --repo owner/repo 1 --body Vigilante started a Codex session for this issue in `" + worktreePath + "` on branch `vigilante/issue-1`.": "ok",
@@ -250,7 +251,8 @@ func TestScanOncePrintsNoEligibleIssues(t *testing.T) {
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: map[string]string{
-			"gh issue list --repo owner/repo --state open --assignee me --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]}]`,
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]}]`,
 		},
 	}
 	if err := app.state.EnsureLayout(); err != nil {
@@ -287,7 +289,8 @@ func TestScanOnceCleansUpMergedIssueSession(t *testing.T) {
 			"git worktree list --porcelain":                              "worktree /tmp/repo\nHEAD abcdef\nbranch refs/heads/main\n",
 			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": "ok",
 			"git branch -D vigilante/issue-1":                            "Deleted branch vigilante/issue-1\n",
-			"gh issue list --repo owner/repo --state open --assignee me --json number,title,createdAt,url,labels": "[]",
+			"gh api user --jq .login":                                    "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
 		},
 	}
 	if err := app.state.EnsureLayout(); err != nil {
@@ -357,7 +360,8 @@ func TestScanOnceMaintainsOpenPullRequest(t *testing.T) {
 			"go test ./...":          "ok",
 			"git push --force-with-lease origin HEAD:vigilante/issue-1": "ok",
 			"gh issue comment --repo owner/repo 1 --body Vigilante rebased PR #31 onto the latest `origin/main`, reran `go test ./...`, and pushed `vigilante/issue-1`.": "ok",
-			"gh issue list --repo owner/repo --state open --assignee me --json number,title,createdAt,url,labels":                                                        "[]",
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
 		},
 	}
 	if err := app.state.EnsureLayout(); err != nil {
@@ -457,5 +461,35 @@ func TestScanOnceUsesExplicitAssigneeFilter(t *testing.T) {
 	}
 	if got := stdout.String(); !strings.Contains(got, "repo: owner/repo no eligible issues (0 open)") {
 		t.Fatalf("unexpected output: %s", got)
+	}
+}
+
+func TestScanOnceReturnsErrorWhenResolvingDefaultAssigneeFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Errors: map[string]error{
+			"gh api user --jq .login": context.DeadlineExceeded,
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main", Assignee: "me"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := app.ScanOnce(context.Background())
+	if err == nil {
+		t.Fatal("expected assignee resolution error")
+	}
+	if got := err.Error(); got != `resolve assignee "me": context deadline exceeded` {
+		t.Fatalf("unexpected error: %s", got)
 	}
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -32,9 +32,14 @@ type PullRequest struct {
 }
 
 func ListOpenIssues(ctx context.Context, runner environment.Runner, repo string, assignee string) ([]Issue, error) {
+	resolvedAssignee, err := resolveAssignee(ctx, runner, assignee)
+	if err != nil {
+		return nil, err
+	}
+
 	args := []string{"issue", "list", "--repo", repo, "--state", "open"}
-	if assignee != "" {
-		args = append(args, "--assignee", assignee)
+	if resolvedAssignee != "" {
+		args = append(args, "--assignee", resolvedAssignee)
 	}
 	args = append(args, "--json", "number,title,createdAt,url,labels")
 	output, err := runner.Run(ctx, "", "gh", args...)
@@ -50,6 +55,18 @@ func ListOpenIssues(ctx context.Context, runner environment.Runner, repo string,
 		return issues[i].CreatedAt.Before(issues[j].CreatedAt)
 	})
 	return issues, nil
+}
+
+func resolveAssignee(ctx context.Context, runner environment.Runner, assignee string) (string, error) {
+	if assignee != "me" {
+		return assignee, nil
+	}
+
+	output, err := runner.Run(ctx, "", "gh", "api", "user", "--jq", ".login")
+	if err != nil {
+		return "", fmt.Errorf("resolve assignee %q: %w", assignee, err)
+	}
+	return strings.TrimSpace(output), nil
 }
 
 func SelectNextIssue(issues []Issue, sessions []state.Session, target state.WatchTarget) *Issue {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -12,7 +12,8 @@ import (
 func TestListOpenIssuesAndSelectNext(t *testing.T) {
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{
-			"gh issue list --repo owner/repo --state open --assignee me --json number,title,createdAt,url,labels": `[{"number":2,"title":"newer","createdAt":"2026-03-10T12:00:00Z","url":"u2","labels":[{"name":"to-do"}]},{"number":1,"title":"older","createdAt":"2026-03-09T12:00:00Z","url":"u1","labels":[{"name":"bug"}]}]`,
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":2,"title":"newer","createdAt":"2026-03-10T12:00:00Z","url":"u2","labels":[{"name":"to-do"}]},{"number":1,"title":"older","createdAt":"2026-03-09T12:00:00Z","url":"u1","labels":[{"name":"bug"}]}]`,
 		},
 	}
 	issues, err := ListOpenIssues(context.Background(), runner, "owner/repo", "me")
@@ -80,6 +81,22 @@ func TestListOpenIssuesAllowsNoAssigneeFilter(t *testing.T) {
 	}
 	if len(issues) != 1 || issues[0].Number != 4 {
 		t.Fatalf("unexpected issues: %#v", issues)
+	}
+}
+
+func TestListOpenIssuesReturnsErrorWhenResolvingMeFails(t *testing.T) {
+	runner := testutil.FakeRunner{
+		Errors: map[string]error{
+			"gh api user --jq .login": context.DeadlineExceeded,
+		},
+	}
+
+	_, err := ListOpenIssues(context.Background(), runner, "owner/repo", "me")
+	if err == nil {
+		t.Fatal("expected resolution error")
+	}
+	if got := err.Error(); got != `resolve assignee "me": context deadline exceeded` {
+		t.Fatalf("unexpected error: %s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- resolve configured assignee `me` to the authenticated GitHub login before calling `gh issue list`
- keep explicit assignee filters unchanged and preserve `me` as the stored/default watch target value
- add tests for successful resolution, explicit assignees, and login-resolution failures

## Testing
- go test ./...
- go vet ./...
- go build ./...
- gofmt -l .

Closes #27