### PR TITLE
Adopt GoReleaser for multi-architecture tagged releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Set up GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          install-only: true
+
       - name: Check formatting
         run: |
           unformatted="$(gofmt -l .)"
@@ -40,3 +45,6 @@ jobs:
 
       - name: Verify build
         run: go build ./...
+
+      - name: Validate GoReleaser config
+        run: goreleaser check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Set up GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          install-only: true
+
       - name: Verify tag policy
         env:
           TAG_NAME: ${{ github.ref_name }}
@@ -39,25 +44,10 @@ jobs:
             exit 1
           fi
 
-      - name: Build release archives
+      - name: Validate GoReleaser config
+        run: goreleaser check
+
+      - name: Build and publish GitHub release
         env:
-          TAG_NAME: ${{ github.ref_name }}
-        run: |
-          mkdir -p dist
-
-          for target in darwin/arm64 darwin/amd64 linux/amd64; do
-            GOOS="${target%/*}"
-            GOARCH="${target#*/}"
-            PACKAGE_DIR="dist/vigilante_${TAG_NAME}_${GOOS}_${GOARCH}"
-
-            mkdir -p "$PACKAGE_DIR"
-            GOOS="$GOOS" GOARCH="$GOARCH" go build -o "$PACKAGE_DIR/vigilante" ./cmd/vigilante
-            tar -C dist -czf "${PACKAGE_DIR}.tar.gz" "$(basename "$PACKAGE_DIR")"
-            rm -rf "$PACKAGE_DIR"
-          done
-
-      - name: Publish GitHub release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG_NAME: ${{ github.ref_name }}
-        run: gh release create "$TAG_NAME" dist/*.tar.gz --generate-notes --title "$TAG_NAME"
+          GITHUB_TOKEN: ${{ github.token }}
+        run: goreleaser release --clean

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,39 @@
+version: 2
+
+project_name: vigilante
+
+builds:
+  - id: vigilante
+    main: ./cmd/vigilante
+    binary: vigilante
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: linux
+        goarch: arm64
+
+archives:
+  - id: release-archives
+    ids:
+      - vigilante
+    formats:
+      - tar.gz
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_{{- if eq .Os "darwin" }}macOS{{ else }}Linux{{ end }}_{{ .Arch }}
+
+checksum:
+  name_template: checksums.txt
+
+release:
+  github:
+    owner: nicobistolfi
+    name: vigilante
+
+changelog:
+  use: github-native

--- a/README.md
+++ b/README.md
@@ -169,8 +169,14 @@ Pull requests are validated in GitHub Actions with native Go commands:
 - `go vet ./...`
 - `go test ./...`
 - `go build ./...`
+- `goreleaser check`
 
-Releases are created by pushing a version tag that matches `{x}.{y}.{z}` and points to a commit already reachable from `main`.
+Tagged releases are built and published with GoReleaser. Pushing a version tag that matches `{x}.{y}.{z}` and points to a commit already reachable from `main` creates a GitHub Release with:
+
+- `darwin/amd64`
+- `darwin/arm64`
+- `linux/amd64`
+- a `checksums.txt` file for the published archives
 
 Recommended release flow:
 
@@ -181,7 +187,7 @@ git tag 1.2.3
 git push origin 1.2.3
 ```
 
-Tags outside the version format, such as `v1.2.3` or `release-1.2.3`, do not trigger the release workflow.
+Tags outside the version format, such as `v1.2.3` or `release-1.2.3`, do not trigger the release workflow. The release workflow validates both the tag format and that the tagged commit is already merged into `main` before GoReleaser publishes artifacts to GitHub Releases.
 
 ## Local State
 


### PR DESCRIPTION
## Summary
- replace the hand-rolled tagged release packaging job with GoReleaser
- add a repository `.goreleaser.yml` for macOS amd64/arm64 and Linux amd64 archives plus checksums
- validate the GoReleaser config in CI and document the tagged release flow in `README.md`

Closes #36

## Validation
- `go test ./...`
- `go build ./...`
- `go run github.com/goreleaser/goreleaser/v2@v2.12.7 check`