### PR TITLE
Standardize Vigilante progress comments

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -448,7 +448,18 @@ func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Sessi
 			session.LastError = ""
 			session.UpdatedAt = a.clock().Format(time.RFC3339)
 			a.state.AppendDaemonLog("stalled session recovered to pr maintenance repo=%s issue=%d branch=%s reason=%q pr=%d", session.Repo, session.IssueNumber, session.Branch, reason, pr.Number)
-			body := fmt.Sprintf("Vigilante detected that the previous local session for branch `%s` was stalled (%s). An existing PR #%d was found, so the issue was recovered into PR maintenance.", session.Branch, reason, pr.Number)
+			body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Implementation In Progress",
+				Emoji:      "🔄",
+				Percent:    70,
+				ETAMinutes: 10,
+				Items: []string{
+					fmt.Sprintf("The previous local session on `%s` stalled (%s).", session.Branch, reason),
+					fmt.Sprintf("An existing PR #%d was found, so Vigilante recovered this issue into PR maintenance.", pr.Number),
+					"Next step: keep the PR merge-ready instead of redispatching a new implementation session.",
+				},
+				Tagline: "Fall seven times, stand up eight.",
+			})
 			if err := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); err != nil {
 				return nil, err
 			}
@@ -460,7 +471,18 @@ func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Sessi
 			session.UpdatedAt = a.clock().Format(time.RFC3339)
 			session.CleanupError = err.Error()
 			a.state.AppendDaemonLog("stalled session cleanup failed repo=%s issue=%d branch=%s reason=%q err=%v", session.Repo, session.IssueNumber, session.Branch, reason, err)
-			body := fmt.Sprintf("Vigilante detected a stalled local session on branch `%s` (%s), but automatic cleanup failed: %s", session.Branch, reason, summarizeMaintenanceError(err))
+			body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Blocked",
+				Emoji:      "🛠️",
+				Percent:    65,
+				ETAMinutes: 15,
+				Items: []string{
+					fmt.Sprintf("The local session on `%s` stalled (%s).", session.Branch, reason),
+					fmt.Sprintf("Automatic cleanup failed: `%s`.", summarizeMaintenanceError(err)),
+					"Next step: resolve the cleanup problem before redispatching the issue.",
+				},
+				Tagline: "The gem cannot be polished without friction.",
+			})
 			if commentErr := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); commentErr != nil {
 				return nil, commentErr
 			}
@@ -476,7 +498,18 @@ func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Sessi
 		session.UpdatedAt = now
 		session.LastError = fmt.Sprintf("stalled session recovered: %s", reason)
 		a.state.AppendDaemonLog("stalled session recovered for redispatch repo=%s issue=%d branch=%s reason=%q", session.Repo, session.IssueNumber, session.Branch, reason)
-		body := fmt.Sprintf("Vigilante detected that the previous local session on branch `%s` was stalled (%s). The abandoned worktree state was cleaned up so the issue can be redispatched.", session.Branch, reason)
+		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+			Stage:      "Implementation In Progress",
+			Emoji:      "🧹",
+			Percent:    15,
+			ETAMinutes: 20,
+			Items: []string{
+				fmt.Sprintf("The previous local session on `%s` stalled (%s).", session.Branch, reason),
+				"The abandoned worktree state was cleaned up successfully.",
+				"Next step: the issue is ready to be redispatched in a fresh worktree.",
+			},
+			Tagline: "A smooth sea never made a skilled sailor.",
+		})
 		if err := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); err != nil {
 			return nil, err
 		}
@@ -518,7 +551,18 @@ func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session
 				session.UpdatedAt = a.clock().Format(time.RFC3339)
 				a.state.AppendDaemonLog("pr maintenance failed repo=%s issue=%d pr=%d branch=%s err=%v", session.Repo, session.IssueNumber, pr.Number, session.Branch, err)
 				if shouldCommentMaintenanceFailure(*session, err) {
-					body := fmt.Sprintf("Vigilante could not keep PR #%d merge-ready on `%s`: %s", pr.Number, session.Branch, summarizeMaintenanceError(err))
+					body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+						Stage:      "Blocked",
+						Emoji:      "🧱",
+						Percent:    85,
+						ETAMinutes: 15,
+						Items: []string{
+							fmt.Sprintf("Vigilante could not keep PR #%d merge-ready on `%s`.", pr.Number, session.Branch),
+							fmt.Sprintf("Failure detail: `%s`.", summarizeMaintenanceError(err)),
+							"Next step: inspect the branch state, fix the maintenance failure, and rerun validation.",
+						},
+						Tagline: "Difficulties strengthen the mind, as labor does the body.",
+					})
 					if commentErr := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); commentErr != nil {
 						a.state.AppendDaemonLog("pr maintenance failure comment failed repo=%s issue=%d pr=%d err=%v", session.Repo, session.IssueNumber, pr.Number, commentErr)
 					}
@@ -574,7 +618,18 @@ func (a *App) maintainOpenPullRequest(ctx context.Context, session *state.Sessio
 		if !isRebaseConflict(rebaseOutput, err) {
 			return err
 		}
-		body := fmt.Sprintf("Vigilante hit rebase conflicts while updating PR #%d onto the latest `origin/main`. Launching the dedicated conflict-resolution skill in `%s`.", pr.Number, session.WorktreePath)
+		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+			Stage:      "Implementation In Progress",
+			Emoji:      "⚔️",
+			Percent:    75,
+			ETAMinutes: 12,
+			Items: []string{
+				fmt.Sprintf("Rebase conflicts appeared while updating PR #%d onto the latest `origin/main`.", pr.Number),
+				fmt.Sprintf("Worktree: `%s`.", session.WorktreePath),
+				"Next step: launch the dedicated conflict-resolution skill and continue from the rebased branch.",
+			},
+			Tagline: "Smooth roads never make skillful drivers.",
+		})
 		if commentErr := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); commentErr != nil {
 			a.state.AppendDaemonLog("pr conflict comment failed repo=%s issue=%d pr=%d err=%v", session.Repo, session.IssueNumber, pr.Number, commentErr)
 		}
@@ -598,7 +653,18 @@ func (a *App) maintainOpenPullRequest(ctx context.Context, session *state.Sessio
 		return err
 	}
 
-	body := fmt.Sprintf("Vigilante rebased PR #%d onto the latest `origin/main`, reran `go test ./...`, and pushed `%s`.", pr.Number, session.Branch)
+	body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Validation Passed",
+		Emoji:      "✅",
+		Percent:    90,
+		ETAMinutes: 5,
+		Items: []string{
+			fmt.Sprintf("Rebased PR #%d onto the latest `origin/main`.", pr.Number),
+			"Reran `go test ./...` after the rebase.",
+			fmt.Sprintf("Pushed the updated branch `%s`.", session.Branch),
+		},
+		Tagline: "Success is where preparation and opportunity meet.",
+	})
 	return ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body)
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	ghcli "github.com/nicobistolfi/vigilante/internal/github"
 	"github.com/nicobistolfi/vigilante/internal/skill"
 	"github.com/nicobistolfi/vigilante/internal/state"
 	"github.com/nicobistolfi/vigilante/internal/testutil"
@@ -214,9 +215,20 @@ func TestScanOnceSelectsEligibleIssueAndPersistsSession(t *testing.T) {
 			"gh api user --jq .login": "nicobistolfi\n",
 			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[{"name":"to-do"}]}]`,
 			"git worktree prune": "ok",
-			"git worktree add -b vigilante/issue-1 " + worktreePath + " main":                                                                                       "ok",
-			"gh issue comment --repo owner/repo 1 --body Vigilante started a Codex session for this issue in `" + worktreePath + "` on branch `vigilante/issue-1`.": "ok",
-			"codex exec --cd " + worktreePath + " --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: /tmp/repo\nIssue: #1 - first\nIssue URL: https://github.com/owner/repo/issues/1\nWorktree path: " + worktreePath + "\nBranch: vigilante/issue-1\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.": "done",
+			"git worktree add -b vigilante/issue-1 " + worktreePath + " main": "ok",
+			"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Session Start",
+				Emoji:      "🚦",
+				Percent:    20,
+				ETAMinutes: 25,
+				Items: []string{
+					"Vigilante launched this implementation session in `" + worktreePath + "`.",
+					"Branch: `vigilante/issue-1`.",
+					"Current stage: handing the issue off to Codex for investigation and implementation.",
+				},
+				Tagline: "Make it simple, but significant.",
+			}): "ok",
+			"codex exec --cd " + worktreePath + " --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: /tmp/repo\nIssue: #1 - first\nIssue URL: https://github.com/owner/repo/issues/1\nWorktree path: " + worktreePath + "\nBranch: vigilante/issue-1\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nUse the same GitHub comment structure for every non-terminal milestone comment: a short header with the current stage and optional emoji, a 10-cell progress bar with percentage, an `ETA: ~N minutes` line, 1-3 concise bullets covering what just happened and what is next, and an optional short playful quote or tagline.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.": "done",
 		},
 	}
 	if err := app.state.EnsureLayout(); err != nil {
@@ -307,12 +319,34 @@ func TestScanOnceSkipsRedispatchForMaintainedIssueAndStartsNextEligibleIssue(t *
 			"git rebase origin/main": "Successfully rebased and updated refs/heads/vigilante/issue-1.\n",
 			"go test ./...":          "ok",
 			"git push --force-with-lease origin HEAD:vigilante/issue-1": "ok",
-			"gh issue comment --repo owner/repo 1 --body Vigilante rebased PR #31 onto the latest `origin/main`, reran `go test ./...`, and pushed `vigilante/issue-1`.": "ok",
-			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels":                                              `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[{"name":"to-do"}]},{"number":2,"title":"second","createdAt":"2026-03-10T12:00:00Z","url":"https://github.com/owner/repo/issues/2","labels":[{"name":"to-do"}]}]`,
+			"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Validation Passed",
+				Emoji:      "✅",
+				Percent:    90,
+				ETAMinutes: 5,
+				Items: []string{
+					"Rebased PR #31 onto the latest `origin/main`.",
+					"Reran `go test ./...` after the rebase.",
+					"Pushed the updated branch `vigilante/issue-1`.",
+				},
+				Tagline: "Success is where preparation and opportunity meet.",
+			}): "ok",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[{"name":"to-do"}]},{"number":2,"title":"second","createdAt":"2026-03-10T12:00:00Z","url":"https://github.com/owner/repo/issues/2","labels":[{"name":"to-do"}]}]`,
 			"git worktree prune": "ok",
-			"git worktree add -b vigilante/issue-2 " + worktreePath2 + " main":                                                                                       "ok",
-			"gh issue comment --repo owner/repo 2 --body Vigilante started a Codex session for this issue in `" + worktreePath2 + "` on branch `vigilante/issue-2`.": "ok",
-			"codex exec --cd " + worktreePath2 + " --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: " + repoPath + "\nIssue: #2 - second\nIssue URL: https://github.com/owner/repo/issues/2\nWorktree path: " + worktreePath2 + "\nBranch: vigilante/issue-2\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.": "done",
+			"git worktree add -b vigilante/issue-2 " + worktreePath2 + " main": "ok",
+			"gh issue comment --repo owner/repo 2 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Session Start",
+				Emoji:      "🚦",
+				Percent:    20,
+				ETAMinutes: 25,
+				Items: []string{
+					"Vigilante launched this implementation session in `" + worktreePath2 + "`.",
+					"Branch: `vigilante/issue-2`.",
+					"Current stage: handing the issue off to Codex for investigation and implementation.",
+				},
+				Tagline: "Make it simple, but significant.",
+			}): "ok",
+			"codex exec --cd " + worktreePath2 + " --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: " + repoPath + "\nIssue: #2 - second\nIssue URL: https://github.com/owner/repo/issues/2\nWorktree path: " + worktreePath2 + "\nBranch: vigilante/issue-2\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nUse the same GitHub comment structure for every non-terminal milestone comment: a short header with the current stage and optional emoji, a 10-cell progress bar with percentage, an `ETA: ~N minutes` line, 1-3 concise bullets covering what just happened and what is next, and an optional short playful quote or tagline.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.": "done",
 		},
 	}
 	if err := app.state.EnsureLayout(); err != nil {
@@ -444,7 +478,18 @@ func TestScanOnceMaintainsOpenPullRequest(t *testing.T) {
 			"git rebase origin/main": "Successfully rebased and updated refs/heads/vigilante/issue-1.\n",
 			"go test ./...":          "ok",
 			"git push --force-with-lease origin HEAD:vigilante/issue-1": "ok",
-			"gh issue comment --repo owner/repo 1 --body Vigilante rebased PR #31 onto the latest `origin/main`, reran `go test ./...`, and pushed `vigilante/issue-1`.": "ok",
+			"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Validation Passed",
+				Emoji:      "✅",
+				Percent:    90,
+				ETAMinutes: 5,
+				Items: []string{
+					"Rebased PR #31 onto the latest `origin/main`.",
+					"Reran `go test ./...` after the rebase.",
+					"Pushed the updated branch `vigilante/issue-1`.",
+				},
+				Tagline: "Success is where preparation and opportunity meet.",
+			}): "ok",
 			"gh api user --jq .login": "nicobistolfi\n",
 			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
 		},
@@ -601,13 +646,35 @@ func TestScanOnceRecoversStalledSessionAndRedispatchesIssue(t *testing.T) {
 			"git worktree list --porcelain":                              "worktree /tmp/repo\nHEAD abcdef\nbranch refs/heads/main\n",
 			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": "ok",
 			"git branch -D vigilante/issue-1":                            "Deleted branch vigilante/issue-1\n",
-			"gh issue comment --repo owner/repo 1 --body Vigilante detected that the previous local session on branch `vigilante/issue-1` was stalled (worktree path is missing). The abandoned worktree state was cleaned up so the issue can be redispatched.": "ok",
+			"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Implementation In Progress",
+				Emoji:      "🧹",
+				Percent:    15,
+				ETAMinutes: 20,
+				Items: []string{
+					"The previous local session on `vigilante/issue-1` stalled (worktree path is missing).",
+					"The abandoned worktree state was cleaned up successfully.",
+					"Next step: the issue is ready to be redispatched in a fresh worktree.",
+				},
+				Tagline: "A smooth sea never made a skilled sailor.",
+			}): "ok",
 			"gh api user --jq .login": "nicobistolfi\n",
-			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels":                                         `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]}]`,
-			"git worktree add -b vigilante/issue-1 " + worktreePath + " main":                                                                                       "ok",
-			"git worktree add " + worktreePath + " vigilante/issue-1":                                                                                               "ok",
-			"gh issue comment --repo owner/repo 1 --body Vigilante started a Codex session for this issue in `" + worktreePath + "` on branch `vigilante/issue-1`.": "ok",
-			"codex exec --cd " + worktreePath + " --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: " + filepath.Join(home, "repo") + "\nIssue: #1 - first\nIssue URL: https://github.com/owner/repo/issues/1\nWorktree path: " + worktreePath + "\nBranch: vigilante/issue-1\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.": "done",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]}]`,
+			"git worktree add -b vigilante/issue-1 " + worktreePath + " main":                                               "ok",
+			"git worktree add " + worktreePath + " vigilante/issue-1":                                                       "ok",
+			"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Session Start",
+				Emoji:      "🚦",
+				Percent:    20,
+				ETAMinutes: 25,
+				Items: []string{
+					"Vigilante launched this implementation session in `" + worktreePath + "`.",
+					"Branch: `vigilante/issue-1`.",
+					"Current stage: handing the issue off to Codex for investigation and implementation.",
+				},
+				Tagline: "Make it simple, but significant.",
+			}): "ok",
+			"codex exec --cd " + worktreePath + " --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: " + filepath.Join(home, "repo") + "\nIssue: #1 - first\nIssue URL: https://github.com/owner/repo/issues/1\nWorktree path: " + worktreePath + "\nBranch: vigilante/issue-1\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nUse the same GitHub comment structure for every non-terminal milestone comment: a short header with the current stage and optional emoji, a 10-cell progress bar with percentage, an `ETA: ~N minutes` line, 1-3 concise bullets covering what just happened and what is next, and an optional short playful quote or tagline.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.": "done",
 		},
 	}
 	if err := app.state.EnsureLayout(); err != nil {
@@ -668,8 +735,19 @@ func TestScanOnceRecoversStalledSessionIntoPRMaintenance(t *testing.T) {
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: map[string]string{
-			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt":                                                                                                                                                  `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
-			"gh issue comment --repo owner/repo 1 --body Vigilante detected that the previous local session for branch `vigilante/issue-1` was stalled (worktree path is missing). An existing PR #31 was found, so the issue was recovered into PR maintenance.": "ok",
+			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
+			"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Implementation In Progress",
+				Emoji:      "🔄",
+				Percent:    70,
+				ETAMinutes: 10,
+				Items: []string{
+					"The previous local session on `vigilante/issue-1` stalled (worktree path is missing).",
+					"An existing PR #31 was found, so Vigilante recovered this issue into PR maintenance.",
+					"Next step: keep the PR merge-ready instead of redispatching a new implementation session.",
+				},
+				Tagline: "Fall seven times, stand up eight.",
+			}): "ok",
 			"git fetch origin main":   "ok",
 			"git status --porcelain":  "",
 			"git rebase origin/main":  "Current branch vigilante/issue-1 is up to date.\n",

--- a/internal/github/comment_format.go
+++ b/internal/github/comment_format.go
@@ -1,0 +1,63 @@
+package ghcli
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ProgressComment struct {
+	Stage      string
+	Emoji      string
+	Percent    int
+	ETAMinutes int
+	Items      []string
+	Tagline    string
+}
+
+func FormatProgressComment(comment ProgressComment) string {
+	header := strings.TrimSpace(comment.Stage)
+	if emoji := strings.TrimSpace(comment.Emoji); emoji != "" {
+		header = strings.TrimSpace(fmt.Sprintf("%s %s", emoji, header))
+	}
+
+	lines := []string{
+		fmt.Sprintf("## %s", header),
+		fmt.Sprintf("`%s %d%%`", progressBar(comment.Percent), clampPercent(comment.Percent)),
+		fmt.Sprintf("`ETA: ~%s`", formatMinutes(comment.ETAMinutes)),
+	}
+	for _, item := range comment.Items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("- %s", item))
+	}
+	if tagline := strings.TrimSpace(comment.Tagline); tagline != "" {
+		lines = append(lines, fmt.Sprintf("> %q", tagline))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func progressBar(percent int) string {
+	percent = clampPercent(percent)
+	filled := percent / 10
+	return strings.Repeat("█", filled) + strings.Repeat("░", 10-filled)
+}
+
+func clampPercent(percent int) int {
+	switch {
+	case percent < 0:
+		return 0
+	case percent > 100:
+		return 100
+	default:
+		return percent
+	}
+}
+
+func formatMinutes(minutes int) string {
+	if minutes <= 1 {
+		return "1 minute"
+	}
+	return fmt.Sprintf("%d minutes", minutes)
+}

--- a/internal/github/comment_format_test.go
+++ b/internal/github/comment_format_test.go
@@ -1,0 +1,22 @@
+package ghcli
+
+import "testing"
+
+func TestFormatProgressComment(t *testing.T) {
+	comment := FormatProgressComment(ProgressComment{
+		Stage:      "Validation Passed",
+		Emoji:      "✅",
+		Percent:    90,
+		ETAMinutes: 5,
+		Items: []string{
+			"Ran `go test ./...`.",
+			"Pushed `vigilante/issue-12`.",
+		},
+		Tagline: "Success is where preparation and opportunity meet.",
+	})
+
+	expected := "## ✅ Validation Passed\n`█████████░ 90%`\n`ETA: ~5 minutes`\n- Ran `go test ./...`.\n- Pushed `vigilante/issue-12`.\n> \"Success is where preparation and opportunity meet.\""
+	if comment != expected {
+		t.Fatalf("unexpected comment:\n%s", comment)
+	}
+}

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -19,7 +19,18 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 	session.ProcessID = os.Getpid()
 	session.LastHeartbeatAt = time.Now().UTC().Format(time.RFC3339)
 	session.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
-	startBody := fmt.Sprintf("Vigilante started a Codex session for this issue in `%s` on branch `%s`.", session.WorktreePath, session.Branch)
+	startBody := ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Session Start",
+		Emoji:      "🚦",
+		Percent:    20,
+		ETAMinutes: 25,
+		Items: []string{
+			fmt.Sprintf("Vigilante launched this implementation session in `%s`.", session.WorktreePath),
+			fmt.Sprintf("Branch: `%s`.", session.Branch),
+			"Current stage: handing the issue off to Codex for investigation and implementation.",
+		},
+		Tagline: "Make it simple, but significant.",
+	})
 	appendSessionLog(logPath, "session started", session, "")
 	if err := ghcli.CommentOnIssue(ctx, env.Runner, target.Repo, issue.Number, startBody); err != nil {
 		session.Status = state.SessionStatusFailed
@@ -47,7 +58,18 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 		session.Status = state.SessionStatusFailed
 		session.LastError = err.Error()
 		appendSessionLog(logPath, "session failed", session, combineLogDetails(output, err.Error()))
-		body := fmt.Sprintf("Vigilante Codex session failed for this issue: %s", summarizeError(err))
+		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+			Stage:      "Blocked",
+			Emoji:      "🛑",
+			Percent:    95,
+			ETAMinutes: 10,
+			Items: []string{
+				"Codex execution stopped before the issue implementation completed.",
+				fmt.Sprintf("Failure detail: `%s`.", summarizeError(err)),
+				"Next step: inspect the failing command or environment and redispatch once the blocker is resolved.",
+			},
+			Tagline: "Plans are only good intentions unless they immediately degenerate into hard work.",
+		})
 		_ = ghcli.CommentOnIssue(ctx, env.Runner, target.Repo, issue.Number, body)
 		return session
 	}
@@ -73,7 +95,18 @@ func RunConflictResolutionSession(ctx context.Context, env *environment.Environm
 	)
 	if err != nil {
 		appendSessionLog(logPath, "conflict resolution failed", session, combineLogDetails(output, err.Error()))
-		body := fmt.Sprintf("Vigilante conflict-resolution session failed for PR #%d on branch `%s`: %s", pr.Number, session.Branch, summarizeError(err))
+		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+			Stage:      "Blocked",
+			Emoji:      "🧯",
+			Percent:    90,
+			ETAMinutes: 12,
+			Items: []string{
+				fmt.Sprintf("Conflict resolution for PR #%d on `%s` did not complete.", pr.Number, session.Branch),
+				fmt.Sprintf("Failure detail: `%s`.", summarizeError(err)),
+				"Next step: review the rebase state in the worktree and rerun the dedicated conflict-resolution flow.",
+			},
+			Tagline: "An obstacle is often a stepping stone.",
+		})
 		_ = ghcli.CommentOnIssue(ctx, env.Runner, target.Repo, session.IssueNumber, body)
 		return err
 	}

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -20,8 +20,19 @@ func TestRunIssueSessionSuccess(t *testing.T) {
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{
-			"gh issue comment --repo owner/repo 7 --body Vigilante started a Codex session for this issue in `/tmp/worktree` on branch `vigilante/issue-7`.": "ok",
-			"codex exec --cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: /tmp/repo\nIssue: #7 - Demo\nIssue URL: https://github.com/owner/repo/issues/7\nWorktree path: /tmp/worktree\nBranch: vigilante/issue-7\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.": "done",
+			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Session Start",
+				Emoji:      "🚦",
+				Percent:    20,
+				ETAMinutes: 25,
+				Items: []string{
+					"Vigilante launched this implementation session in `/tmp/worktree`.",
+					"Branch: `vigilante/issue-7`.",
+					"Current stage: handing the issue off to Codex for investigation and implementation.",
+				},
+				Tagline: "Make it simple, but significant.",
+			}): "ok",
+			"codex exec --cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: /tmp/repo\nIssue: #7 - Demo\nIssue URL: https://github.com/owner/repo/issues/7\nWorktree path: /tmp/worktree\nBranch: vigilante/issue-7\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nUse the same GitHub comment structure for every non-terminal milestone comment: a short header with the current stage and optional emoji, a 10-cell progress bar with percentage, an `ETA: ~N minutes` line, 1-3 concise bullets covering what just happened and what is next, and an optional short playful quote or tagline.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.": "done",
 		},
 	}
 	env := &environment.Environment{OS: "darwin", Runner: runner}
@@ -48,11 +59,33 @@ func TestRunIssueSessionFailureCommentsOnIssue(t *testing.T) {
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{
-			"gh issue comment --repo owner/repo 7 --body Vigilante started a Codex session for this issue in `/tmp/worktree` on branch `vigilante/issue-7`.":                                              "ok",
-			"gh issue comment --repo owner/repo 7 --body Vigilante Codex session failed for this issue: codex exec [--cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox prompt]: exit status 1": "ok",
+			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Session Start",
+				Emoji:      "🚦",
+				Percent:    20,
+				ETAMinutes: 25,
+				Items: []string{
+					"Vigilante launched this implementation session in `/tmp/worktree`.",
+					"Branch: `vigilante/issue-7`.",
+					"Current stage: handing the issue off to Codex for investigation and implementation.",
+				},
+				Tagline: "Make it simple, but significant.",
+			}): "ok",
+			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Blocked",
+				Emoji:      "🛑",
+				Percent:    95,
+				ETAMinutes: 10,
+				Items: []string{
+					"Codex execution stopped before the issue implementation completed.",
+					"Failure detail: `codex exec [--cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox prompt]: exit status 1`.",
+					"Next step: inspect the failing command or environment and redispatch once the blocker is resolved.",
+				},
+				Tagline: "Plans are only good intentions unless they immediately degenerate into hard work.",
+			}): "ok",
 		},
 		Errors: map[string]error{
-			"codex exec --cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: /tmp/repo\nIssue: #7 - Demo\nIssue URL: https://github.com/owner/repo/issues/7\nWorktree path: /tmp/worktree\nBranch: vigilante/issue-7\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.": errors.New("codex exec [--cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox prompt]: exit status 1"),
+			"codex exec --cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: /tmp/repo\nIssue: #7 - Demo\nIssue URL: https://github.com/owner/repo/issues/7\nWorktree path: /tmp/worktree\nBranch: vigilante/issue-7\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nUse the same GitHub comment structure for every non-terminal milestone comment: a short header with the current stage and optional emoji, a 10-cell progress bar with percentage, an `ETA: ~N minutes` line, 1-3 concise bullets covering what just happened and what is next, and an optional short playful quote or tagline.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.": errors.New("codex exec [--cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox prompt]: exit status 1"),
 		},
 	}
 	env := &environment.Environment{OS: "darwin", Runner: runner}
@@ -82,7 +115,18 @@ func TestRunConflictResolutionSessionFailureCommentsOnIssue(t *testing.T) {
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{
-			"gh issue comment --repo owner/repo 7 --body Vigilante conflict-resolution session failed for PR #17 on branch `vigilante/issue-7`: codex exec [--cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox prompt]: exit status 1": "ok",
+			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Blocked",
+				Emoji:      "🧯",
+				Percent:    90,
+				ETAMinutes: 12,
+				Items: []string{
+					"Conflict resolution for PR #17 on `vigilante/issue-7` did not complete.",
+					"Failure detail: `codex exec [--cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox prompt]: exit status 1`.",
+					"Next step: review the rebase state in the worktree and rerun the dedicated conflict-resolution flow.",
+				},
+				Tagline: "An obstacle is often a stepping stone.",
+			}): "ok",
 		},
 		Errors: map[string]error{
 			"codex exec --cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox Use the `vigilante-conflict-resolution` skill for this task.\nRepository: owner/repo\nLocal repository path: /tmp/repo\nIssue: #7 - Demo\nIssue URL: https://github.com/owner/repo/issues/7\nPull Request: #17\nPull Request URL: https://github.com/owner/repo/pull/17\nWorktree path: /tmp/worktree\nBranch: vigilante/issue-7\nBase branch: origin/main\nResolve the current rebase conflicts in the assigned worktree, use `gh issue comment` for progress and failures, rerun `go test ./...` after conflict resolution if the rebase succeeds, and push the updated branch when finished.\nKeep the changes minimal and focused on getting the PR back to a merge-ready state.": errors.New("codex exec [--cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox prompt]: exit status 1"),

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -43,6 +43,7 @@ func BuildIssuePrompt(target state.WatchTarget, issue ghcli.Issue, session state
 		fmt.Sprintf("Worktree path: %s", session.WorktreePath),
 		fmt.Sprintf("Branch: %s", session.Branch),
 		"Use `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.",
+		"Use the same GitHub comment structure for every non-terminal milestone comment: a short header with the current stage and optional emoji, a 10-cell progress bar with percentage, an `ETA: ~N minutes` line, 1-3 concise bullets covering what just happened and what is next, and an optional short playful quote or tagline.",
 		"Use the issue as the source of truth for the requested behavior and keep the implementation minimal.",
 	}
 	return strings.Join(lines, "\n")

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -133,7 +133,7 @@ func TestBuildIssuePrompt(t *testing.T) {
 	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
 	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12"}
 	prompt := BuildIssuePrompt(target, issue, session)
-	for _, text := range []string{"Use the `vigilante-issue-implementation` skill", "Issue: #12 - Fix bug", "Worktree path: /tmp/worktree", "gh issue comment", "implementation plan", "open a pull request"} {
+	for _, text := range []string{"Use the `vigilante-issue-implementation` skill", "Issue: #12 - Fix bug", "Worktree path: /tmp/worktree", "gh issue comment", "implementation plan", "open a pull request", "10-cell progress bar", "ETA: ~N minutes"} {
 		if !strings.Contains(prompt, text) {
 			t.Fatalf("prompt missing %q: %s", text, prompt)
 		}


### PR DESCRIPTION
## Summary
- add a shared deterministic formatter for Vigilante GitHub issue progress comments
- use the formatter for session start, blocker, stalled-session recovery, PR maintenance, conflict, and validation updates
- update the Codex issue prompt and tests so milestone comments follow the same structure

## Testing
- go test ./...

Closes #17