### PR TITLE
Support issue labels that override the coding agent provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ Initial rules:
 - enforce `max_parallel_sessions` independently for each watched repository
 - count both running implementation sessions and open-PR maintenance sessions against that repository limit
 - avoid duplicate work across multiple daemon scans
+- allow an issue label that exactly matches a registered provider id, such as `codex`, to override the watch target provider for that issue only
+- if more than one provider-id label is present on the same issue, skip dispatch instead of choosing a provider arbitrarily
 - prefer oldest eligible open issue first unless later prioritization rules are added
 
 Future policy can expand to richer label filters, assignment rules, and priority queues.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -434,9 +434,19 @@ func (a *App) ScanOnce(ctx context.Context) error {
 			for _, next := range nextIssues {
 				a.state.AppendDaemonLog("scan repo selected issue repo=%s issue=%d title=%q", target.Repo, next.Number, next.Title)
 
+				selectedProvider, providerErr := resolveIssueProvider(*target, next)
+				if providerErr != nil {
+					a.state.AppendDaemonLog("scan repo issue provider conflict repo=%s issue=%d err=%v", target.Repo, next.Number, providerErr)
+					fmt.Fprintf(a.stdout, "repo: %s skipped issue #%d: %s\n", target.Repo, next.Number, summarizeText(providerErr.Error()))
+					continue
+				}
+				if selectedProvider != target.Provider {
+					a.state.AppendDaemonLog("scan repo issue provider override repo=%s issue=%d provider=%s source=label", target.Repo, next.Number, selectedProvider)
+				}
+
 				wt, err := worktree.CreateIssueWorktree(ctx, a.env.Runner, *target, next.Number, next.Title)
 				if err != nil {
-					session := blockedIssueSessionForDispatchFailure(*target, next, err, a.clock())
+					session := blockedIssueSessionForDispatchFailure(*target, next, selectedProvider, err, a.clock())
 					a.state.AppendDaemonLog("scan repo dispatch blocked repo=%s issue=%d err=%v", target.Repo, next.Number, err)
 					sessions = upsertSession(sessions, session)
 					if err := a.state.SaveSessions(sessions); err != nil {
@@ -450,7 +460,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 				session := state.Session{
 					RepoPath:        target.Path,
 					Repo:            target.Repo,
-					Provider:        target.Provider,
+					Provider:        selectedProvider,
 					IssueNumber:     next.Number,
 					IssueTitle:      next.Title,
 					IssueURL:        next.URL,
@@ -1177,11 +1187,27 @@ func summarizeText(text string) string {
 	return text
 }
 
-func blockedIssueSessionForDispatchFailure(target state.WatchTarget, issue ghcli.Issue, err error, now time.Time) state.Session {
+func resolveIssueProvider(target state.WatchTarget, issue ghcli.Issue) (string, error) {
+	selected := strings.TrimSpace(target.Provider)
+	if selected == "" {
+		selected = provider.DefaultID
+	}
+
+	override, err := provider.ResolveIssueLabel(issue.Labels)
+	if err != nil {
+		return "", fmt.Errorf("issue #%d has conflicting provider labels: %w", issue.Number, err)
+	}
+	if override == "" {
+		return selected, nil
+	}
+	return override, nil
+}
+
+func blockedIssueSessionForDispatchFailure(target state.WatchTarget, issue ghcli.Issue, selectedProvider string, err error, now time.Time) state.Session {
 	session := state.Session{
 		RepoPath:     target.Path,
 		Repo:         target.Repo,
-		Provider:     target.Provider,
+		Provider:     selectedProvider,
 		IssueNumber:  issue.Number,
 		IssueTitle:   issue.Title,
 		IssueURL:     issue.URL,

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -400,6 +400,57 @@ func TestScanOnceSelectsEligibleIssueAndPersistsSession(t *testing.T) {
 	}
 }
 
+func TestScanOnceUsesProviderLabelOverrideForSession(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	branch := "vigilante/issue-1-first"
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[{"name":"codex"}]}]`,
+			"git worktree prune": "ok",
+			"git worktree add -b " + branch + " " + worktreePath + " main":                                                         "ok",
+			sessionStartCommentCommand("owner/repo", 1, worktreePath, branch):                                                      "ok",
+			issuePromptCommand(worktreePath, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", branch): "done",
+		},
+		Errors: map[string]error{
+			"git show-ref --verify --quiet refs/heads/" + branch:         errors.New("exit status 1"),
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": errors.New("exit status 1"),
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: repoPath, Repo: "owner/repo", Branch: "main", Assignee: "me", Provider: "claude"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	app.waitForSessions()
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if sessions[0].Provider != "codex" {
+		t.Fatalf("expected issue label override to persist codex provider: %#v", sessions[0])
+	}
+}
+
 func TestScanOncePrintsNoEligibleIssues(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -42,6 +42,32 @@ var registry = map[string]Provider{
 	DefaultID: codexProvider{},
 }
 
+func RegisteredIDs() []string {
+	ids := make([]string, 0, len(registry))
+	for id := range registry {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func ResolveIssueLabel(labels []ghcli.Label) (string, error) {
+	matches := make([]string, 0, len(registry))
+	for _, providerID := range RegisteredIDs() {
+		if ghcli.HasAnyLabel(labels, providerID) {
+			matches = append(matches, providerID)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return "", nil
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf("multiple provider labels: %s", strings.Join(matches, ", "))
+	}
+}
+
 func Resolve(id string) (Provider, error) {
 	resolved := strings.TrimSpace(id)
 	if resolved == "" {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,6 +1,11 @@
 package provider
 
-import "testing"
+import (
+	"testing"
+
+	ghcli "github.com/nicobistolfi/vigilante/internal/github"
+	"github.com/nicobistolfi/vigilante/internal/state"
+)
 
 func TestResolveDefaultsToCodex(t *testing.T) {
 	selectedProvider, err := Resolve("")
@@ -27,4 +32,70 @@ func TestRequiredToolsetIncludesSharedAndProviderTools(t *testing.T) {
 			t.Fatalf("unexpected toolset: %#v", got)
 		}
 	}
+}
+
+func TestResolveIssueLabelUsesRegisteredProviderIDs(t *testing.T) {
+	original := registry
+	registry = map[string]Provider{
+		DefaultID: codexProvider{},
+		"cursor":  testProvider{id: "cursor"},
+	}
+	t.Cleanup(func() {
+		registry = original
+	})
+
+	selected, err := ResolveIssueLabel([]ghcli.Label{{Name: "cursor"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selected != "cursor" {
+		t.Fatalf("unexpected provider label match: %q", selected)
+	}
+}
+
+func TestResolveIssueLabelRejectsConflictingProviderLabels(t *testing.T) {
+	original := registry
+	registry = map[string]Provider{
+		DefaultID: codexProvider{},
+		"cursor":  testProvider{id: "cursor"},
+	}
+	t.Cleanup(func() {
+		registry = original
+	})
+
+	_, err := ResolveIssueLabel([]ghcli.Label{{Name: DefaultID}, {Name: "cursor"}})
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	if got := err.Error(); got != "multiple provider labels: codex, cursor" {
+		t.Fatalf("unexpected conflict error: %s", got)
+	}
+}
+
+type testProvider struct {
+	id string
+}
+
+func (p testProvider) ID() string {
+	return p.id
+}
+
+func (p testProvider) DisplayName() string {
+	return p.id
+}
+
+func (p testProvider) RequiredTools() []string {
+	return nil
+}
+
+func (p testProvider) EnsureRuntimeInstalled(store *state.Store) error {
+	return nil
+}
+
+func (p testProvider) BuildIssueInvocation(task IssueTask) (Invocation, error) {
+	return Invocation{}, nil
+}
+
+func (p testProvider) BuildConflictResolutionInvocation(task ConflictTask) (Invocation, error) {
+	return Invocation{}, nil
 }


### PR DESCRIPTION
## Summary
- resolve issue-level provider overrides from registered provider ids instead of a hard-coded label map
- persist the selected provider on new sessions and skip dispatch when conflicting provider labels are present
- document the provider-label contract and cover the new behavior with provider and app tests

## Validation
- go test ./...
- go build ./...

Closes #60