### PR TITLE
Add blocked-session recovery and resume flow

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -113,12 +113,41 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 		}
 		return a.Unwatch(args[1])
 	case "list":
-		return a.List()
+		fs := flag.NewFlagSet("list", flag.ContinueOnError)
+		fs.SetOutput(a.stderr)
+		blockedOnly := fs.Bool("blocked", false, "show blocked sessions instead of watch targets")
+		if err := fs.Parse(args[1:]); err != nil {
+			return err
+		}
+		return a.List(*blockedOnly)
+	case "resume":
+		return a.runResumeCommand(ctx, args[1:])
 	case "daemon":
 		return a.runDaemonCommand(ctx, args[1:])
 	default:
 		return fmt.Errorf("unknown command %q", args[0])
 	}
+}
+
+func (a *App) runResumeCommand(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("resume", flag.ContinueOnError)
+	fs.SetOutput(a.stderr)
+	repo := fs.String("repo", "", "repository slug")
+	issue := fs.Int("issue", 0, "issue number")
+	allBlocked := fs.Bool("all-blocked", false, "resume all blocked sessions")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *allBlocked {
+		if *repo != "" || *issue != 0 {
+			return errors.New("usage: vigilante resume --all-blocked")
+		}
+		return a.ResumeAllBlocked(ctx)
+	}
+	if *repo == "" || *issue <= 0 {
+		return errors.New("usage: vigilante resume --repo <owner/name> --issue <n>")
+	}
+	return a.ResumeSession(ctx, *repo, *issue, "cli")
 }
 
 func (a *App) runDaemonCommand(ctx context.Context, args []string) error {
@@ -269,9 +298,12 @@ func (a *App) Unwatch(rawPath string) error {
 	return nil
 }
 
-func (a *App) List() error {
+func (a *App) List(blockedOnly bool) error {
 	if err := a.state.EnsureLayout(); err != nil {
 		return err
+	}
+	if blockedOnly {
+		return a.listBlockedSessions()
 	}
 	targets, err := a.state.LoadWatchTargets()
 	if err != nil {
@@ -329,6 +361,10 @@ func (a *App) ScanOnce(ctx context.Context) error {
 			return err
 		}
 		sessions, err = a.recoverStalledSessions(ctx, sessions)
+		if err != nil {
+			return err
+		}
+		sessions, err = a.processGitHubResumeRequests(ctx, sessions)
 		if err != nil {
 			return err
 		}
@@ -551,6 +587,8 @@ func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session
 				session.UpdatedAt = a.clock().Format(time.RFC3339)
 				a.state.AppendDaemonLog("pr maintenance failed repo=%s issue=%d pr=%d branch=%s err=%v", session.Repo, session.IssueNumber, pr.Number, session.Branch, err)
 				if shouldCommentMaintenanceFailure(*session, err) {
+					blocked := classifyBlockedReason("pr_maintenance", "git fetch origin main", err)
+					markSessionBlocked(session, "pr_maintenance", blocked, a.clock())
 					body := ghcli.FormatProgressComment(ghcli.ProgressComment{
 						Stage:      "Blocked",
 						Emoji:      "🧱",
@@ -558,8 +596,8 @@ func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session
 						ETAMinutes: 15,
 						Items: []string{
 							fmt.Sprintf("Vigilante could not keep PR #%d merge-ready on `%s`.", pr.Number, session.Branch),
-							fmt.Sprintf("Failure detail: `%s`.", summarizeMaintenanceError(err)),
-							"Next step: inspect the branch state, fix the maintenance failure, and rerun validation.",
+							fmt.Sprintf("Cause class: `%s`.", blocked.Kind),
+							fmt.Sprintf("Next step: fix the blocker, then run `%s` or request resume from GitHub.", session.ResumeHint),
 						},
 						Tagline: "Difficulties strengthen the mind, as labor does the body.",
 					})
@@ -668,6 +706,293 @@ func (a *App) maintainOpenPullRequest(ctx context.Context, session *state.Sessio
 	return ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body)
 }
 
+func (a *App) listBlockedSessions() error {
+	sessions, err := a.state.LoadSessions()
+	if err != nil {
+		return err
+	}
+	count := 0
+	for _, session := range sessions {
+		if session.Status != state.SessionStatusBlocked {
+			continue
+		}
+		count++
+		fmt.Fprintf(a.stdout, "%s issue #%d  %s\n", session.Repo, session.IssueNumber, blockedStateLabel(session))
+		fmt.Fprintf(a.stdout, "  cause: %s\n", fallbackText(session.BlockedReason.Kind, "unknown_operator_action_required"))
+		if session.BlockedReason.Operation != "" {
+			fmt.Fprintf(a.stdout, "  failed op: %s\n", session.BlockedReason.Operation)
+		}
+		if session.BlockedAt != "" {
+			fmt.Fprintf(a.stdout, "  blocked at: %s\n", session.BlockedAt)
+		}
+		if session.ResumeHint != "" {
+			fmt.Fprintf(a.stdout, "  resume: %s\n", session.ResumeHint)
+		}
+		fmt.Fprintln(a.stdout, `  github resume: comment "@vigilanteai resume" or add label "resume"`)
+	}
+	if count == 0 {
+		fmt.Fprintln(a.stdout, "no blocked sessions")
+	}
+	return nil
+}
+
+func (a *App) processGitHubResumeRequests(ctx context.Context, sessions []state.Session) ([]state.Session, error) {
+	for i := range sessions {
+		session := &sessions[i]
+		if session.Status != state.SessionStatusBlocked {
+			continue
+		}
+
+		details, err := ghcli.GetIssueDetails(ctx, a.env.Runner, session.Repo, session.IssueNumber)
+		if err != nil {
+			return nil, err
+		}
+		if ghcli.HasAnyLabel(details.Labels, "resume", "vigilante:resume") {
+			for _, label := range []string{"resume", "vigilante:resume"} {
+				if ghcli.HasAnyLabel(details.Labels, label) {
+					if err := ghcli.RemoveIssueLabel(ctx, a.env.Runner, session.Repo, session.IssueNumber, label); err != nil {
+						return nil, err
+					}
+				}
+			}
+			if err := a.resumeBlockedSession(ctx, session, "label"); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		comments, err := ghcli.ListIssueComments(ctx, a.env.Runner, session.Repo, session.IssueNumber)
+		if err != nil {
+			return nil, err
+		}
+		comment := ghcli.FindResumeComment(comments, session.LastResumeCommentID)
+		if comment == nil {
+			continue
+		}
+		if err := ghcli.AddIssueCommentReaction(ctx, a.env.Runner, session.Repo, comment.ID, "salute"); err != nil {
+			return nil, err
+		}
+		session.LastResumeCommentID = comment.ID
+		session.LastResumeCommentAt = comment.CreatedAt.UTC().Format(time.RFC3339)
+		session.LastResumeSource = "comment"
+		if err := a.resumeBlockedSession(ctx, session, "comment"); err != nil {
+			return nil, err
+		}
+	}
+	return sessions, nil
+}
+
+func (a *App) ResumeAllBlocked(ctx context.Context) error {
+	if err := a.state.EnsureLayout(); err != nil {
+		return err
+	}
+	sessions, err := a.state.LoadSessions()
+	if err != nil {
+		return err
+	}
+	resumed := 0
+	for i := range sessions {
+		if sessions[i].Status != state.SessionStatusBlocked {
+			continue
+		}
+		if err := a.resumeBlockedSession(ctx, &sessions[i], "cli"); err != nil {
+			return err
+		}
+		resumed++
+	}
+	if err := a.state.SaveSessions(sessions); err != nil {
+		return err
+	}
+	fmt.Fprintf(a.stdout, "resumed %d blocked session(s)\n", resumed)
+	return nil
+}
+
+func (a *App) ResumeSession(ctx context.Context, repo string, issue int, source string) error {
+	if err := a.state.EnsureLayout(); err != nil {
+		return err
+	}
+	sessions, err := a.state.LoadSessions()
+	if err != nil {
+		return err
+	}
+	found := false
+	for i := range sessions {
+		if sessions[i].Repo != repo || sessions[i].IssueNumber != issue {
+			continue
+		}
+		found = true
+		if sessions[i].Status != state.SessionStatusBlocked {
+			return fmt.Errorf("issue #%d in %s is not blocked", issue, repo)
+		}
+		if err := a.resumeBlockedSession(ctx, &sessions[i], source); err != nil {
+			return err
+		}
+		break
+	}
+	if !found {
+		return fmt.Errorf("blocked session not found for %s issue #%d", repo, issue)
+	}
+	if err := a.state.SaveSessions(sessions); err != nil {
+		return err
+	}
+	fmt.Fprintf(a.stdout, "resume attempted for %s issue #%d\n", repo, issue)
+	return nil
+}
+
+func (a *App) resumeBlockedSession(ctx context.Context, session *state.Session, source string) error {
+	if session.Status != state.SessionStatusBlocked {
+		return nil
+	}
+	session.Status = state.SessionStatusResuming
+	session.LastResumeSource = source
+	session.UpdatedAt = a.clock().Format(time.RFC3339)
+
+	if err := a.preflightResume(ctx, *session); err != nil {
+		blocked := classifyBlockedReason(session.BlockedStage, session.BlockedReason.Operation, err)
+		markSessionBlocked(session, fallbackText(session.BlockedStage, "pr_maintenance"), blocked, a.clock())
+		session.LastError = err.Error()
+		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+			Stage:      "Blocked",
+			Emoji:      "🧱",
+			Percent:    88,
+			ETAMinutes: 10,
+			Items: []string{
+				fmt.Sprintf("Resume preflight did not pass for `%s`.", session.Branch),
+				fmt.Sprintf("Cause class: `%s`.", blocked.Kind),
+				fmt.Sprintf("Next step: fix the blocker, then run `%s` or request resume from GitHub again.", session.ResumeHint),
+			},
+			Tagline: "Clear eyes, full hearts, can’t lose.",
+		})
+		return ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body)
+	}
+
+	var err error
+	switch session.BlockedStage {
+	case "pr_maintenance":
+		err = a.resumeBlockedMaintenance(ctx, session)
+	case "conflict_resolution":
+		err = a.resumeBlockedConflictResolution(ctx, session)
+	default:
+		err = a.resumeBlockedIssueExecution(ctx, session)
+	}
+	if err != nil {
+		blocked := classifyBlockedReason(session.BlockedStage, session.BlockedReason.Operation, err)
+		markSessionBlocked(session, fallbackText(session.BlockedStage, "pr_maintenance"), blocked, a.clock())
+		session.LastError = err.Error()
+		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+			Stage:      "Blocked",
+			Emoji:      "🧱",
+			Percent:    90,
+			ETAMinutes: 12,
+			Items: []string{
+				fmt.Sprintf("Resume did not complete for `%s`.", session.Branch),
+				fmt.Sprintf("Cause class: `%s`.", blocked.Kind),
+				fmt.Sprintf("Next step: fix the blocker, then run `%s` or request resume from GitHub again.", session.ResumeHint),
+			},
+			Tagline: "The comeback is always stronger than the setback.",
+		})
+		return ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body)
+	}
+
+	previousKind := session.BlockedReason.Kind
+	previousStage := session.BlockedStage
+	clearBlockedState(session, a.clock(), source)
+	body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Recovered",
+		Emoji:      "🫡",
+		Percent:    92,
+		ETAMinutes: 5,
+		Items: []string{
+			fmt.Sprintf("The previous `%s` block was cleared for `%s`.", fallbackText(previousKind, "unknown_operator_action_required"), session.Branch),
+			fmt.Sprintf("Resume source: `%s`.", source),
+			fmt.Sprintf("Next step: Vigilante resumed `%s` successfully.", fallbackText(previousStage, "issue_execution")),
+		},
+		Tagline: "Back on the wire.",
+	})
+	return ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body)
+}
+
+func (a *App) preflightResume(ctx context.Context, session state.Session) error {
+	switch session.BlockedReason.Kind {
+	case "git_auth":
+		_, err := a.env.Runner.Run(ctx, session.WorktreePath, "git", "fetch", "origin", "main")
+		return err
+	case "gh_auth":
+		if _, err := a.env.Runner.Run(ctx, "", "gh", "auth", "status"); err != nil {
+			return err
+		}
+		_, err := ghcli.GetIssueDetails(ctx, a.env.Runner, session.Repo, session.IssueNumber)
+		return err
+	case "provider_missing":
+		_, err := a.env.Runner.LookPath("codex")
+		return err
+	case "provider_auth", "provider_runtime_error":
+		if _, err := a.env.Runner.LookPath("codex"); err != nil {
+			return err
+		}
+		_, err := a.env.Runner.Run(ctx, "", "codex", "--version")
+		return err
+	default:
+		return nil
+	}
+}
+
+func (a *App) resumeBlockedMaintenance(ctx context.Context, session *state.Session) error {
+	pr, err := ghcli.FindPullRequestForBranch(ctx, a.env.Runner, session.Repo, session.Branch)
+	if err != nil {
+		return err
+	}
+	if pr == nil {
+		return errors.New("no pull request found for blocked maintenance session")
+	}
+	session.PullRequestNumber = pr.Number
+	session.PullRequestURL = pr.URL
+	session.PullRequestState = pr.State
+	if pr.State != "OPEN" {
+		return fmt.Errorf("pull request #%d is not open", pr.Number)
+	}
+	if err := a.maintainOpenPullRequest(ctx, session, *pr); err != nil {
+		return err
+	}
+	session.Status = state.SessionStatusSuccess
+	session.LastMaintenanceError = ""
+	return nil
+}
+
+func (a *App) resumeBlockedIssueExecution(ctx context.Context, session *state.Session) error {
+	issue := ghcli.Issue{Number: session.IssueNumber, Title: session.IssueTitle, URL: session.IssueURL}
+	target := state.WatchTarget{Path: session.RepoPath, Repo: session.Repo, Branch: "main"}
+	prompt := skill.BuildIssuePrompt(target, issue, *session)
+	output, err := a.env.Runner.Run(ctx, "", "codex", "exec", "--cd", session.WorktreePath, "--dangerously-bypass-approvals-and-sandbox", prompt)
+	session.EndedAt = a.clock().Format(time.RFC3339)
+	session.LastHeartbeatAt = session.EndedAt
+	session.UpdatedAt = session.EndedAt
+	if err != nil {
+		a.state.AppendDaemonLog("resume issue execution failed repo=%s issue=%d err=%v output=%s", session.Repo, session.IssueNumber, err, summarizeText(output))
+		return err
+	}
+	session.Status = state.SessionStatusSuccess
+	session.LastError = ""
+	a.state.AppendDaemonLog("resume issue execution succeeded repo=%s issue=%d output=%s", session.Repo, session.IssueNumber, summarizeText(output))
+	return nil
+}
+
+func (a *App) resumeBlockedConflictResolution(ctx context.Context, session *state.Session) error {
+	pr, err := ghcli.FindPullRequestForBranch(ctx, a.env.Runner, session.Repo, session.Branch)
+	if err != nil {
+		return err
+	}
+	if pr == nil {
+		return errors.New("no pull request found for blocked conflict-resolution session")
+	}
+	target := state.WatchTarget{Path: session.RepoPath, Repo: session.Repo, Branch: "main"}
+	if err := issuerunner.RunConflictResolutionSession(ctx, a.env, a.state, target, *session, *pr); err != nil {
+		return err
+	}
+	session.Status = state.SessionStatusSuccess
+	return nil
+}
+
 func stalledSessionThreshold() time.Duration {
 	raw := strings.TrimSpace(os.Getenv("VIGILANTE_STALLED_SESSION_THRESHOLD"))
 	if raw == "" {
@@ -740,11 +1065,92 @@ func shouldCommentMaintenanceFailure(session state.Session, err error) bool {
 }
 
 func summarizeMaintenanceError(err error) string {
-	text := strings.TrimSpace(err.Error())
+	return summarizeText(err.Error())
+}
+
+func summarizeText(text string) string {
+	text = strings.TrimSpace(text)
 	if len(text) > 400 {
 		return text[:400]
 	}
 	return text
+}
+
+func classifyBlockedReason(stage string, operation string, err error) state.BlockedReason {
+	text := strings.ToLower(strings.TrimSpace(err.Error()))
+	reason := state.BlockedReason{
+		Kind:      "unknown_operator_action_required",
+		Operation: operation,
+		Summary:   summarizeMaintenanceError(err),
+		Detail:    summarizeMaintenanceError(err),
+	}
+	switch {
+	case strings.Contains(text, "permission denied (publickey)") || strings.Contains(text, "sign_and_send_pubkey") || strings.Contains(text, "could not read from remote repository"):
+		reason.Kind = "git_auth"
+	case strings.Contains(text, "gh auth") || strings.Contains(text, "not logged into") || strings.Contains(text, "authentication failed"):
+		reason.Kind = "gh_auth"
+	case strings.Contains(text, "session expired") || strings.Contains(text, "re-auth") || strings.Contains(text, "login required") || strings.Contains(text, "unauthorized"):
+		reason.Kind = "provider_auth"
+	case strings.Contains(text, "executable file not found") || strings.Contains(text, "no such file or directory"):
+		reason.Kind = "provider_missing"
+	case strings.Contains(text, "worktree is not clean"):
+		reason.Kind = "dirty_worktree"
+	case strings.Contains(text, "go test") || strings.Contains(text, "validation"):
+		reason.Kind = "validation_failed"
+	case strings.Contains(text, "network is unreachable") || strings.Contains(text, "timed out"):
+		reason.Kind = "network_unreachable"
+	case stage == "issue_execution" || stage == "conflict_resolution":
+		reason.Kind = "provider_runtime_error"
+	}
+	return reason
+}
+
+func markSessionBlocked(session *state.Session, stage string, blocked state.BlockedReason, now time.Time) {
+	session.Status = state.SessionStatusBlocked
+	session.BlockedAt = now.Format(time.RFC3339)
+	session.BlockedStage = stage
+	session.BlockedReason = blocked
+	session.RetryPolicy = "paused"
+	session.ResumeRequired = true
+	session.ResumeHint = fmt.Sprintf("vigilante resume --repo %s --issue %d", session.Repo, session.IssueNumber)
+	session.ProcessID = 0
+}
+
+func clearBlockedState(session *state.Session, now time.Time, source string) {
+	session.Status = state.SessionStatusSuccess
+	session.BlockedAt = ""
+	session.BlockedReason = state.BlockedReason{}
+	session.BlockedStage = ""
+	session.RetryPolicy = ""
+	session.ResumeRequired = false
+	session.ResumeHint = ""
+	session.RecoveredAt = now.Format(time.RFC3339)
+	session.UpdatedAt = session.RecoveredAt
+	session.LastError = ""
+	session.LastMaintenanceError = ""
+	session.LastResumeSource = source
+}
+
+func blockedStateLabel(session state.Session) string {
+	switch session.BlockedReason.Kind {
+	case "git_auth":
+		return "blocked_waiting_for_credentials"
+	case "gh_auth":
+		return "blocked_waiting_for_github_auth"
+	case "provider_auth":
+		return "blocked_waiting_for_provider_auth"
+	case "provider_missing":
+		return "blocked_waiting_for_provider_binary"
+	default:
+		return "blocked_waiting_for_operator"
+	}
+}
+
+func fallbackText(value string, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
 }
 
 func (a *App) ensureTooling(ctx context.Context) error {
@@ -764,7 +1170,9 @@ func (a *App) printUsage() {
 	fmt.Fprintln(a.stderr, "  vigilante setup [-d]")
 	fmt.Fprintln(a.stderr, "  vigilante watch [-d] [--label value] [--assignee value] <path>")
 	fmt.Fprintln(a.stderr, "  vigilante unwatch <path>")
-	fmt.Fprintln(a.stderr, "  vigilante list")
+	fmt.Fprintln(a.stderr, "  vigilante list [--blocked]")
+	fmt.Fprintln(a.stderr, "  vigilante resume --repo <owner/name> --issue <n>")
+	fmt.Fprintln(a.stderr, "  vigilante resume --all-blocked")
 	fmt.Fprintln(a.stderr, "  vigilante daemon run [--once] [--interval duration]")
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -119,7 +119,7 @@ func TestWatchListAndUnwatch(t *testing.T) {
 	}
 
 	stdout.Reset()
-	if err := app.List(); err != nil {
+	if err := app.List(false); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(stdout.String(), "\"repo\": \"nicobistolfi/vigilante\"") {
@@ -196,6 +196,139 @@ func TestWatchUpdatesExistingTarget(t *testing.T) {
 	}
 	if targets[0].Assignee != "nicobistolfi" {
 		t.Fatalf("expected assignee to be preserved: %#v", targets[0])
+	}
+}
+
+func TestListBlockedSessions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		Repo:                 "owner/repo",
+		IssueNumber:          44,
+		Status:               state.SessionStatusBlocked,
+		BlockedAt:            "2026-03-11T13:20:13Z",
+		BlockedStage:         "pr_maintenance",
+		BlockedReason:        state.BlockedReason{Kind: "git_auth", Operation: "git fetch origin main"},
+		ResumeHint:           "vigilante resume --repo owner/repo --issue 44",
+		ResumeRequired:       true,
+		RetryPolicy:          "paused",
+		WorktreePath:         "/tmp/repo/.worktrees/vigilante/issue-44",
+		Branch:               "vigilante/issue-44",
+		LastMaintenanceError: "git fetch origin main: exit status 128",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.List(true); err != nil {
+		t.Fatal(err)
+	}
+	got := stdout.String()
+	for _, want := range []string{
+		"owner/repo issue #44  blocked_waiting_for_credentials",
+		"cause: git_auth",
+		"failed op: git fetch origin main",
+		"resume: vigilante resume --repo owner/repo --issue 44",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected blocked list output to contain %q, got: %s", want, got)
+		}
+	}
+}
+
+func TestScanOnceProcessesGitHubCommentResumeRequest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1":          `{"labels":[]}`,
+			"gh api repos/owner/repo/issues/1/comments": `[{"id":101,"body":"@vigilanteai resume","created_at":"2026-03-10T12:30:00Z","user":{"login":"nicobistolfi"}}]`,
+			"gh api --method POST -H Accept: application/vnd.github+json repos/owner/repo/issues/comments/101/reactions -f content=salute": "{}",
+			"codex --version": "codex 1.0.0",
+			"codex exec --cd " + worktreePath + " --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: " + repoPath + "\nIssue: #1 - first\nIssue URL: https://github.com/owner/repo/issues/1\nWorktree path: " + worktreePath + "\nBranch: vigilante/issue-1\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nUse the same GitHub comment structure for every non-terminal milestone comment: a short header with the current stage and optional emoji, a 10-cell progress bar with percentage, an `ETA: ~N minutes` line, 1-3 concise bullets covering what just happened and what is next, and an optional short playful quote or tagline.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.": "done",
+			"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Recovered",
+				Emoji:      "🫡",
+				Percent:    92,
+				ETAMinutes: 5,
+				Items: []string{
+					"The previous `provider_auth` block was cleared for `vigilante/issue-1`.",
+					"Resume source: `comment`.",
+					"Next step: Vigilante resumed `issue_execution` successfully.",
+				},
+				Tagline: "Back on the wire.",
+			}): "ok",
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: repoPath, Repo: "owner/repo", Branch: "main", Assignee: "me"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:        repoPath,
+		Repo:            "owner/repo",
+		IssueNumber:     1,
+		IssueTitle:      "first",
+		IssueURL:        "https://github.com/owner/repo/issues/1",
+		Branch:          "vigilante/issue-1",
+		WorktreePath:    worktreePath,
+		Status:          state.SessionStatusBlocked,
+		BlockedAt:       "2026-03-11T13:19:12Z",
+		BlockedStage:    "issue_execution",
+		BlockedReason:   state.BlockedReason{Kind: "provider_auth", Operation: "codex exec", Summary: "session expired", Detail: "session expired"},
+		RetryPolicy:     "paused",
+		ResumeRequired:  true,
+		ResumeHint:      "vigilante resume --repo owner/repo --issue 1",
+		UpdatedAt:       "2026-03-11T13:19:12Z",
+		LastHeartbeatAt: "2026-03-11T13:19:12Z",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if sessions[0].Status != state.SessionStatusSuccess {
+		t.Fatalf("expected resumed session to be successful: %#v", sessions[0])
+	}
+	if sessions[0].LastResumeCommentID != 101 || sessions[0].LastResumeSource != "comment" {
+		t.Fatalf("expected claimed comment metadata to be persisted: %#v", sessions[0])
+	}
+	if sessions[0].RecoveredAt == "" {
+		t.Fatalf("expected recovery timestamp to be recorded: %#v", sessions[0])
 	}
 }
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -31,6 +31,19 @@ type PullRequest struct {
 	MergedAt *time.Time `json:"mergedAt"`
 }
 
+type IssueComment struct {
+	ID        int64     `json:"id"`
+	Body      string    `json:"body"`
+	CreatedAt time.Time `json:"created_at"`
+	User      struct {
+		Login string `json:"login"`
+	} `json:"user"`
+}
+
+type IssueDetails struct {
+	Labels []Label `json:"labels"`
+}
+
 func ListOpenIssues(ctx context.Context, runner environment.Runner, repo string, assignee string) ([]Issue, error) {
 	resolvedAssignee, err := resolveAssignee(ctx, runner, assignee)
 	if err != nil {
@@ -89,7 +102,7 @@ func SelectNextIssue(issues []Issue, sessions []state.Session, target state.Watc
 }
 
 func sessionBlocksRedispatch(session state.Session) bool {
-	if session.Status == state.SessionStatusRunning {
+	if session.Status == state.SessionStatusRunning || session.Status == state.SessionStatusBlocked || session.Status == state.SessionStatusResuming {
 		return true
 	}
 	if session.Status != state.SessionStatusSuccess {
@@ -121,6 +134,79 @@ func CommentOnIssue(ctx context.Context, runner environment.Runner, repo string,
 	return err
 }
 
+func GetIssueDetails(ctx context.Context, runner environment.Runner, repo string, number int) (*IssueDetails, error) {
+	output, err := runner.Run(ctx, "", "gh", "api", issueAPIPath(repo, number))
+	if err != nil {
+		return nil, err
+	}
+
+	var details IssueDetails
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &details); err != nil {
+		return nil, fmt.Errorf("parse gh issue details output: %w", err)
+	}
+	return &details, nil
+}
+
+func ListIssueComments(ctx context.Context, runner environment.Runner, repo string, number int) ([]IssueComment, error) {
+	output, err := runner.Run(ctx, "", "gh", "api", issueAPIPath(repo, number)+"/comments")
+	if err != nil {
+		return nil, err
+	}
+
+	var comments []IssueComment
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &comments); err != nil {
+		return nil, fmt.Errorf("parse gh issue comments output: %w", err)
+	}
+	sort.Slice(comments, func(i, j int) bool {
+		return comments[i].CreatedAt.Before(comments[j].CreatedAt)
+	})
+	return comments, nil
+}
+
+func AddIssueCommentReaction(ctx context.Context, runner environment.Runner, repo string, commentID int64, content string) error {
+	_, err := runner.Run(
+		ctx,
+		"",
+		"gh",
+		"api",
+		"--method", "POST",
+		"-H", "Accept: application/vnd.github+json",
+		fmt.Sprintf("repos/%s/issues/comments/%d/reactions", repo, commentID),
+		"-f", "content="+content,
+	)
+	return err
+}
+
+func RemoveIssueLabel(ctx context.Context, runner environment.Runner, repo string, number int, label string) error {
+	_, err := runner.Run(ctx, "", "gh", "issue", "edit", "--repo", repo, fmt.Sprintf("%d", number), "--remove-label", label)
+	return err
+}
+
+func HasAnyLabel(labels []Label, wanted ...string) bool {
+	for _, label := range labels {
+		for _, candidate := range wanted {
+			if label.Name == candidate {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func FindResumeComment(comments []IssueComment, claimedCommentID int64) *IssueComment {
+	for i := len(comments) - 1; i >= 0; i-- {
+		body := strings.TrimSpace(comments[i].Body)
+		if body != "@vigilanteai resume" {
+			continue
+		}
+		if claimedCommentID != 0 && comments[i].ID == claimedCommentID {
+			return nil
+		}
+		return &comments[i]
+	}
+	return nil
+}
+
 func FindPullRequestForBranch(ctx context.Context, runner environment.Runner, repo string, branch string) (*PullRequest, error) {
 	output, err := runner.Run(ctx, "", "gh", "pr", "list", "--repo", repo, "--head", branch, "--state", "all", "--json", "number,url,state,mergedAt")
 	if err != nil {
@@ -135,4 +221,8 @@ func FindPullRequestForBranch(ctx context.Context, runner environment.Runner, re
 		return nil, nil
 	}
 	return &prs[0], nil
+}
+
+func issueAPIPath(repo string, number int) string {
+	return "repos/" + repo + "/issues/" + fmt.Sprintf("%d", number)
 }

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -16,6 +17,9 @@ import (
 
 func RunIssueSession(ctx context.Context, env *environment.Environment, store *state.Store, target state.WatchTarget, issue ghcli.Issue, session state.Session) state.Session {
 	logPath := store.SessionLogPath(issue.Number)
+	if session.Repo == "" {
+		session.Repo = target.Repo
+	}
 	session.ProcessID = os.Getpid()
 	session.LastHeartbeatAt = time.Now().UTC().Format(time.RFC3339)
 	session.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
@@ -55,7 +59,8 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 	session.LastHeartbeatAt = session.EndedAt
 	session.UpdatedAt = session.EndedAt
 	if err != nil {
-		session.Status = state.SessionStatusFailed
+		blocked := classifyBlockedFailure("issue_execution", "codex exec", output, err)
+		markSessionBlocked(&session, "issue_execution", blocked, time.Now().UTC())
 		session.LastError = err.Error()
 		appendSessionLog(logPath, "session failed", session, combineLogDetails(output, err.Error()))
 		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
@@ -65,8 +70,8 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 			ETAMinutes: 10,
 			Items: []string{
 				"Codex execution stopped before the issue implementation completed.",
-				fmt.Sprintf("Failure detail: `%s`.", summarizeError(err)),
-				"Next step: inspect the failing command or environment and redispatch once the blocker is resolved.",
+				fmt.Sprintf("Cause class: `%s`.", blocked.Kind),
+				fmt.Sprintf("Next step: fix the blocker, then run `%s` or request resume from GitHub.", session.ResumeHint),
 			},
 			Tagline: "Plans are only good intentions unless they immediately degenerate into hard work.",
 		})
@@ -95,6 +100,7 @@ func RunConflictResolutionSession(ctx context.Context, env *environment.Environm
 	)
 	if err != nil {
 		appendSessionLog(logPath, "conflict resolution failed", session, combineLogDetails(output, err.Error()))
+		blocked := classifyBlockedFailure("conflict_resolution", "codex exec", output, err)
 		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
 			Stage:      "Blocked",
 			Emoji:      "🧯",
@@ -102,8 +108,8 @@ func RunConflictResolutionSession(ctx context.Context, env *environment.Environm
 			ETAMinutes: 12,
 			Items: []string{
 				fmt.Sprintf("Conflict resolution for PR #%d on `%s` did not complete.", pr.Number, session.Branch),
-				fmt.Sprintf("Failure detail: `%s`.", summarizeError(err)),
-				"Next step: review the rebase state in the worktree and rerun the dedicated conflict-resolution flow.",
+				fmt.Sprintf("Cause class: `%s`.", blocked.Kind),
+				fmt.Sprintf("Next step: fix the blocker, then run `%s` or request resume from GitHub.", buildResumeHint(session)),
 			},
 			Tagline: "An obstacle is often a stepping stone.",
 		})
@@ -121,6 +127,54 @@ func summarizeError(err error) string {
 		return text[:400]
 	}
 	return text
+}
+
+func markSessionBlocked(session *state.Session, stage string, blocked state.BlockedReason, now time.Time) {
+	session.Status = state.SessionStatusBlocked
+	session.BlockedAt = now.Format(time.RFC3339)
+	session.BlockedStage = stage
+	session.BlockedReason = blocked
+	session.RetryPolicy = "paused"
+	session.ResumeRequired = true
+	session.ResumeHint = buildResumeHint(*session)
+	session.ProcessID = 0
+	session.RecoveredAt = ""
+}
+
+func buildResumeHint(session state.Session) string {
+	return fmt.Sprintf("vigilante resume --repo %s --issue %d", session.Repo, session.IssueNumber)
+}
+
+func classifyBlockedFailure(stage string, operation string, output string, err error) state.BlockedReason {
+	text := strings.ToLower(strings.TrimSpace(output + "\n" + err.Error()))
+	reason := state.BlockedReason{
+		Kind:      "unknown_operator_action_required",
+		Operation: operation,
+		Summary:   summarizeError(err),
+		Detail:    summarizeError(errors.New(strings.TrimSpace(output))),
+	}
+	switch {
+	case strings.Contains(text, "permission denied (publickey)") || strings.Contains(text, "sign_and_send_pubkey") || strings.Contains(text, "could not read from remote repository"):
+		reason.Kind = "git_auth"
+	case strings.Contains(text, "gh auth") || strings.Contains(text, "not logged into") || strings.Contains(text, "authentication failed"):
+		reason.Kind = "gh_auth"
+	case strings.Contains(text, "session expired") || strings.Contains(text, "re-auth") || strings.Contains(text, "login required") || strings.Contains(text, "unauthorized"):
+		reason.Kind = "provider_auth"
+	case strings.Contains(text, "executable file not found") || strings.Contains(text, "no such file or directory"):
+		reason.Kind = "provider_missing"
+	case strings.Contains(text, "worktree is not clean"):
+		reason.Kind = "dirty_worktree"
+	case strings.Contains(text, "go test") || strings.Contains(text, "validation"):
+		reason.Kind = "validation_failed"
+	case strings.Contains(text, "network is unreachable") || strings.Contains(text, "timed out"):
+		reason.Kind = "network_unreachable"
+	case strings.Contains(strings.ToLower(stage), "issue") || strings.Contains(strings.ToLower(stage), "conflict"):
+		reason.Kind = "provider_runtime_error"
+	}
+	if reason.Detail == "" {
+		reason.Detail = reason.Summary
+	}
+	return reason
 }
 
 func appendSessionLog(path string, event string, session state.Session, details string) {

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -78,8 +78,8 @@ func TestRunIssueSessionFailureCommentsOnIssue(t *testing.T) {
 				ETAMinutes: 10,
 				Items: []string{
 					"Codex execution stopped before the issue implementation completed.",
-					"Failure detail: `codex exec [--cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox prompt]: exit status 1`.",
-					"Next step: inspect the failing command or environment and redispatch once the blocker is resolved.",
+					"Cause class: `provider_runtime_error`.",
+					"Next step: fix the blocker, then run `vigilante resume --repo owner/repo --issue 7` or request resume from GitHub.",
 				},
 				Tagline: "Plans are only good intentions unless they immediately degenerate into hard work.",
 			}): "ok",
@@ -95,7 +95,7 @@ func TestRunIssueSessionFailureCommentsOnIssue(t *testing.T) {
 	}
 	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
 	got := RunIssueSession(context.Background(), env, store, state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
-	if got.Status != state.SessionStatusFailed {
+	if got.Status != state.SessionStatusBlocked {
 		t.Fatalf("unexpected status: %#v", got)
 	}
 	if !strings.Contains(got.LastError, "exit status 1") {
@@ -122,8 +122,8 @@ func TestRunConflictResolutionSessionFailureCommentsOnIssue(t *testing.T) {
 				ETAMinutes: 12,
 				Items: []string{
 					"Conflict resolution for PR #17 on `vigilante/issue-7` did not complete.",
-					"Failure detail: `codex exec [--cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox prompt]: exit status 1`.",
-					"Next step: review the rebase state in the worktree and rerun the dedicated conflict-resolution flow.",
+					"Cause class: `provider_runtime_error`.",
+					"Next step: fix the blocker, then run `vigilante resume --repo owner/repo --issue 7` or request resume from GitHub.",
 				},
 				Tagline: "An obstacle is often a stepping stone.",
 			}): "ok",

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -27,10 +27,19 @@ type WatchTarget struct {
 type SessionStatus string
 
 const (
-	SessionStatusRunning SessionStatus = "running"
-	SessionStatusSuccess SessionStatus = "success"
-	SessionStatusFailed  SessionStatus = "failed"
+	SessionStatusRunning  SessionStatus = "running"
+	SessionStatusBlocked  SessionStatus = "blocked"
+	SessionStatusResuming SessionStatus = "resuming"
+	SessionStatusSuccess  SessionStatus = "success"
+	SessionStatusFailed   SessionStatus = "failed"
 )
+
+type BlockedReason struct {
+	Kind      string `json:"kind,omitempty"`
+	Operation string `json:"operation,omitempty"`
+	Summary   string `json:"summary,omitempty"`
+	Detail    string `json:"detail,omitempty"`
+}
 
 type Session struct {
 	RepoPath             string        `json:"repo_path"`
@@ -47,6 +56,16 @@ type Session struct {
 	PullRequestMergedAt  string        `json:"pull_request_merged_at,omitempty"`
 	LastMaintainedAt     string        `json:"last_maintained_at,omitempty"`
 	LastMaintenanceError string        `json:"last_maintenance_error,omitempty"`
+	BlockedAt            string        `json:"blocked_at,omitempty"`
+	BlockedStage         string        `json:"blocked_stage,omitempty"`
+	BlockedReason        BlockedReason `json:"blocked_reason,omitempty"`
+	RetryPolicy          string        `json:"retry_policy,omitempty"`
+	ResumeRequired       bool          `json:"resume_required,omitempty"`
+	ResumeHint           string        `json:"resume_hint,omitempty"`
+	LastResumeSource     string        `json:"last_resume_source,omitempty"`
+	LastResumeCommentID  int64         `json:"last_resume_comment_id,omitempty"`
+	LastResumeCommentAt  string        `json:"last_resume_comment_at,omitempty"`
+	RecoveredAt          string        `json:"recovered_at,omitempty"`
 	MonitoringStoppedAt  string        `json:"monitoring_stopped_at,omitempty"`
 	CleanupCompletedAt   string        `json:"cleanup_completed_at,omitempty"`
 	CleanupError         string        `json:"cleanup_error,omitempty"`


### PR DESCRIPTION
## Summary
- persist structured blocked-session metadata and pause operator-actionable retry loops
- add explicit recovery paths through `vigilante resume`, `vigilante list --blocked`, and GitHub resume signals
- post recovered comments after successful resume and cover the new flows with tests

## Validation
- `go test ./...`

Closes #44.
