### PR TITLE
Add Gradle multi-project issue implementation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For each watched repository:
    - `git`
    - `gh`
    - the configured coding-agent provider CLI (`codex` or `claude`)
-4. Ensure the coding-agent issue implementation skill from `skills/vigilante-issue-implementation/` is installed during setup, including its companion agent metadata.
+4. Ensure the coding-agent issue implementation skills from `skills/` are installed during setup, including their companion agent metadata.
 5. Query GitHub for open issues.
 6. Determine which issues are eligible for execution.
 7. Create a git worktree for the selected issue.
@@ -168,6 +168,7 @@ Expected behavior:
 - verifies `git`, `gh`, and the selected coding-agent provider CLI
 - installs the bundled coding-agent skills for regular runtime use, including any companion files under each skill directory
   - `vigilante-issue-implementation`
+  - `vigilante-gradle-multi-project-issue-implementation`
   - `vigilante-conflict-resolution`
   - `vigilante-create-issue`
 - installs or updates the daemon definition when requested

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -14,6 +14,7 @@ import (
 )
 
 const VigilanteIssueImplementation = "vigilante-issue-implementation"
+const VigilanteGradleMultiProjectIssueImplementation = "vigilante-gradle-multi-project-issue-implementation"
 const VigilanteConflictResolution = "vigilante-conflict-resolution"
 const VigilanteCreateIssue = "vigilante-create-issue"
 
@@ -23,6 +24,7 @@ const RuntimeClaude = "claude"
 func VigilanteSkillNames() []string {
 	return []string{
 		VigilanteIssueImplementation,
+		VigilanteGradleMultiProjectIssueImplementation,
 		VigilanteConflictResolution,
 		VigilanteCreateIssue,
 	}
@@ -105,10 +107,11 @@ func BuildIssuePrompt(target state.WatchTarget, issue ghcli.Issue, session state
 
 func BuildIssuePromptForRuntime(runtime string, target state.WatchTarget, issue ghcli.Issue, session state.Session) string {
 	lines := []string{}
+	issueSkillName := issueImplementationSkillName(target.Path)
 	if strings.TrimSpace(runtime) == RuntimeClaude {
-		lines = append(lines, InlineSkillHeader(VigilanteIssueImplementation))
+		lines = append(lines, InlineSkillHeader(issueSkillName))
 	} else {
-		lines = append(lines, fmt.Sprintf("Use the `%s` skill for this task.", VigilanteIssueImplementation))
+		lines = append(lines, fmt.Sprintf("Use the `%s` skill for this task.", issueSkillName))
 	}
 	lines = append(lines,
 		fmt.Sprintf("Repository: %s", target.Repo),
@@ -123,6 +126,27 @@ func BuildIssuePromptForRuntime(runtime string, target state.WatchTarget, issue 
 		"Use the issue as the source of truth for the requested behavior and keep the implementation minimal.",
 	)
 	return strings.Join(lines, "\n")
+}
+
+func issueImplementationSkillName(repoPath string) string {
+	if isGradleMultiProjectRepo(repoPath) {
+		return VigilanteGradleMultiProjectIssueImplementation
+	}
+	return VigilanteIssueImplementation
+}
+
+func isGradleMultiProjectRepo(repoPath string) bool {
+	for _, name := range []string{"settings.gradle", "settings.gradle.kts"} {
+		body, err := os.ReadFile(filepath.Join(repoPath, name))
+		if err != nil {
+			continue
+		}
+		text := string(body)
+		if strings.Contains(text, "include(") || strings.Contains(text, "include ") || strings.Contains(text, "includeFlat(") {
+			return true
+		}
+	}
+	return false
 }
 
 func BuildIssuePreflightPrompt(target state.WatchTarget, issue ghcli.Issue, session state.Session) string {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -140,6 +140,44 @@ func TestBuildIssuePrompt(t *testing.T) {
 	}
 }
 
+func TestBuildIssuePromptUsesGradleMultiProjectSkillWhenSettingsIncludesSubprojects(t *testing.T) {
+	repoDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repoDir, "settings.gradle.kts"), []byte("include(\":api\", \":worker\")\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	target := state.WatchTarget{Path: repoDir, Repo: "owner/repo"}
+	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
+	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
+	prompt := BuildIssuePrompt(target, issue, session)
+
+	if !strings.Contains(prompt, "Use the `vigilante-gradle-multi-project-issue-implementation` skill") {
+		t.Fatalf("prompt missing gradle multi-project skill routing: %s", prompt)
+	}
+}
+
+func TestGradleMultiProjectSkillContentCoversScopedValidationAndDatabaseFlows(t *testing.T) {
+	skillDir := repoSkillDir(VigilanteGradleMultiProjectIssueImplementation)
+	body, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(body)
+	for _, needle := range []string{"selected subproject", "Gradle task scope", "docker-compose-launch", "Postgres", "MySQL"} {
+		if !strings.Contains(text, needle) {
+			t.Fatalf("gradle skill missing %q: %s", needle, text)
+		}
+	}
+
+	agentBody, err := os.ReadFile(filepath.Join(skillDir, "agents", "openai.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(agentBody), "docker-compose-launch") {
+		t.Fatalf("gradle skill agent metadata missing docker-compose-launch guidance: %s", string(agentBody))
+	}
+}
+
 func TestBuildIssuePreflightPrompt(t *testing.T) {
 	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
 	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}

--- a/skillassets.go
+++ b/skillassets.go
@@ -4,5 +4,5 @@ import "embed"
 
 // Skills contains built-in runtime skill files for installed binaries.
 //
-//go:embed skills/vigilante-issue-implementation skills/vigilante-conflict-resolution skills/vigilante-create-issue
+//go:embed skills/vigilante-issue-implementation skills/vigilante-gradle-multi-project-issue-implementation skills/vigilante-conflict-resolution skills/vigilante-create-issue
 var Skills embed.FS

--- a/skills/vigilante-gradle-multi-project-issue-implementation/SKILL.md
+++ b/skills/vigilante-gradle-multi-project-issue-implementation/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: vigilante-gradle-multi-project-issue-implementation
+description: Implement a GitHub issue end-to-end for Gradle multi-project repositories dispatched by Vigilante. Detect the relevant subproject scope, use repo-defined Gradle tasks, start required database services with docker-compose-launch, and keep the issue updated with progress.
+---
+
+# Vigilante Gradle Multi-Project Issue Implementation
+
+## Overview
+Implement one GitHub issue from Vigilante dispatch through validated code changes, a pushed branch, and an opened pull request from the provided worktree. This skill is specific to Gradle multi-project repositories and should avoid JS workspace assumptions.
+
+## Workflow
+1. Confirm scope from the issue and repository docs
+- Read the issue text first and treat it as the source of truth.
+- Read `AGENTS.md`, `README.md`, and any area-specific docs that constrain the touched subprojects.
+
+2. Map the Gradle project shape before coding
+- Inspect `settings.gradle` or `settings.gradle.kts` to identify included subprojects.
+- Identify the smallest relevant Gradle subproject set for the issue and keep implementation scoped there unless shared build logic requires a broader change.
+- Log the selected subproject(s) and the Gradle task scope you plan to use in your progress updates.
+
+3. Use repo-defined Gradle commands
+- Prefer checked-in Gradle wrappers and existing repo tasks over guessed commands.
+- Run targeted Gradle tasks for the affected subproject(s) when possible, such as `:service:test` or `:app:check`, instead of whole-repo builds.
+- Only widen validation scope when the repo structure or changed files require it.
+
+4. Start required local services when tests or boot flows need them
+- If the affected service relies on local databases such as Postgres or MySQL, invoke `docker-compose-launch` before running the dependent validation or manual verification flow.
+- Use the repository's documented service profile or compose command instead of inventing one.
+
+5. Keep the standard Vigilante delivery contract
+- Comment on the GitHub issue when work starts, when the plan is ready, at meaningful milestones, on failures, and when the pull request is opened.
+- Push the assigned branch and open a pull request when implementation and validation are complete.
+
+## Guardrails
+- Stay inside the provided worktree.
+- Keep validation scoped to the relevant Gradle subproject(s) whenever possible.
+- Do not assume Android, JVM, or module naming conventions beyond what the repository already defines.
+- Do not skip `docker-compose-launch` when the repository depends on local database services for the touched flow.

--- a/skills/vigilante-gradle-multi-project-issue-implementation/agents/openai.yaml
+++ b/skills/vigilante-gradle-multi-project-issue-implementation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Vigilante Gradle Multi-Project Issue Implementation"
+  short_description: "Implement a Vigilante-dispatched GitHub issue in a Gradle multi-project repository with subproject-aware validation and database-service setup"
+  default_prompt: "Use $vigilante-gradle-multi-project-issue-implementation to implement the assigned issue in the provided Gradle multi-project worktree, keep validation scoped to the right subprojects, use docker-compose-launch when local databases are required, push the branch, open a PR, and comment progress or failures back to the linked GitHub issue."


### PR DESCRIPTION
## Summary
- add a bundled Gradle multi-project issue-implementation skill with subproject-scoped Gradle guidance and `docker-compose-launch` support
- route issue prompts to that skill when the assigned repository has `settings.gradle(.kts)` include markers
- cover skill installation/embed behavior and Gradle routing with tests

## Testing
- go test ./...

Closes #71
