### PR TITLE
Fix release workflow tag trigger pattern

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - '+([0-9]).+([0-9]).+([0-9])'
+      - '*.*.*'
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ git tag 1.2.3
 git push origin 1.2.3
 ```
 
-Tags outside the version format, such as `v1.2.3` or `release-1.2.3`, do not trigger the release workflow. The release workflow validates both the tag format and that the tagged commit is already merged into `main` before GoReleaser publishes artifacts to GitHub Releases.
+Tags that do not match the required version format, such as `v1.2.3` or `release-1.2.3`, may start the release workflow but are rejected by the tag validation step before GoReleaser publishes artifacts. The release workflow also validates that the tagged commit is already merged into `main` before publishing to GitHub Releases.
 
 ## Local State
 


### PR DESCRIPTION
## Summary
- replace the unsupported release tag trigger with a GitHub Actions-compatible glob
- keep strict numeric tag validation in the release job
- update the README release note to reflect that invalid tags are rejected in-workflow

Closes #50

## Validation
- `go test ./...`
- `go run github.com/goreleaser/goreleaser/v2@latest check`
