### PR TITLE
Recover stalled issue sessions

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/nicobistolfi/vigilante/internal/environment"
@@ -26,6 +27,7 @@ import (
 
 const defaultScanInterval = 1 * time.Minute
 const defaultAssigneeFilter = "me"
+const defaultStalledSessionThreshold = 10 * time.Minute
 
 type App struct {
 	stdout io.Writer
@@ -326,6 +328,10 @@ func (a *App) ScanOnce(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		sessions, err = a.recoverStalledSessions(ctx, sessions)
+		if err != nil {
+			return err
+		}
 		sessions, err = a.maintainPullRequests(ctx, sessions)
 		if err != nil {
 			return err
@@ -364,16 +370,18 @@ func (a *App) ScanOnce(ctx context.Context) error {
 			a.state.AppendDaemonLog("scan repo worktree ready repo=%s issue=%d path=%s branch=%s", target.Repo, next.Number, wt.Path, wt.Branch)
 
 			session := state.Session{
-				RepoPath:     target.Path,
-				Repo:         target.Repo,
-				IssueNumber:  next.Number,
-				IssueTitle:   next.Title,
-				IssueURL:     next.URL,
-				Branch:       wt.Branch,
-				WorktreePath: wt.Path,
-				Status:       state.SessionStatusRunning,
-				StartedAt:    a.clock().Format(time.RFC3339),
-				UpdatedAt:    a.clock().Format(time.RFC3339),
+				RepoPath:        target.Path,
+				Repo:            target.Repo,
+				IssueNumber:     next.Number,
+				IssueTitle:      next.Title,
+				IssueURL:        next.URL,
+				Branch:          wt.Branch,
+				WorktreePath:    wt.Path,
+				Status:          state.SessionStatusRunning,
+				ProcessID:       os.Getpid(),
+				StartedAt:       a.clock().Format(time.RFC3339),
+				LastHeartbeatAt: a.clock().Format(time.RFC3339),
+				UpdatedAt:       a.clock().Format(time.RFC3339),
 			}
 			sessions = upsertSession(sessions, session)
 			if err := a.state.SaveSessions(sessions); err != nil {
@@ -404,6 +412,77 @@ func (a *App) ScanOnce(ctx context.Context) error {
 		return nil
 	}
 	return nil
+}
+
+func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Session) ([]state.Session, error) {
+	threshold := stalledSessionThreshold()
+
+	for i := range sessions {
+		session := &sessions[i]
+		if session.Status != state.SessionStatusRunning {
+			continue
+		}
+		if sessionProcessAlive(session.ProcessID) {
+			continue
+		}
+
+		stale, reason := isStalledSession(*session, a.clock(), threshold)
+		if !stale {
+			continue
+		}
+
+		pr, err := ghcli.FindPullRequestForBranch(ctx, a.env.Runner, session.Repo, session.Branch)
+		if err != nil {
+			return nil, err
+		}
+		if pr != nil {
+			session.Status = state.SessionStatusSuccess
+			session.ProcessID = 0
+			session.LastHeartbeatAt = ""
+			session.PullRequestNumber = pr.Number
+			session.PullRequestURL = pr.URL
+			session.PullRequestState = pr.State
+			if pr.MergedAt != nil {
+				session.PullRequestMergedAt = pr.MergedAt.UTC().Format(time.RFC3339)
+			}
+			session.LastError = ""
+			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			a.state.AppendDaemonLog("stalled session recovered to pr maintenance repo=%s issue=%d branch=%s reason=%q pr=%d", session.Repo, session.IssueNumber, session.Branch, reason, pr.Number)
+			body := fmt.Sprintf("Vigilante detected that the previous local session for branch `%s` was stalled (%s). An existing PR #%d was found, so the issue was recovered into PR maintenance.", session.Branch, reason, pr.Number)
+			if err := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		if err := worktree.CleanupIssueArtifacts(ctx, a.env.Runner, session.RepoPath, session.WorktreePath, session.Branch); err != nil {
+			session.LastError = fmt.Sprintf("stalled session detected (%s) but cleanup failed: %v", reason, err)
+			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			session.CleanupError = err.Error()
+			a.state.AppendDaemonLog("stalled session cleanup failed repo=%s issue=%d branch=%s reason=%q err=%v", session.Repo, session.IssueNumber, session.Branch, reason, err)
+			body := fmt.Sprintf("Vigilante detected a stalled local session on branch `%s` (%s), but automatic cleanup failed: %s", session.Branch, reason, summarizeMaintenanceError(err))
+			if commentErr := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); commentErr != nil {
+				return nil, commentErr
+			}
+			continue
+		}
+
+		now := a.clock().Format(time.RFC3339)
+		session.Status = state.SessionStatusFailed
+		session.ProcessID = 0
+		session.LastHeartbeatAt = ""
+		session.CleanupError = ""
+		session.EndedAt = now
+		session.UpdatedAt = now
+		session.LastError = fmt.Sprintf("stalled session recovered: %s", reason)
+		a.state.AppendDaemonLog("stalled session recovered for redispatch repo=%s issue=%d branch=%s reason=%q", session.Repo, session.IssueNumber, session.Branch, reason)
+		body := fmt.Sprintf("Vigilante detected that the previous local session on branch `%s` was stalled (%s). The abandoned worktree state was cleaned up so the issue can be redispatched.", session.Branch, reason)
+		if err := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); err != nil {
+			return nil, err
+		}
+	}
+
+	return sessions, nil
 }
 
 func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session) ([]state.Session, error) {
@@ -521,6 +600,63 @@ func (a *App) maintainOpenPullRequest(ctx context.Context, session *state.Sessio
 
 	body := fmt.Sprintf("Vigilante rebased PR #%d onto the latest `origin/main`, reran `go test ./...`, and pushed `%s`.", pr.Number, session.Branch)
 	return ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body)
+}
+
+func stalledSessionThreshold() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("VIGILANTE_STALLED_SESSION_THRESHOLD"))
+	if raw == "" {
+		return defaultStalledSessionThreshold
+	}
+	parsed, err := time.ParseDuration(raw)
+	if err != nil || parsed <= 0 {
+		return defaultStalledSessionThreshold
+	}
+	return parsed
+}
+
+func isStalledSession(session state.Session, now time.Time, threshold time.Duration) (bool, string) {
+	if _, err := os.Stat(session.WorktreePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return true, "worktree path is missing"
+		}
+	}
+
+	lastActivity := sessionActivityTime(session)
+	if lastActivity.IsZero() {
+		return true, "session has no recorded heartbeat"
+	}
+	if now.Sub(lastActivity) < threshold {
+		return false, ""
+	}
+	if session.ProcessID > 0 {
+		return true, fmt.Sprintf("process %d is not running and the session has been idle since %s", session.ProcessID, lastActivity.Format(time.RFC3339))
+	}
+	return true, fmt.Sprintf("no active process is recorded and the session has been idle since %s", lastActivity.Format(time.RFC3339))
+}
+
+func sessionActivityTime(session state.Session) time.Time {
+	for _, raw := range []string{session.LastHeartbeatAt, session.UpdatedAt, session.StartedAt} {
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		parsed, err := time.Parse(time.RFC3339, raw)
+		if err == nil {
+			return parsed
+		}
+	}
+	return time.Time{}
+}
+
+func sessionProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	err = process.Signal(syscall.Signal(0))
+	return err == nil
 }
 
 func rebaseChangedHistory(output string) bool {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nicobistolfi/vigilante/internal/skill"
 	"github.com/nicobistolfi/vigilante/internal/state"
@@ -261,7 +262,15 @@ func TestScanOncePrintsNoEligibleIssues(t *testing.T) {
 	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main", Assignee: "me", Labels: []string{"to-do"}}}); err != nil {
 		t.Fatal(err)
 	}
-	if err := app.state.SaveSessions([]state.Session{{Repo: "owner/repo", IssueNumber: 1, Status: state.SessionStatusRunning}}); err != nil {
+	if err := app.state.SaveSessions([]state.Session{{
+		Repo:            "owner/repo",
+		IssueNumber:     1,
+		Status:          state.SessionStatusRunning,
+		ProcessID:       os.Getpid(),
+		StartedAt:       time.Now().UTC().Format(time.RFC3339),
+		LastHeartbeatAt: time.Now().UTC().Format(time.RFC3339),
+		UpdatedAt:       time.Now().UTC().Format(time.RFC3339),
+	}}); err != nil {
 		t.Fatal(err)
 	}
 	if err := app.ScanOnce(context.Background()); err != nil {
@@ -567,5 +576,148 @@ func TestScanOnceReturnsErrorWhenResolvingDefaultAssigneeFails(t *testing.T) {
 	}
 	if got := err.Error(); got != `resolve assignee "me": context deadline exceeded` {
 		t.Fatalf("unexpected error: %s", got)
+	}
+}
+
+func TestScanOnceRecoversStalledSessionAndRedispatchesIssue(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+
+	var stdout bytes.Buffer
+	app := New()
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	now := time.Date(2026, 3, 10, 15, 0, 0, 0, time.UTC)
+	app.clock = func() time.Time { return now }
+
+	worktreePath := filepath.Join(home, "repo", ".worktrees", "vigilante", "issue-1")
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": "[]",
+			"git worktree prune":                                         "ok",
+			"git worktree list --porcelain":                              "worktree /tmp/repo\nHEAD abcdef\nbranch refs/heads/main\n",
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": "ok",
+			"git branch -D vigilante/issue-1":                            "Deleted branch vigilante/issue-1\n",
+			"gh issue comment --repo owner/repo 1 --body Vigilante detected that the previous local session on branch `vigilante/issue-1` was stalled (worktree path is missing). The abandoned worktree state was cleaned up so the issue can be redispatched.": "ok",
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels":                                         `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]}]`,
+			"git worktree add -b vigilante/issue-1 " + worktreePath + " main":                                                                                       "ok",
+			"git worktree add " + worktreePath + " vigilante/issue-1":                                                                                               "ok",
+			"gh issue comment --repo owner/repo 1 --body Vigilante started a Codex session for this issue in `" + worktreePath + "` on branch `vigilante/issue-1`.": "ok",
+			"codex exec --cd " + worktreePath + " --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: " + filepath.Join(home, "repo") + "\nIssue: #1 - first\nIssue URL: https://github.com/owner/repo/issues/1\nWorktree path: " + worktreePath + "\nBranch: vigilante/issue-1\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.": "done",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "repo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: filepath.Join(home, "repo"), Repo: "owner/repo", Branch: "main"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:        filepath.Join(home, "repo"),
+		Repo:            "owner/repo",
+		IssueNumber:     1,
+		IssueTitle:      "first",
+		IssueURL:        "https://github.com/owner/repo/issues/1",
+		Branch:          "vigilante/issue-1",
+		WorktreePath:    worktreePath,
+		Status:          state.SessionStatusRunning,
+		ProcessID:       999999,
+		StartedAt:       now.Add(-20 * time.Minute).Format(time.RFC3339),
+		LastHeartbeatAt: now.Add(-20 * time.Minute).Format(time.RFC3339),
+		UpdatedAt:       now.Add(-20 * time.Minute).Format(time.RFC3339),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 || sessions[0].Status != state.SessionStatusSuccess {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if got := stdout.String(); !strings.Contains(got, "repo: owner/repo started issue #1 in "+worktreePath) {
+		t.Fatalf("unexpected output: %s", got)
+	}
+}
+
+func TestScanOnceRecoversStalledSessionIntoPRMaintenance(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	var stdout bytes.Buffer
+	app := New()
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	now := time.Date(2026, 3, 10, 15, 0, 0, 0, time.UTC)
+	app.clock = func() time.Time { return now }
+
+	worktreePath := filepath.Join(home, "repo", ".worktrees", "vigilante", "issue-1")
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt":                                                                                                                                                  `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
+			"gh issue comment --repo owner/repo 1 --body Vigilante detected that the previous local session for branch `vigilante/issue-1` was stalled (worktree path is missing). An existing PR #31 was found, so the issue was recovered into PR maintenance.": "ok",
+			"git fetch origin main":   "ok",
+			"git status --porcelain":  "",
+			"git rebase origin/main":  "Current branch vigilante/issue-1 is up to date.\n",
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "repo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: filepath.Join(home, "repo"), Repo: "owner/repo", Branch: "main"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:        filepath.Join(home, "repo"),
+		Repo:            "owner/repo",
+		IssueNumber:     1,
+		IssueTitle:      "first",
+		IssueURL:        "https://github.com/owner/repo/issues/1",
+		Branch:          "vigilante/issue-1",
+		WorktreePath:    worktreePath,
+		Status:          state.SessionStatusRunning,
+		ProcessID:       999999,
+		StartedAt:       now.Add(-20 * time.Minute).Format(time.RFC3339),
+		LastHeartbeatAt: now.Add(-20 * time.Minute).Format(time.RFC3339),
+		UpdatedAt:       now.Add(-20 * time.Minute).Format(time.RFC3339),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if sessions[0].Status != state.SessionStatusSuccess {
+		t.Fatalf("expected success session after recovery: %#v", sessions[0])
+	}
+	if sessions[0].PullRequestNumber != 31 || sessions[0].LastMaintainedAt == "" {
+		t.Fatalf("expected PR maintenance tracking after recovery: %#v", sessions[0])
 	}
 }

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -16,6 +16,8 @@ import (
 
 func RunIssueSession(ctx context.Context, env *environment.Environment, store *state.Store, target state.WatchTarget, issue ghcli.Issue, session state.Session) state.Session {
 	logPath := store.SessionLogPath(issue.Number)
+	session.ProcessID = os.Getpid()
+	session.LastHeartbeatAt = time.Now().UTC().Format(time.RFC3339)
 	session.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 	startBody := fmt.Sprintf("Vigilante started a Codex session for this issue in `%s` on branch `%s`.", session.WorktreePath, session.Branch)
 	appendSessionLog(logPath, "session started", session, "")
@@ -39,6 +41,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 		prompt,
 	)
 	session.EndedAt = time.Now().UTC().Format(time.RFC3339)
+	session.LastHeartbeatAt = session.EndedAt
 	session.UpdatedAt = session.EndedAt
 	if err != nil {
 		session.Status = state.SessionStatusFailed

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -50,7 +50,9 @@ type Session struct {
 	MonitoringStoppedAt  string        `json:"monitoring_stopped_at,omitempty"`
 	CleanupCompletedAt   string        `json:"cleanup_completed_at,omitempty"`
 	CleanupError         string        `json:"cleanup_error,omitempty"`
+	ProcessID            int           `json:"process_id,omitempty"`
 	StartedAt            string        `json:"started_at,omitempty"`
+	LastHeartbeatAt      string        `json:"last_heartbeat_at,omitempty"`
 	EndedAt              string        `json:"ended_at,omitempty"`
 	UpdatedAt            string        `json:"updated_at,omitempty"`
 	LastError            string        `json:"last_error,omitempty"`


### PR DESCRIPTION
## Summary
- persist local process and heartbeat metadata for running issue sessions
- recover stalled running sessions into PR maintenance when a PR already exists, otherwise clean up and redispatch the issue
- add scheduler tests covering stale redispatch and stale PR-maintenance recovery

Closes #31

## Validation
- go test ./...
- go build ./...