### PR TITLE
Count only active sessions toward dispatch concurrency

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -493,7 +493,7 @@ func TestScanOncePrintsNoEligibleIssues(t *testing.T) {
 	}
 }
 
-func TestScanOnceSkipsRedispatchForMaintainedIssueAndStartsNextEligibleIssue(t *testing.T) {
+func TestScanOnceMaintainedIssueDoesNotConsumeOnlyDispatchSlot(t *testing.T) {
 	home := t.TempDir()
 	repoPath := filepath.Join(home, "repo")
 	worktreePath1 := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
@@ -558,7 +558,7 @@ func TestScanOnceSkipsRedispatchForMaintainedIssueAndStartsNextEligibleIssue(t *
 	if err := app.state.EnsureLayout(); err != nil {
 		t.Fatal(err)
 	}
-	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: repoPath, Repo: "owner/repo", Branch: "main", Assignee: "me", Labels: []string{"to-do"}, MaxParallel: 2}}); err != nil {
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: repoPath, Repo: "owner/repo", Branch: "main", Assignee: "me", Labels: []string{"to-do"}, MaxParallel: 1}}); err != nil {
 		t.Fatal(err)
 	}
 	if err := app.state.SaveSessions([]state.Session{{

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -97,7 +97,7 @@ func SelectIssues(issues []Issue, sessions []state.Session, target state.WatchTa
 
 	active := map[int]bool{}
 	for _, session := range sessions {
-		if session.Repo == target.Repo && sessionBlocksRedispatch(session) {
+		if session.Repo == target.Repo && sessionPreventsRedispatch(session) {
 			active[session.IssueNumber] = true
 		}
 	}
@@ -122,15 +122,15 @@ func SelectIssues(issues []Issue, sessions []state.Session, target state.WatchTa
 func ActiveSessionCount(sessions []state.Session, target state.WatchTarget) int {
 	count := 0
 	for _, session := range sessions {
-		if session.Repo == target.Repo && sessionBlocksRedispatch(session) {
+		if session.Repo == target.Repo && sessionConsumesDispatchCapacity(session) {
 			count++
 		}
 	}
 	return count
 }
 
-func sessionBlocksRedispatch(session state.Session) bool {
-	if session.Status == state.SessionStatusRunning || session.Status == state.SessionStatusBlocked || session.Status == state.SessionStatusResuming {
+func sessionPreventsRedispatch(session state.Session) bool {
+	if sessionConsumesDispatchCapacity(session) || session.Status == state.SessionStatusBlocked {
 		return true
 	}
 	if session.Status != state.SessionStatusSuccess {
@@ -140,6 +140,10 @@ func sessionBlocksRedispatch(session state.Session) bool {
 		return false
 	}
 	return true
+}
+
+func sessionConsumesDispatchCapacity(session state.Session) bool {
+	return session.Status == state.SessionStatusRunning || session.Status == state.SessionStatusResuming
 }
 
 func matchesLabelAllowlist(issue Issue, allowlist []string) bool {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -102,15 +102,33 @@ func TestSelectIssuesHonorsRequestedLimit(t *testing.T) {
 	}
 }
 
-func TestActiveSessionCountIncludesOpenPullRequestMaintenance(t *testing.T) {
+func TestActiveSessionCountCountsOnlyActiveExecutionSessions(t *testing.T) {
 	count := ActiveSessionCount([]state.Session{
 		{Repo: "owner/repo", IssueNumber: 1, Status: state.SessionStatusRunning},
+		{Repo: "owner/repo", IssueNumber: 5, Status: state.SessionStatusResuming},
 		{Repo: "owner/repo", IssueNumber: 2, Status: state.SessionStatusSuccess, PullRequestState: "OPEN"},
+		{Repo: "owner/repo", IssueNumber: 6, Status: state.SessionStatusBlocked},
 		{Repo: "owner/repo", IssueNumber: 3, Status: state.SessionStatusSuccess, CleanupCompletedAt: "2026-03-10T15:00:00Z"},
 		{Repo: "owner/other", IssueNumber: 4, Status: state.SessionStatusRunning},
 	}, state.WatchTarget{Repo: "owner/repo"})
 	if count != 2 {
 		t.Fatalf("unexpected active session count: %d", count)
+	}
+}
+
+func TestSelectIssuesSkipsBlockedAndOpenPullRequestSessionsWithoutConsumingCapacity(t *testing.T) {
+	issues := []Issue{
+		{Number: 1, Labels: []Label{{Name: "to-do"}}},
+		{Number: 2, Labels: []Label{{Name: "to-do"}}},
+		{Number: 3, Labels: []Label{{Name: "to-do"}}},
+	}
+
+	selected := SelectIssues(issues, []state.Session{
+		{Repo: "owner/repo", IssueNumber: 1, Status: state.SessionStatusBlocked},
+		{Repo: "owner/repo", IssueNumber: 2, Status: state.SessionStatusSuccess, PullRequestState: "OPEN"},
+	}, state.WatchTarget{Repo: "owner/repo", Labels: []string{"to-do"}}, 2)
+	if len(selected) != 1 || selected[0].Number != 3 {
+		t.Fatalf("unexpected selected issues: %#v", selected)
 	}
 }
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -92,6 +92,10 @@ func (p testProvider) EnsureRuntimeInstalled(store *state.Store) error {
 	return nil
 }
 
+func (p testProvider) BuildIssuePreflightInvocation(task IssueTask) (Invocation, error) {
+	return Invocation{}, nil
+}
+
 func (p testProvider) BuildIssueInvocation(task IssueTask) (Invocation, error) {
 	return Invocation{}, nil
 }


### PR DESCRIPTION
## Summary
- count only running and resuming sessions toward dispatch concurrency
- keep blocked and open-PR success sessions non-redispatchable without consuming execution slots
- add scheduler tests for helper logic and `ScanOnce` behavior under `max_parallel=1`

## Validation
- `go test ./...`
- `go build ./...`

Closes #76.
