### PR TITLE
Require baseline preflight before issue implementation

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1056,6 +1056,22 @@ func (a *App) resumeBlockedIssueExecution(ctx context.Context, session *state.Se
 	if err != nil {
 		return err
 	}
+	if session.BlockedStage == "baseline_preflight" {
+		preflightInvocation, err := selectedProvider.BuildIssuePreflightInvocation(provider.IssueTask{
+			Target:  target,
+			Issue:   issue,
+			Session: *session,
+		})
+		if err != nil {
+			return err
+		}
+		preflightOutput, err := a.env.Runner.Run(ctx, preflightInvocation.Dir, preflightInvocation.Name, preflightInvocation.Args...)
+		if err != nil {
+			a.state.AppendDaemonLog("resume issue preflight failed repo=%s issue=%d err=%v output=%s", session.Repo, session.IssueNumber, err, summarizeText(preflightOutput))
+			return err
+		}
+		a.state.AppendDaemonLog("resume issue preflight succeeded repo=%s issue=%d output=%s", session.Repo, session.IssueNumber, summarizeText(preflightOutput))
+	}
 	invocation, err := selectedProvider.BuildIssueInvocation(provider.IssueTask{
 		Target:  target,
 		Issue:   issue,
@@ -1223,11 +1239,11 @@ func classifyBlockedReason(stage string, operation string, err error) state.Bloc
 		reason.Kind = "provider_missing"
 	case strings.Contains(text, "worktree is not clean"):
 		reason.Kind = "dirty_worktree"
-	case strings.Contains(text, "go test") || strings.Contains(text, "validation"):
+	case strings.Contains(text, "go test") || strings.Contains(text, "validation") || strings.Contains(text, "build failed") || strings.Contains(text, "tests failed"):
 		reason.Kind = "validation_failed"
 	case strings.Contains(text, "network is unreachable") || strings.Contains(text, "timed out"):
 		reason.Kind = "network_unreachable"
-	case stage == "issue_execution" || stage == "conflict_resolution":
+	case stage == "issue_execution" || stage == "conflict_resolution" || stage == "baseline_preflight":
 		reason.Kind = "provider_runtime_error"
 	}
 	return reason

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -273,7 +273,7 @@ func TestScanOnceProcessesGitHubCommentResumeRequest(t *testing.T) {
 			"gh api repos/owner/repo/issues/1/comments": `[{"id":101,"body":"@vigilanteai resume","created_at":"2026-03-10T12:30:00Z","user":{"login":"nicobistolfi"}}]`,
 			"gh api --method POST -H Accept: application/vnd.github+json repos/owner/repo/issues/comments/101/reactions -f content=eyes": "{}",
 			"codex --version": "codex 1.0.0",
-			"codex exec --cd " + worktreePath + " --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: " + repoPath + "\nIssue: #1 - first\nIssue URL: https://github.com/owner/repo/issues/1\nWorktree path: " + worktreePath + "\nBranch: vigilante/issue-1\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nFor the coding-agent start comment, use `## 🕹️ Coding Agent Launched: Codex` instead of a generic session-start title.\nUse the same GitHub comment structure for every non-terminal milestone comment: a short header with the current stage and optional emoji, a 10-cell progress bar with percentage, an `ETA: ~N minutes` line, 1-3 concise bullets covering what just happened and what is next, and an optional short playful quote or tagline.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.": "done",
+			issuePromptCommand(worktreePath, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1"): "done",
 			"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
 				Stage:      "Recovered",
 				Emoji:      "🫡",
@@ -370,8 +370,8 @@ func TestScanOnceSelectsEligibleIssueAndPersistsSession(t *testing.T) {
 				},
 				Tagline: "Make it simple, but significant.",
 			}): "ok",
-			"codex exec --cd " + worktreePath + " --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: /tmp/repo\nIssue: #1 - first\nIssue URL: https://github.com/owner/repo/issues/1\nWorktree path: " + worktreePath + "\nBranch: " + branch + "\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.":                                                                                                                                                                                                                                                                                                                                                                                                                                                         "done",
-			"codex exec --cd " + worktreePath + " --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: /tmp/repo\nIssue: #1 - first\nIssue URL: https://github.com/owner/repo/issues/1\nWorktree path: " + worktreePath + "\nBranch: " + branch + "\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nFor the coding-agent start comment, use `## 🕹️ Coding Agent Launched: Codex` instead of a generic session-start title.\nUse the same GitHub comment structure for every non-terminal milestone comment: a short header with the current stage and optional emoji, a 10-cell progress bar with percentage, an `ETA: ~N minutes` line, 1-3 concise bullets covering what just happened and what is next, and an optional short playful quote or tagline.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.": "done",
+			preflightPromptCommand(worktreePath, "owner/repo", "/tmp/repo", 1, "first", "https://github.com/owner/repo/issues/1", branch): "baseline ok",
+			issuePromptCommand(worktreePath, "owner/repo", "/tmp/repo", 1, "first", "https://github.com/owner/repo/issues/1", branch):     "done",
 		},
 		Errors: map[string]error{
 			"git show-ref --verify --quiet refs/heads/" + branch:         errors.New("exit status 1"),
@@ -496,8 +496,8 @@ func TestScanOnceSkipsRedispatchForMaintainedIssueAndStartsNextEligibleIssue(t *
 				},
 				Tagline: "Make it simple, but significant.",
 			}): "ok",
-			"codex exec --cd " + worktreePath2 + " --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: " + repoPath + "\nIssue: #2 - second\nIssue URL: https://github.com/owner/repo/issues/2\nWorktree path: " + worktreePath2 + "\nBranch: " + branch2 + "\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.":                                                                                                                                                                                                                                                                                                                                                                                                                                                         "done",
-			"codex exec --cd " + worktreePath2 + " --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: " + repoPath + "\nIssue: #2 - second\nIssue URL: https://github.com/owner/repo/issues/2\nWorktree path: " + worktreePath2 + "\nBranch: " + branch2 + "\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nFor the coding-agent start comment, use `## 🕹️ Coding Agent Launched: Codex` instead of a generic session-start title.\nUse the same GitHub comment structure for every non-terminal milestone comment: a short header with the current stage and optional emoji, a 10-cell progress bar with percentage, an `ETA: ~N minutes` line, 1-3 concise bullets covering what just happened and what is next, and an optional short playful quote or tagline.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.": "done",
+			preflightPromptCommand(worktreePath2, "owner/repo", repoPath, 2, "second", "https://github.com/owner/repo/issues/2", branch2): "baseline ok",
+			issuePromptCommand(worktreePath2, "owner/repo", repoPath, 2, "second", "https://github.com/owner/repo/issues/2", branch2):     "done",
 		},
 		Errors: map[string]error{
 			"git show-ref --verify --quiet refs/heads/" + branch2:        errors.New("exit status 1"),
@@ -565,9 +565,10 @@ func TestScanOnceWithMaxParallelOnePreservesSerialBehavior(t *testing.T) {
 			"gh api user --jq .login": "nicobistolfi\n",
 			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]},{"number":2,"title":"second","createdAt":"2026-03-10T12:00:00Z","url":"https://github.com/owner/repo/issues/2","labels":[]}]`,
 			"git worktree prune": "ok",
-			"git worktree add -b vigilante/issue-1-first " + worktreePath1 + " main":                                                                   "ok",
-			sessionStartCommentCommand("owner/repo", 1, worktreePath1, "vigilante/issue-1-first"):                                                      "ok",
-			issuePromptCommand(worktreePath1, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1-first"): "done",
+			"git worktree add -b vigilante/issue-1-first " + worktreePath1 + " main":                                                                       "ok",
+			sessionStartCommentCommand("owner/repo", 1, worktreePath1, "vigilante/issue-1-first"):                                                          "ok",
+			preflightPromptCommand(worktreePath1, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1-first"): "baseline ok",
+			issuePromptCommand(worktreePath1, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1-first"):     "done",
 		},
 	}
 	if err := app.state.EnsureLayout(); err != nil {
@@ -613,12 +614,14 @@ func TestScanOnceStartsMultipleIssuesUpToConfiguredLimit(t *testing.T) {
 			"gh api user --jq .login": "nicobistolfi\n",
 			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]},{"number":2,"title":"second","createdAt":"2026-03-10T12:00:00Z","url":"https://github.com/owner/repo/issues/2","labels":[]},{"number":3,"title":"third","createdAt":"2026-03-11T12:00:00Z","url":"https://github.com/owner/repo/issues/3","labels":[]}]`,
 			"git worktree prune": "ok",
-			"git worktree add -b vigilante/issue-1-first " + worktreePath1 + " main":                                                                     "ok",
-			"git worktree add -b vigilante/issue-2-second " + worktreePath2 + " main":                                                                    "ok",
-			sessionStartCommentCommand("owner/repo", 1, worktreePath1, "vigilante/issue-1-first"):                                                        "ok",
-			sessionStartCommentCommand("owner/repo", 2, worktreePath2, "vigilante/issue-2-second"):                                                       "ok",
-			issuePromptCommand(worktreePath1, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1-first"):   "done",
-			issuePromptCommand(worktreePath2, "owner/repo", repoPath, 2, "second", "https://github.com/owner/repo/issues/2", "vigilante/issue-2-second"): "done",
+			"git worktree add -b vigilante/issue-1-first " + worktreePath1 + " main":                                                                         "ok",
+			"git worktree add -b vigilante/issue-2-second " + worktreePath2 + " main":                                                                        "ok",
+			sessionStartCommentCommand("owner/repo", 1, worktreePath1, "vigilante/issue-1-first"):                                                            "ok",
+			sessionStartCommentCommand("owner/repo", 2, worktreePath2, "vigilante/issue-2-second"):                                                           "ok",
+			preflightPromptCommand(worktreePath1, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1-first"):   "baseline ok",
+			preflightPromptCommand(worktreePath2, "owner/repo", repoPath, 2, "second", "https://github.com/owner/repo/issues/2", "vigilante/issue-2-second"): "baseline ok",
+			issuePromptCommand(worktreePath1, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1-first"):       "done",
+			issuePromptCommand(worktreePath2, "owner/repo", repoPath, 2, "second", "https://github.com/owner/repo/issues/2", "vigilante/issue-2-second"):     "done",
 		},
 	}
 	if err := app.state.EnsureLayout(); err != nil {
@@ -733,9 +736,10 @@ func TestScanOnceBlocksFailedIssueDispatchAndContinuesToNextIssue(t *testing.T) 
 			"gh api user --jq .login": "nicobistolfi\n",
 			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]},{"number":2,"title":"second","createdAt":"2026-03-10T12:00:00Z","url":"https://github.com/owner/repo/issues/2","labels":[]}]`,
 			"git worktree prune": "ok",
-			"git worktree add -b " + branch2 + " " + worktreePath2 + " main":                                                          "ok",
-			sessionStartCommentCommand("owner/repo", 2, worktreePath2, branch2):                                                       "ok",
-			issuePromptCommand(worktreePath2, "owner/repo", repoPath, 2, "second", "https://github.com/owner/repo/issues/2", branch2): "done",
+			"git worktree add -b " + branch2 + " " + worktreePath2 + " main":                                                              "ok",
+			sessionStartCommentCommand("owner/repo", 2, worktreePath2, branch2):                                                           "ok",
+			preflightPromptCommand(worktreePath2, "owner/repo", repoPath, 2, "second", "https://github.com/owner/repo/issues/2", branch2): "baseline ok",
+			issuePromptCommand(worktreePath2, "owner/repo", repoPath, 2, "second", "https://github.com/owner/repo/issues/2", branch2):     "done",
 		},
 		Errors: map[string]error{
 			"git worktree add -b vigilante/issue-1-first " + worktreePath1 + " main": errors.New("exit status 1: worktree add failed"),
@@ -798,15 +802,18 @@ func TestScanOnceEnforcesLimitsIndependentlyAcrossRepositories(t *testing.T) {
 			"gh issue list --repo owner/repo-a --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first-a","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo-a/issues/1","labels":[]},{"number":2,"title":"second-a","createdAt":"2026-03-10T12:00:00Z","url":"https://github.com/owner/repo-a/issues/2","labels":[]}]`,
 			"gh issue list --repo owner/repo-b --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":10,"title":"first-b","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo-b/issues/10","labels":[]},{"number":11,"title":"second-b","createdAt":"2026-03-10T12:00:00Z","url":"https://github.com/owner/repo-b/issues/11","labels":[]}]`,
 			"git worktree prune": "ok",
-			"git worktree add -b vigilante/issue-1-first-a " + worktreeA1 + " main":                                                                              "ok",
-			"git worktree add -b vigilante/issue-2-second-a " + worktreeA2 + " main":                                                                             "ok",
-			"git worktree add -b vigilante/issue-10-first-b " + worktreeB10 + " main":                                                                            "ok",
-			sessionStartCommentCommand("owner/repo-a", 1, worktreeA1, "vigilante/issue-1-first-a"):                                                               "ok",
-			sessionStartCommentCommand("owner/repo-a", 2, worktreeA2, "vigilante/issue-2-second-a"):                                                              "ok",
-			sessionStartCommentCommand("owner/repo-b", 10, worktreeB10, "vigilante/issue-10-first-b"):                                                            "ok",
-			issuePromptCommand(worktreeA1, "owner/repo-a", repoPathA, 1, "first-a", "https://github.com/owner/repo-a/issues/1", "vigilante/issue-1-first-a"):     "done",
-			issuePromptCommand(worktreeA2, "owner/repo-a", repoPathA, 2, "second-a", "https://github.com/owner/repo-a/issues/2", "vigilante/issue-2-second-a"):   "done",
-			issuePromptCommand(worktreeB10, "owner/repo-b", repoPathB, 10, "first-b", "https://github.com/owner/repo-b/issues/10", "vigilante/issue-10-first-b"): "done",
+			"git worktree add -b vigilante/issue-1-first-a " + worktreeA1 + " main":                                                                                  "ok",
+			"git worktree add -b vigilante/issue-2-second-a " + worktreeA2 + " main":                                                                                 "ok",
+			"git worktree add -b vigilante/issue-10-first-b " + worktreeB10 + " main":                                                                                "ok",
+			sessionStartCommentCommand("owner/repo-a", 1, worktreeA1, "vigilante/issue-1-first-a"):                                                                   "ok",
+			sessionStartCommentCommand("owner/repo-a", 2, worktreeA2, "vigilante/issue-2-second-a"):                                                                  "ok",
+			sessionStartCommentCommand("owner/repo-b", 10, worktreeB10, "vigilante/issue-10-first-b"):                                                                "ok",
+			preflightPromptCommand(worktreeA1, "owner/repo-a", repoPathA, 1, "first-a", "https://github.com/owner/repo-a/issues/1", "vigilante/issue-1-first-a"):     "baseline ok",
+			preflightPromptCommand(worktreeA2, "owner/repo-a", repoPathA, 2, "second-a", "https://github.com/owner/repo-a/issues/2", "vigilante/issue-2-second-a"):   "baseline ok",
+			preflightPromptCommand(worktreeB10, "owner/repo-b", repoPathB, 10, "first-b", "https://github.com/owner/repo-b/issues/10", "vigilante/issue-10-first-b"): "baseline ok",
+			issuePromptCommand(worktreeA1, "owner/repo-a", repoPathA, 1, "first-a", "https://github.com/owner/repo-a/issues/1", "vigilante/issue-1-first-a"):         "done",
+			issuePromptCommand(worktreeA2, "owner/repo-a", repoPathA, 2, "second-a", "https://github.com/owner/repo-a/issues/2", "vigilante/issue-2-second-a"):       "done",
+			issuePromptCommand(worktreeB10, "owner/repo-b", repoPathB, 10, "first-b", "https://github.com/owner/repo-b/issues/10", "vigilante/issue-10-first-b"):     "done",
 		},
 	}
 	if err := app.state.EnsureLayout(); err != nil {
@@ -857,9 +864,10 @@ func TestScanOnceContinuesWhenOneRepositoryScanFails(t *testing.T) {
 			"gh api user --jq .login": "nicobistolfi\n",
 			"gh issue list --repo owner/repo-b --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":10,"title":"first-b","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo-b/issues/10","labels":[]}]`,
 			"git worktree prune": "ok",
-			"git worktree add -b " + branchB10 + " " + worktreeB10 + " main":                                                                  "ok",
-			sessionStartCommentCommand("owner/repo-b", 10, worktreeB10, branchB10):                                                            "ok",
-			issuePromptCommand(worktreeB10, "owner/repo-b", repoPathB, 10, "first-b", "https://github.com/owner/repo-b/issues/10", branchB10): "done",
+			"git worktree add -b " + branchB10 + " " + worktreeB10 + " main":                                                                      "ok",
+			sessionStartCommentCommand("owner/repo-b", 10, worktreeB10, branchB10):                                                                "ok",
+			preflightPromptCommand(worktreeB10, "owner/repo-b", repoPathB, 10, "first-b", "https://github.com/owner/repo-b/issues/10", branchB10): "baseline ok",
+			issuePromptCommand(worktreeB10, "owner/repo-b", repoPathB, 10, "first-b", "https://github.com/owner/repo-b/issues/10", branchB10):     "done",
 		},
 		Errors: map[string]error{
 			"gh issue list --repo owner/repo-a --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": errors.New("gh auth status failed"),
@@ -1183,8 +1191,8 @@ func TestScanOnceRecoversStalledSessionAndRedispatchesIssue(t *testing.T) {
 				},
 				Tagline: "Make it simple, but significant.",
 			}): "ok",
-			"codex exec --cd " + worktreePath + " --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: " + filepath.Join(home, "repo") + "\nIssue: #1 - first\nIssue URL: https://github.com/owner/repo/issues/1\nWorktree path: " + worktreePath + "\nBranch: " + branch + "\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.":                                                                                                                                                                                                                                                                                                                                                                                                                                                         "done",
-			"codex exec --cd " + worktreePath + " --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: " + filepath.Join(home, "repo") + "\nIssue: #1 - first\nIssue URL: https://github.com/owner/repo/issues/1\nWorktree path: " + worktreePath + "\nBranch: " + branch + "\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nFor the coding-agent start comment, use `## 🕹️ Coding Agent Launched: Codex` instead of a generic session-start title.\nUse the same GitHub comment structure for every non-terminal milestone comment: a short header with the current stage and optional emoji, a 10-cell progress bar with percentage, an `ETA: ~N minutes` line, 1-3 concise bullets covering what just happened and what is next, and an optional short playful quote or tagline.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.": "done",
+			preflightPromptCommand(worktreePath, "owner/repo", filepath.Join(home, "repo"), 1, "first", "https://github.com/owner/repo/issues/1", branch): "baseline ok",
+			issuePromptCommand(worktreePath, "owner/repo", filepath.Join(home, "repo"), 1, "first", "https://github.com/owner/repo/issues/1", branch):     "done",
 		},
 		Errors: map[string]error{
 			"git show-ref --verify --quiet refs/heads/" + branch:         errors.New("exit status 1"),
@@ -1331,5 +1339,17 @@ func sessionStartCommentCommand(repo string, issueNumber int, worktreePath strin
 }
 
 func issuePromptCommand(worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, branch string) string {
-	return "codex exec --cd " + worktreePath + " --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: " + repo + "\nLocal repository path: " + repoPath + "\nIssue: #" + fmt.Sprintf("%d", issueNumber) + " - " + title + "\nIssue URL: " + issueURL + "\nWorktree path: " + worktreePath + "\nBranch: " + branch + "\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nFor the coding-agent start comment, use `## 🕹️ Coding Agent Launched: Codex` instead of a generic session-start title.\nUse the same GitHub comment structure for every non-terminal milestone comment: a short header with the current stage and optional emoji, a 10-cell progress bar with percentage, an `ETA: ~N minutes` line, 1-3 concise bullets covering what just happened and what is next, and an optional short playful quote or tagline.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal."
+	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePrompt(
+		state.WatchTarget{Path: repoPath, Repo: repo},
+		ghcli.Issue{Number: issueNumber, Title: title, URL: issueURL},
+		state.Session{WorktreePath: worktreePath, Branch: branch, Provider: "codex"},
+	))
+}
+
+func preflightPromptCommand(worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, branch string) string {
+	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePreflightPrompt(
+		state.WatchTarget{Path: repoPath, Repo: repo},
+		ghcli.Issue{Number: issueNumber, Title: title, URL: issueURL},
+		state.Session{WorktreePath: worktreePath, Branch: branch},
+	))
 }

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -23,6 +23,18 @@ func (codexProvider) EnsureRuntimeInstalled(store *state.Store) error {
 	return skill.EnsureInstalled(store.CodexHome())
 }
 
+func (codexProvider) BuildIssuePreflightInvocation(task IssueTask) (Invocation, error) {
+	return Invocation{
+		Name: "codex",
+		Args: []string{
+			"exec",
+			"--cd", task.Session.WorktreePath,
+			"--dangerously-bypass-approvals-and-sandbox",
+			skill.BuildIssuePreflightPrompt(task.Target, task.Issue, task.Session),
+		},
+	}, nil
+}
+
 func (codexProvider) BuildIssueInvocation(task IssueTask) (Invocation, error) {
 	return Invocation{
 		Name: "codex",

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -34,6 +34,7 @@ type Provider interface {
 	DisplayName() string
 	RequiredTools() []string
 	EnsureRuntimeInstalled(store *state.Store) error
+	BuildIssuePreflightInvocation(task IssueTask) (Invocation, error)
 	BuildIssueInvocation(task IssueTask) (Invocation, error)
 	BuildConflictResolutionInvocation(task ConflictTask) (Invocation, error)
 }

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -55,6 +55,42 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 		return session
 	}
 
+	preflightInvocation, err := selectedProvider.BuildIssuePreflightInvocation(provider.IssueTask{Target: target, Issue: issue, Session: session})
+	if err != nil {
+		session.Status = state.SessionStatusFailed
+		session.LastError = err.Error()
+		session.EndedAt = time.Now().UTC().Format(time.RFC3339)
+		session.LastHeartbeatAt = session.EndedAt
+		session.UpdatedAt = session.EndedAt
+		appendSessionLog(logPath, "issue preflight invocation build failed", session, err.Error())
+		return session
+	}
+	preflightOutput, err := env.Runner.Run(ctx, preflightInvocation.Dir, preflightInvocation.Name, preflightInvocation.Args...)
+	if err != nil {
+		blocked := classifyBlockedFailure("baseline_preflight", preflightInvocation.Name, preflightOutput, err)
+		markSessionBlocked(&session, "baseline_preflight", blocked, time.Now().UTC())
+		session.LastError = err.Error()
+		session.EndedAt = time.Now().UTC().Format(time.RFC3339)
+		session.LastHeartbeatAt = session.EndedAt
+		session.UpdatedAt = session.EndedAt
+		appendSessionLog(logPath, "issue preflight failed", session, combineLogDetails(preflightOutput, err.Error()))
+		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+			Stage:      "Blocked",
+			Emoji:      "🧱",
+			Percent:    25,
+			ETAMinutes: 15,
+			Items: []string{
+				"Repository baseline validation failed before issue implementation began.",
+				fmt.Sprintf("Cause class: `%s`.", blocked.Kind),
+				fmt.Sprintf("Next step: restore the repository baseline, then run `%s` or request resume from GitHub.", session.ResumeHint),
+			},
+			Tagline: "Strong foundations make calm debugging sessions.",
+		})
+		_ = ghcli.CommentOnIssue(ctx, env.Runner, target.Repo, issue.Number, body)
+		return session
+	}
+	appendSessionLog(logPath, "issue preflight succeeded", session, preflightOutput)
+
 	invocation, err := selectedProvider.BuildIssueInvocation(provider.IssueTask{Target: target, Issue: issue, Session: session})
 	if err != nil {
 		session.Status = state.SessionStatusFailed
@@ -70,7 +106,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 	session.LastHeartbeatAt = session.EndedAt
 	session.UpdatedAt = session.EndedAt
 	if err != nil {
-		blocked := classifyBlockedFailure("issue_execution", "codex exec", output, err)
+		blocked := classifyBlockedFailure("issue_execution", invocation.Name, output, err)
 		markSessionBlocked(&session, "issue_execution", blocked, time.Now().UTC())
 		session.LastError = err.Error()
 		appendSessionLog(logPath, "session failed", session, combineLogDetails(output, err.Error()))
@@ -113,7 +149,7 @@ func RunConflictResolutionSession(ctx context.Context, env *environment.Environm
 	output, err := env.Runner.Run(ctx, invocation.Dir, invocation.Name, invocation.Args...)
 	if err != nil {
 		appendSessionLog(logPath, "conflict resolution failed", session, combineLogDetails(output, err.Error()))
-		blocked := classifyBlockedFailure("conflict_resolution", "codex exec", output, err)
+		blocked := classifyBlockedFailure("conflict_resolution", invocation.Name, output, err)
 		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
 			Stage:      "Blocked",
 			Emoji:      "🧯",
@@ -177,11 +213,11 @@ func classifyBlockedFailure(stage string, operation string, output string, err e
 		reason.Kind = "provider_missing"
 	case strings.Contains(text, "worktree is not clean"):
 		reason.Kind = "dirty_worktree"
-	case strings.Contains(text, "go test") || strings.Contains(text, "validation"):
+	case strings.Contains(text, "go test") || strings.Contains(text, "validation") || strings.Contains(text, "build failed") || strings.Contains(text, "tests failed"):
 		reason.Kind = "validation_failed"
 	case strings.Contains(text, "network is unreachable") || strings.Contains(text, "timed out"):
 		reason.Kind = "network_unreachable"
-	case strings.Contains(strings.ToLower(stage), "issue") || strings.Contains(strings.ToLower(stage), "conflict"):
+	case strings.Contains(strings.ToLower(stage), "issue") || strings.Contains(strings.ToLower(stage), "conflict") || strings.Contains(strings.ToLower(stage), "preflight"):
 		reason.Kind = "provider_runtime_error"
 	}
 	if reason.Detail == "" {

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/nicobistolfi/vigilante/internal/environment"
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
+	"github.com/nicobistolfi/vigilante/internal/skill"
 	"github.com/nicobistolfi/vigilante/internal/state"
 	"github.com/nicobistolfi/vigilante/internal/testutil"
 )
@@ -32,7 +33,8 @@ func TestRunIssueSessionSuccess(t *testing.T) {
 				},
 				Tagline: "Make it simple, but significant.",
 			}): "ok",
-			"codex exec --cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: /tmp/repo\nIssue: #7 - Demo\nIssue URL: https://github.com/owner/repo/issues/7\nWorktree path: /tmp/worktree\nBranch: vigilante/issue-7\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nFor the coding-agent start comment, use `## 🕹️ Coding Agent Launched: Codex` instead of a generic session-start title.\nUse the same GitHub comment structure for every non-terminal milestone comment: a short header with the current stage and optional emoji, a 10-cell progress bar with percentage, an `ETA: ~N minutes` line, 1-3 concise bullets covering what just happened and what is next, and an optional short playful quote or tagline.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.": "done",
+			preflightPromptCommand("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", "vigilante/issue-7"): "baseline ok",
+			issuePromptCommand("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", "vigilante/issue-7"):     "done",
 		},
 	}
 	env := &environment.Environment{OS: "darwin", Runner: runner}
@@ -73,19 +75,19 @@ func TestRunIssueSessionFailureCommentsOnIssue(t *testing.T) {
 			}): "ok",
 			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
 				Stage:      "Blocked",
-				Emoji:      "🛑",
-				Percent:    95,
-				ETAMinutes: 10,
+				Emoji:      "🧱",
+				Percent:    25,
+				ETAMinutes: 15,
 				Items: []string{
-					"Codex execution stopped before the issue implementation completed.",
-					"Cause class: `provider_runtime_error`.",
-					"Next step: fix the blocker, then run `vigilante resume --repo owner/repo --issue 7` or request resume from GitHub.",
+					"Repository baseline validation failed before issue implementation began.",
+					"Cause class: `validation_failed`.",
+					"Next step: restore the repository baseline, then run `vigilante resume --repo owner/repo --issue 7` or request resume from GitHub.",
 				},
-				Tagline: "Plans are only good intentions unless they immediately degenerate into hard work.",
+				Tagline: "Strong foundations make calm debugging sessions.",
 			}): "ok",
 		},
 		Errors: map[string]error{
-			"codex exec --cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: /tmp/repo\nIssue: #7 - Demo\nIssue URL: https://github.com/owner/repo/issues/7\nWorktree path: /tmp/worktree\nBranch: vigilante/issue-7\nUse `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.\nFor the coding-agent start comment, use `## 🕹️ Coding Agent Launched: Codex` instead of a generic session-start title.\nUse the same GitHub comment structure for every non-terminal milestone comment: a short header with the current stage and optional emoji, a 10-cell progress bar with percentage, an `ETA: ~N minutes` line, 1-3 concise bullets covering what just happened and what is next, and an optional short playful quote or tagline.\nUse the issue as the source of truth for the requested behavior and keep the implementation minimal.": errors.New("codex exec [--cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox prompt]: exit status 1"),
+			preflightPromptCommand("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", "vigilante/issue-7"): errors.New("baseline validation failed: go test ./... exit status 1"),
 		},
 	}
 	env := &environment.Environment{OS: "darwin", Runner: runner}
@@ -98,14 +100,14 @@ func TestRunIssueSessionFailureCommentsOnIssue(t *testing.T) {
 	if got.Status != state.SessionStatusBlocked {
 		t.Fatalf("unexpected status: %#v", got)
 	}
-	if !strings.Contains(got.LastError, "exit status 1") {
+	if !strings.Contains(got.LastError, "go test ./...") {
 		t.Fatalf("unexpected error: %#v", got)
 	}
 	data, err := os.ReadFile(store.SessionLogPath(7))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(data), "session failed") || !strings.Contains(string(data), "exit status 1") {
+	if !strings.Contains(string(data), "issue preflight failed") || !strings.Contains(string(data), "go test ./...") {
 		t.Fatalf("unexpected log: %s", string(data))
 	}
 }
@@ -181,4 +183,20 @@ func TestAppendSessionLogUsesLocalTimezone(t *testing.T) {
 	if strings.Contains(text, "Z] session started") {
 		t.Fatalf("expected local timezone log entry, got %q", text)
 	}
+}
+
+func preflightPromptCommand(worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, branch string) string {
+	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePreflightPrompt(
+		state.WatchTarget{Path: repoPath, Repo: repo},
+		ghcli.Issue{Number: issueNumber, Title: title, URL: issueURL},
+		state.Session{WorktreePath: worktreePath, Branch: branch},
+	))
+}
+
+func issuePromptCommand(worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, branch string) string {
+	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePrompt(
+		state.WatchTarget{Path: repoPath, Repo: repo},
+		ghcli.Issue{Number: issueNumber, Title: title, URL: issueURL},
+		state.Session{WorktreePath: worktreePath, Branch: branch, Provider: "codex"},
+	))
 }

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -60,6 +60,24 @@ func BuildIssuePrompt(target state.WatchTarget, issue ghcli.Issue, session state
 	return strings.Join(lines, "\n")
 }
 
+func BuildIssuePreflightPrompt(target state.WatchTarget, issue ghcli.Issue, session state.Session) string {
+	lines := []string{
+		fmt.Sprintf("Repository: %s", target.Repo),
+		fmt.Sprintf("Local repository path: %s", target.Path),
+		fmt.Sprintf("Issue: #%d - %s", issue.Number, issue.Title),
+		fmt.Sprintf("Issue URL: %s", issue.URL),
+		fmt.Sprintf("Worktree path: %s", session.WorktreePath),
+		fmt.Sprintf("Branch: %s", session.Branch),
+		fmt.Sprintf("Before implementing issue #%d, validate the repository baseline from the current `main`-derived worktree without making any file changes.", issue.Number),
+		"Detect and run the appropriate build or equivalent verification command for this repository.",
+		"Detect and run the existing test suite when tests are present; if no tests exist, state that clearly and continue.",
+		"If the baseline build or tests fail, exit with a non-zero status and summarize the failing validation in the final output.",
+		"If the baseline is healthy, exit successfully with a short summary of the commands you validated.",
+		"Do not implement the issue, do not modify files, do not commit, and do not comment on GitHub during this preflight.",
+	}
+	return strings.Join(lines, "\n")
+}
+
 func displayProviderName(name string) string {
 	name = strings.TrimSpace(name)
 	if name == "" {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -140,6 +140,18 @@ func TestBuildIssuePrompt(t *testing.T) {
 	}
 }
 
+func TestBuildIssuePreflightPrompt(t *testing.T) {
+	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
+	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
+	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
+	prompt := BuildIssuePreflightPrompt(target, issue, session)
+	for _, text := range []string{"Repository: owner/repo", "Issue: #12 - Fix bug", "`main`-derived worktree", "build or equivalent verification command", "existing test suite", "Do not implement the issue", "do not comment on GitHub"} {
+		if !strings.Contains(prompt, text) {
+			t.Fatalf("prompt missing %q: %s", text, prompt)
+		}
+	}
+}
+
 func TestBuildConflictResolutionPrompt(t *testing.T) {
 	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
 	session := state.Session{IssueNumber: 12, IssueTitle: "Fix bug", IssueURL: "https://example.com/issues/12", WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12"}


### PR DESCRIPTION
## Summary
- add a provider-driven issue preflight invocation that validates the repository baseline before implementation starts
- block sessions on a distinct `baseline_preflight` stage and rerun that preflight on resume when needed
- expand startup tests to cover the new preflight path and baseline failure behavior

## Validation
- `go test ./...`

Closes #62.
