### PR TITLE
Keep the daemon scanning after issue-specific failures

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -414,10 +414,9 @@ func (a *App) ScanOnce(ctx context.Context) error {
 			issues, err := ghcli.ListOpenIssues(ctx, a.env.Runner, target.Repo, target.Assignee)
 			target.LastScanAt = a.clock().Format(time.RFC3339)
 			if err != nil {
-				if saveErr := a.state.SaveWatchTargets(targets); saveErr != nil {
-					return saveErr
-				}
-				return err
+				a.state.AppendDaemonLog("scan repo issues failed repo=%s err=%v", target.Repo, err)
+				fmt.Fprintf(a.stdout, "repo: %s scan failed: %s\n", target.Repo, summarizeText(err.Error()))
+				continue
 			}
 			a.state.AppendDaemonLog("scan repo issues repo=%s open_issues=%d", target.Repo, len(issues))
 
@@ -437,7 +436,14 @@ func (a *App) ScanOnce(ctx context.Context) error {
 
 				wt, err := worktree.CreateIssueWorktree(ctx, a.env.Runner, *target, next.Number, next.Title)
 				if err != nil {
-					return err
+					session := blockedIssueSessionForDispatchFailure(*target, next, err, a.clock())
+					a.state.AppendDaemonLog("scan repo dispatch blocked repo=%s issue=%d err=%v", target.Repo, next.Number, err)
+					sessions = upsertSession(sessions, session)
+					if err := a.state.SaveSessions(sessions); err != nil {
+						return err
+					}
+					fmt.Fprintf(a.stdout, "repo: %s blocked issue #%d: %s\n", target.Repo, next.Number, summarizeText(err.Error()))
+					continue
 				}
 				a.state.AppendDaemonLog("scan repo worktree ready repo=%s issue=%d path=%s branch=%s", target.Repo, next.Number, wt.Path, wt.Branch)
 
@@ -502,7 +508,9 @@ func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Sessi
 
 		pr, err := ghcli.FindPullRequestForBranch(ctx, a.env.Runner, session.Repo, session.Branch)
 		if err != nil {
-			return nil, err
+			a.recordSessionFailure(session, "issue_execution", "gh pr list", err)
+			a.state.AppendDaemonLog("stalled session pr lookup failed repo=%s issue=%d branch=%s err=%v", session.Repo, session.IssueNumber, session.Branch, err)
+			continue
 		}
 		if pr != nil {
 			session.Status = state.SessionStatusSuccess
@@ -530,7 +538,9 @@ func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Sessi
 				Tagline: "Fall seven times, stand up eight.",
 			})
 			if err := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); err != nil {
-				return nil, err
+				session.LastError = err.Error()
+				session.UpdatedAt = a.clock().Format(time.RFC3339)
+				a.state.AppendDaemonLog("stalled session recovery comment failed repo=%s issue=%d branch=%s err=%v", session.Repo, session.IssueNumber, session.Branch, err)
 			}
 			continue
 		}
@@ -553,7 +563,9 @@ func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Sessi
 				Tagline: "The gem cannot be polished without friction.",
 			})
 			if commentErr := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); commentErr != nil {
-				return nil, commentErr
+				session.LastError = commentErr.Error()
+				session.UpdatedAt = a.clock().Format(time.RFC3339)
+				a.state.AppendDaemonLog("stalled session cleanup comment failed repo=%s issue=%d branch=%s err=%v", session.Repo, session.IssueNumber, session.Branch, commentErr)
 			}
 			continue
 		}
@@ -580,7 +592,9 @@ func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Sessi
 			Tagline: "A smooth sea never made a skilled sailor.",
 		})
 		if err := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); err != nil {
-			return nil, err
+			session.LastError = err.Error()
+			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			a.state.AppendDaemonLog("stalled session redispatch comment failed repo=%s issue=%d branch=%s err=%v", session.Repo, session.IssueNumber, session.Branch, err)
 		}
 	}
 
@@ -806,38 +820,53 @@ func (a *App) processGitHubResumeRequests(ctx context.Context, sessions []state.
 
 		details, err := ghcli.GetIssueDetails(ctx, a.env.Runner, session.Repo, session.IssueNumber)
 		if err != nil {
-			return nil, err
+			a.recordSessionFailure(session, fallbackText(session.BlockedStage, "issue_execution"), "gh issue view", err)
+			a.state.AppendDaemonLog("resume issue details failed repo=%s issue=%d err=%v", session.Repo, session.IssueNumber, err)
+			continue
 		}
 		if ghcli.HasAnyLabel(details.Labels, "resume", "vigilante:resume") {
+			labelRemovalFailed := false
 			for _, label := range []string{"resume", "vigilante:resume"} {
 				if ghcli.HasAnyLabel(details.Labels, label) {
 					if err := ghcli.RemoveIssueLabel(ctx, a.env.Runner, session.Repo, session.IssueNumber, label); err != nil {
-						return nil, err
+						a.recordSessionFailure(session, fallbackText(session.BlockedStage, "issue_execution"), "gh issue edit --remove-label", err)
+						a.state.AppendDaemonLog("resume label removal failed repo=%s issue=%d label=%s err=%v", session.Repo, session.IssueNumber, label, err)
+						labelRemovalFailed = true
+						break
 					}
 				}
 			}
+			if labelRemovalFailed {
+				continue
+			}
 			if err := a.resumeBlockedSession(ctx, session, "label"); err != nil {
-				return nil, err
+				a.recordSessionFailure(session, fallbackText(session.BlockedStage, "issue_execution"), fallbackText(session.BlockedReason.Operation, "resume"), err)
+				a.state.AppendDaemonLog("resume by label failed repo=%s issue=%d err=%v", session.Repo, session.IssueNumber, err)
 			}
 			continue
 		}
 
 		comments, err := ghcli.ListIssueComments(ctx, a.env.Runner, session.Repo, session.IssueNumber)
 		if err != nil {
-			return nil, err
+			a.recordSessionFailure(session, fallbackText(session.BlockedStage, "issue_execution"), "gh issue comments", err)
+			a.state.AppendDaemonLog("resume comment lookup failed repo=%s issue=%d err=%v", session.Repo, session.IssueNumber, err)
+			continue
 		}
 		comment := ghcli.FindResumeComment(comments, session.LastResumeCommentID)
 		if comment == nil {
 			continue
 		}
 		if err := ghcli.AddIssueCommentReaction(ctx, a.env.Runner, session.Repo, comment.ID, "salute"); err != nil {
-			return nil, err
+			a.recordSessionFailure(session, fallbackText(session.BlockedStage, "issue_execution"), "gh api issue comment reactions", err)
+			a.state.AppendDaemonLog("resume reaction failed repo=%s issue=%d comment=%d err=%v", session.Repo, session.IssueNumber, comment.ID, err)
+			continue
 		}
 		session.LastResumeCommentID = comment.ID
 		session.LastResumeCommentAt = comment.CreatedAt.UTC().Format(time.RFC3339)
 		session.LastResumeSource = "comment"
 		if err := a.resumeBlockedSession(ctx, session, "comment"); err != nil {
-			return nil, err
+			a.recordSessionFailure(session, fallbackText(session.BlockedStage, "issue_execution"), fallbackText(session.BlockedReason.Operation, "resume"), err)
+			a.state.AppendDaemonLog("resume by comment failed repo=%s issue=%d comment=%d err=%v", session.Repo, session.IssueNumber, comment.ID, err)
 		}
 	}
 	return sessions, nil
@@ -1146,6 +1175,33 @@ func summarizeText(text string) string {
 		return text[:400]
 	}
 	return text
+}
+
+func blockedIssueSessionForDispatchFailure(target state.WatchTarget, issue ghcli.Issue, err error, now time.Time) state.Session {
+	session := state.Session{
+		RepoPath:     target.Path,
+		Repo:         target.Repo,
+		Provider:     target.Provider,
+		IssueNumber:  issue.Number,
+		IssueTitle:   issue.Title,
+		IssueURL:     issue.URL,
+		Branch:       worktree.IssueBranchName(issue.Number, issue.Title),
+		WorktreePath: worktree.IssueWorktreePath(target.Path, issue.Number),
+		Status:       state.SessionStatusFailed,
+		StartedAt:    now.Format(time.RFC3339),
+		UpdatedAt:    now.Format(time.RFC3339),
+		LastError:    err.Error(),
+	}
+	markSessionBlocked(&session, "issue_execution", classifyBlockedReason("issue_execution", "git worktree add", err), now)
+	session.LastError = err.Error()
+	session.UpdatedAt = now.Format(time.RFC3339)
+	return session
+}
+
+func (a *App) recordSessionFailure(session *state.Session, stage string, operation string, err error) {
+	markSessionBlocked(session, stage, classifyBlockedReason(stage, operation, err), a.clock())
+	session.LastError = err.Error()
+	session.UpdatedAt = a.clock().Format(time.RFC3339)
 }
 
 func classifyBlockedReason(stage string, operation string, err error) state.BlockedReason {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -713,6 +713,69 @@ func TestScanOnceDoesNotExceedConfiguredLimit(t *testing.T) {
 	}
 }
 
+func TestScanOnceBlocksFailedIssueDispatchAndContinuesToNextIssue(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	worktreePath1 := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	worktreePath2 := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-2")
+	branch2 := "vigilante/issue-2-second"
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+
+	var stdout bytes.Buffer
+	app := New()
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]},{"number":2,"title":"second","createdAt":"2026-03-10T12:00:00Z","url":"https://github.com/owner/repo/issues/2","labels":[]}]`,
+			"git worktree prune": "ok",
+			"git worktree add -b " + branch2 + " " + worktreePath2 + " main":                                                          "ok",
+			sessionStartCommentCommand("owner/repo", 2, worktreePath2, branch2):                                                       "ok",
+			issuePromptCommand(worktreePath2, "owner/repo", repoPath, 2, "second", "https://github.com/owner/repo/issues/2", branch2): "done",
+		},
+		Errors: map[string]error{
+			"git worktree add -b vigilante/issue-1-first " + worktreePath1 + " main": errors.New("exit status 1: worktree add failed"),
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: repoPath, Repo: "owner/repo", Branch: "main", Assignee: "me", MaxParallel: 2}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	app.waitForSessions()
+
+	got := stdout.String()
+	if !strings.Contains(got, "repo: owner/repo blocked issue #1: exit status 1: worktree add failed") {
+		t.Fatalf("expected blocked issue output, got: %s", got)
+	}
+	if !strings.Contains(got, "repo: owner/repo started issue #2 in "+worktreePath2) {
+		t.Fatalf("expected second issue to start, got: %s", got)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 2 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if sessions[0].IssueNumber != 1 || sessions[0].Status != state.SessionStatusBlocked {
+		t.Fatalf("expected first issue to be blocked, got: %#v", sessions[0])
+	}
+	if sessions[1].IssueNumber != 2 || sessions[1].Status != state.SessionStatusSuccess {
+		t.Fatalf("expected second issue to succeed, got: %#v", sessions[1])
+	}
+}
+
 func TestScanOnceEnforcesLimitsIndependentlyAcrossRepositories(t *testing.T) {
 	home := t.TempDir()
 	repoPathA := filepath.Join(home, "repo-a")
@@ -770,6 +833,66 @@ func TestScanOnceEnforcesLimitsIndependentlyAcrossRepositories(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(sessions) != 3 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+}
+
+func TestScanOnceContinuesWhenOneRepositoryScanFails(t *testing.T) {
+	home := t.TempDir()
+	repoPathA := filepath.Join(home, "repo-a")
+	repoPathB := filepath.Join(home, "repo-b")
+	worktreeB10 := filepath.Join(repoPathB, ".worktrees", "vigilante", "issue-10")
+	branchB10 := "vigilante/issue-10-first-b"
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+
+	var stdout bytes.Buffer
+	app := New()
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo-b --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":10,"title":"first-b","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo-b/issues/10","labels":[]}]`,
+			"git worktree prune": "ok",
+			"git worktree add -b " + branchB10 + " " + worktreeB10 + " main":                                                                  "ok",
+			sessionStartCommentCommand("owner/repo-b", 10, worktreeB10, branchB10):                                                            "ok",
+			issuePromptCommand(worktreeB10, "owner/repo-b", repoPathB, 10, "first-b", "https://github.com/owner/repo-b/issues/10", branchB10): "done",
+		},
+		Errors: map[string]error{
+			"gh issue list --repo owner/repo-a --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": errors.New("gh auth status failed"),
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{
+		{Path: repoPathA, Repo: "owner/repo-a", Branch: "main", Assignee: "me", MaxParallel: 1},
+		{Path: repoPathB, Repo: "owner/repo-b", Branch: "main", Assignee: "me", MaxParallel: 1},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	app.waitForSessions()
+
+	got := stdout.String()
+	if !strings.Contains(got, "repo: owner/repo-a scan failed: gh auth status failed") {
+		t.Fatalf("expected repo-a scan failure output, got: %s", got)
+	}
+	if !strings.Contains(got, "repo: owner/repo-b started issue #10 in "+worktreeB10) {
+		t.Fatalf("expected repo-b issue to start, got: %s", got)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 || sessions[0].Repo != "owner/repo-b" || sessions[0].Status != state.SessionStatusSuccess {
 		t.Fatalf("unexpected sessions: %#v", sessions)
 	}
 }
@@ -979,13 +1102,14 @@ func TestScanOnceUsesExplicitAssigneeFilter(t *testing.T) {
 	}
 }
 
-func TestScanOnceReturnsErrorWhenResolvingDefaultAssigneeFails(t *testing.T) {
+func TestScanOnceReportsRepoScanFailureWhenResolvingDefaultAssigneeFails(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
 	t.Setenv("HOME", home)
 
 	app := New()
-	app.stdout = &bytes.Buffer{}
+	var stdout bytes.Buffer
+	app.stdout = &stdout
 	app.stderr = testutil.IODiscard{}
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
@@ -1001,11 +1125,11 @@ func TestScanOnceReturnsErrorWhenResolvingDefaultAssigneeFails(t *testing.T) {
 	}
 
 	err := app.ScanOnce(context.Background())
-	if err == nil {
-		t.Fatal("expected assignee resolution error")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := err.Error(); got != `resolve assignee "me": context deadline exceeded` {
-		t.Fatalf("unexpected error: %s", got)
+	if got := stdout.String(); !strings.Contains(got, `repo: owner/repo scan failed: resolve assignee "me": context deadline exceeded`) {
+		t.Fatalf("unexpected output: %s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep the scan loop running when a single issue dispatch fails or a single repository scan fails
- persist blocked session state for dispatch failures instead of aborting the whole scan
- add regression coverage for isolated issue and repository failure handling

Closes #57

## Validation
- go test ./...