### PR TITLE
Add vigilante-create-issue skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ Expected behavior:
 - initializes `watchlist.json`
 - verifies `git`, `gh`, and `codex`
 - installs the bundled coding-agent skills for regular runtime use, including any companion files under each skill directory
+  - `vigilante-issue-implementation`
+  - `vigilante-conflict-resolution`
+  - `vigilante-create-issue`
 - installs or updates the daemon definition when requested
 
 ## Development Mode

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -15,9 +15,18 @@ import (
 
 const VigilanteIssueImplementation = "vigilante-issue-implementation"
 const VigilanteConflictResolution = "vigilante-conflict-resolution"
+const VigilanteCreateIssue = "vigilante-create-issue"
+
+func VigilanteSkillNames() []string {
+	return []string{
+		VigilanteIssueImplementation,
+		VigilanteConflictResolution,
+		VigilanteCreateIssue,
+	}
+}
 
 func EnsureInstalled(codexHome string) error {
-	for _, name := range []string{VigilanteIssueImplementation, VigilanteConflictResolution} {
+	for _, name := range VigilanteSkillNames() {
 		skillDir := filepath.Join(codexHome, "skills", name)
 		source, err := resolveSkillSource(name)
 		if err != nil {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -15,7 +15,7 @@ import (
 func TestEnsureInstalledPrefersRepoSkillsWhenAvailable(t *testing.T) {
 	dir := t.TempDir()
 	repoRoot := t.TempDir()
-	for _, name := range []string{VigilanteIssueImplementation, VigilanteConflictResolution} {
+	for _, name := range VigilanteSkillNames() {
 		skillSourceDir := filepath.Join(repoRoot, "skills", name)
 		if err := os.MkdirAll(skillSourceDir, 0o755); err != nil {
 			t.Fatal(err)
@@ -44,7 +44,7 @@ func TestEnsureInstalledPrefersRepoSkillsWhenAvailable(t *testing.T) {
 	if err := EnsureInstalled(dir); err != nil {
 		t.Fatal(err)
 	}
-	for _, name := range []string{VigilanteIssueImplementation, VigilanteConflictResolution} {
+	for _, name := range VigilanteSkillNames() {
 		path := filepath.Join(dir, "skills", name, "SKILL.md")
 		data, err := os.ReadFile(path)
 		if err != nil {
@@ -76,7 +76,7 @@ func TestResolveSkillSourceFallsBackToEmbeddedAssets(t *testing.T) {
 		_ = os.Chdir(wd)
 	}()
 
-	for _, name := range []string{VigilanteIssueImplementation, VigilanteConflictResolution} {
+	for _, name := range VigilanteSkillNames() {
 		source, err := resolveSkillSource(name)
 		if err != nil {
 			t.Fatal(err)
@@ -120,7 +120,7 @@ func TestEnsureInstalledUsesEmbeddedAssetsOutsideRepo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for _, name := range []string{VigilanteIssueImplementation, VigilanteConflictResolution} {
+	for _, name := range VigilanteSkillNames() {
 		path := filepath.Join(dir, "skills", name, "SKILL.md")
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("expected %s to exist: %v", path, err)

--- a/skillassets.go
+++ b/skillassets.go
@@ -4,5 +4,5 @@ import "embed"
 
 // Skills contains built-in runtime skill files for installed binaries.
 //
-//go:embed skills/vigilante-issue-implementation skills/vigilante-conflict-resolution
+//go:embed skills/vigilante-issue-implementation skills/vigilante-conflict-resolution skills/vigilante-create-issue
 var Skills embed.FS

--- a/skills/vigilante-create-issue/SKILL.md
+++ b/skills/vigilante-create-issue/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: vigilante-create-issue
+description: Help a human author write an implementation-ready GitHub issue that Vigilante can execute reliably.
+---
+
+# Vigilante Create Issue
+
+## Overview
+Use this skill when a human wants to write or refine a GitHub issue that Vigilante will later implement. The goal is not to design the full solution for them. The goal is to turn a vague request into an issue with enough behavioral detail, constraints, and verification criteria for a headless coding agent to execute safely.
+
+## Outcome
+Produce a GitHub issue draft that is:
+
+- specific about the problem and why it matters
+- grounded in repository or product context
+- explicit about expected behavior and non-goals
+- realistic about implementation flexibility and hard constraints
+- testable through concrete acceptance criteria
+- clear about validation and regression coverage
+
+## Workflow
+1. Clarify the request before writing
+- Identify the change the user actually wants.
+- Ask for missing repository, product, or user context when it affects implementation.
+- Separate required behavior from guesses or preferences.
+
+2. Frame the issue around execution
+- Write for the agent that will implement the issue later, not for a broad brainstorming audience.
+- Prefer observable behavior over vague aspirations.
+- Note any constraints that must be preserved: CLI flags, APIs, config compatibility, UX expectations, rollout limits, or performance boundaries.
+
+3. Capture implementation guidance without over-constraining
+- Include likely solution paths when they materially reduce ambiguity.
+- Mark which implementation details are required and which are flexible.
+- Call out known tradeoffs or rejected alternatives when relevant.
+
+4. Make completion testable
+- Convert expectations into pass/fail acceptance criteria.
+- State what tests should be added or updated.
+- Mention the key regressions or failure modes that must be prevented.
+
+5. Deliver a ready-to-file issue
+- Return a polished issue draft in Markdown.
+- Keep it concise, but do not omit information needed for reliable execution.
+
+## Required Sections
+Every issue draft should cover these sections when relevant:
+
+1. Problem statement
+- What is wrong, missing, or desired?
+- Why does this matter now?
+
+2. Context
+- What repository, product, or workflow context does the implementer need?
+- What is the current behavior?
+- Who is affected?
+- What assumptions or constraints are already known?
+
+3. Desired outcome
+- What should be true after implementation?
+- What is explicitly out of scope?
+
+4. Possible implementation approaches
+- What are the most plausible solution paths?
+- Which details are required versus flexible?
+- What tradeoffs should the implementer understand?
+
+5. Acceptance criteria
+- Use explicit, testable statements.
+- Prefer behavior-focused checks over generic wording like "works correctly."
+
+6. Testing expectations
+- State which test layers matter: unit, integration, CLI, workflow, end-to-end, or manual verification.
+- Mention critical regressions and failure modes that need coverage.
+
+7. Operational or UX considerations
+- Include logging, migrations, config compatibility, docs, observability, rollout, or backward compatibility concerns when applicable.
+
+## Issue Quality Rules
+- Do not leave "should support X" statements undefined when the expected behavior can be stated concretely.
+- Do not hide key constraints inside prose if they materially affect implementation.
+- Do not invent repository details that were not provided. Flag missing context instead.
+- Do not overload the issue with speculative architecture unless the decision matters to execution.
+- Do include non-goals so the eventual implementation stays narrow.
+- Do include exact commands, files, components, or workflows when they are already known.
+
+## Recommended Questions To Ask
+Use these to tighten the issue before drafting:
+
+- What exactly should change?
+- What currently happens instead?
+- Why is the change needed?
+- What constraints must the implementation respect?
+- Which solution options are acceptable, and which are not?
+- How will we know the issue is done?
+- What tests prove the change works?
+- What regressions must be prevented?
+
+## Output Template
+Use this structure for the final issue draft:
+
+```md
+## Summary
+<One short paragraph describing the problem and desired change.>
+
+## Problem
+- <What is wrong, missing, or desired>
+- <Why it matters>
+
+## Context
+- <Current behavior>
+- <Relevant repo, product, or workflow details>
+- <Constraints or assumptions>
+
+## Desired Outcome
+- <Expected end-state>
+- <Non-goals or out-of-scope items>
+
+## Implementation Notes
+- <Likely approach or options>
+- <Required constraints vs flexible details>
+- <Tradeoffs, if relevant>
+
+## Acceptance Criteria
+- [ ] <Specific observable behavior>
+- [ ] <Specific observable behavior>
+
+## Testing Expectations
+- <Tests to add or update>
+- <Failure modes or regressions to cover>
+
+## Operational / UX Considerations
+- <Docs, logging, migration, compatibility, rollout, observability, etc.>
+```
+
+## Final Checks
+Before returning the issue draft, verify that:
+
+- the problem is understandable without extra oral context
+- the desired outcome is observable
+- the acceptance criteria are testable
+- the testing section names the expected validation
+- the issue gives Vigilante enough direction to implement without guessing the basics

--- a/skills/vigilante-create-issue/agents/openai.yaml
+++ b/skills/vigilante-create-issue/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: Vigilante Create Issue
+model: gpt-5
+behavior:
+  default_prompt: "Use $vigilante-create-issue to turn the user's request into an implementation-ready GitHub issue for Vigilante."


### PR DESCRIPTION
## Summary
- add a bundled `vigilante-create-issue` skill for writing implementation-ready issues
- install and embed it alongside the other Vigilante skills
- extend skill installation tests to cover the full bundled skill set

Closes #46

## Validation
- `go test ./...`
- `go build ./...`