### PR TITLE
Add running-session listing and cleanup flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,25 @@ Expected fields:
 - last scan time
 - active issue/session, if any
 
+### `vigilante list --running`
+
+Show currently running sessions with their repository, issue number, branch, and worktree path.
+
+### `vigilante cleanup --repo <owner/name> [--issue <n>]`
+
+Clean up running sessions without touching unrelated historical session records.
+
+Expected behavior:
+
+- `--repo <owner/name> --issue <n>` cleans up one running session for a single issue
+- `--repo <owner/name>` cleans up all running sessions for one repository
+- removes the running-session blockage from local state
+- removes the local worktree and issue branch when those artifacts are present and safe to delete
+
+### `vigilante cleanup --all`
+
+Clean up all running sessions across all watched repositories.
+
 ### `vigilante unwatch <path>`
 
 Remove a repository from the watchlist without deleting the repository itself.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -39,6 +39,8 @@ type App struct {
 
 	sessionMu sync.Mutex
 	sessionWG sync.WaitGroup
+	cancelMu  sync.Mutex
+	cancels   map[string]context.CancelFunc
 }
 
 type stringListFlag []string
@@ -59,10 +61,11 @@ func (f *stringListFlag) Set(value string) error {
 func New() *App {
 	store := state.NewStore()
 	return &App{
-		stdout: os.Stdout,
-		stderr: os.Stderr,
-		state:  store,
-		clock:  time.Now().UTC,
+		stdout:  os.Stdout,
+		stderr:  os.Stderr,
+		state:   store,
+		clock:   time.Now().UTC,
+		cancels: make(map[string]context.CancelFunc),
 		env: &environment.Environment{
 			OS: runtime.GOOS,
 			Runner: environment.LoggingRunner{
@@ -121,10 +124,16 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 		fs := flag.NewFlagSet("list", flag.ContinueOnError)
 		fs.SetOutput(a.stderr)
 		blockedOnly := fs.Bool("blocked", false, "show blocked sessions instead of watch targets")
+		runningOnly := fs.Bool("running", false, "show running sessions instead of watch targets")
 		if err := fs.Parse(args[1:]); err != nil {
 			return err
 		}
-		return a.List(*blockedOnly)
+		if *blockedOnly && *runningOnly {
+			return errors.New("usage: vigilante list [--blocked | --running]")
+		}
+		return a.List(*blockedOnly, *runningOnly)
+	case "cleanup":
+		return a.runCleanupCommand(ctx, args[1:])
 	case "resume":
 		return a.runResumeCommand(ctx, args[1:])
 	case "daemon":
@@ -153,6 +162,34 @@ func (a *App) runResumeCommand(ctx context.Context, args []string) error {
 		return errors.New("usage: vigilante resume --repo <owner/name> --issue <n>")
 	}
 	return a.ResumeSession(ctx, *repo, *issue, "cli")
+}
+
+func (a *App) runCleanupCommand(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("cleanup", flag.ContinueOnError)
+	fs.SetOutput(a.stderr)
+	repo := fs.String("repo", "", "repository slug")
+	issue := fs.Int("issue", 0, "issue number")
+	all := fs.Bool("all", false, "clean up all running sessions")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	switch {
+	case *all && (*repo != "" || *issue != 0):
+		return errors.New("usage: vigilante cleanup --all")
+	case *all:
+		return a.CleanupAllRunningSessions(ctx, "cli")
+	case *repo == "" && *issue == 0:
+		return errors.New("usage: vigilante cleanup --repo <owner/name> [--issue <n>]")
+	case *repo == "":
+		return errors.New("usage: vigilante cleanup --repo <owner/name> --issue <n>")
+	case *issue < 0:
+		return errors.New("issue number must be positive")
+	case *issue == 0:
+		return a.CleanupRepoRunningSessions(ctx, *repo, "cli")
+	default:
+		return a.CleanupSession(ctx, *repo, *issue, "cli")
+	}
 }
 
 func (a *App) runDaemonCommand(ctx context.Context, args []string) error {
@@ -318,12 +355,15 @@ func (a *App) Unwatch(rawPath string) error {
 	return nil
 }
 
-func (a *App) List(blockedOnly bool) error {
+func (a *App) List(blockedOnly bool, runningOnly bool) error {
 	if err := a.state.EnsureLayout(); err != nil {
 		return err
 	}
 	if blockedOnly {
 		return a.listBlockedSessions()
+	}
+	if runningOnly {
+		return a.listRunningSessions()
 	}
 	targets, err := a.state.LoadWatchTargets()
 	if err != nil {
@@ -383,6 +423,10 @@ func (a *App) ScanOnce(ctx context.Context) error {
 		a.sessionMu.Lock()
 		defer a.sessionMu.Unlock()
 		sessions, err := a.state.LoadSessions()
+		if err != nil {
+			return err
+		}
+		sessions, err = a.processGitHubCleanupRequests(ctx, sessions)
 		if err != nil {
 			return err
 		}
@@ -695,11 +739,18 @@ func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session
 }
 
 func (a *App) launchIssueSession(ctx context.Context, target state.WatchTarget, issue ghcli.Issue, session state.Session) {
+	runCtx, cancel := context.WithCancel(ctx)
+	key := sessionKey(session.Repo, session.IssueNumber)
+	a.cancelMu.Lock()
+	a.cancels[key] = cancel
+	a.cancelMu.Unlock()
+
 	a.sessionWG.Add(1)
 	go func() {
 		defer a.sessionWG.Done()
+		defer a.clearSessionCancel(key)
 
-		result := issuerunner.RunIssueSession(ctx, a.env, a.state, target, issue, session)
+		result := issuerunner.RunIssueSession(runCtx, a.env, a.state, target, issue, session)
 
 		a.sessionMu.Lock()
 		defer a.sessionMu.Unlock()
@@ -707,6 +758,10 @@ func (a *App) launchIssueSession(ctx context.Context, target state.WatchTarget, 
 		sessions, err := a.state.LoadSessions()
 		if err != nil {
 			a.state.AppendDaemonLog("session result load failed repo=%s issue=%d err=%v", target.Repo, issue.Number, err)
+			return
+		}
+		if existing, ok := findSession(sessions, target.Repo, issue.Number); ok && existing.LastCleanupSource != "" {
+			a.state.AppendDaemonLog("session result ignored after cleanup repo=%s issue=%d source=%s", target.Repo, issue.Number, existing.LastCleanupSource)
 			return
 		}
 		sessions = upsertSession(sessions, result)
@@ -821,6 +876,88 @@ func (a *App) listBlockedSessions() error {
 	return nil
 }
 
+func (a *App) listRunningSessions() error {
+	sessions, err := a.state.LoadSessions()
+	if err != nil {
+		return err
+	}
+	count := 0
+	for _, session := range sessions {
+		if session.Status != state.SessionStatusRunning {
+			continue
+		}
+		count++
+		fmt.Fprintf(a.stdout, "%s issue #%d  running\n", session.Repo, session.IssueNumber)
+		fmt.Fprintf(a.stdout, "  branch: %s\n", session.Branch)
+		fmt.Fprintf(a.stdout, "  worktree: %s\n", session.WorktreePath)
+		if session.StartedAt != "" {
+			fmt.Fprintf(a.stdout, "  started at: %s\n", session.StartedAt)
+		}
+	}
+	if count == 0 {
+		fmt.Fprintln(a.stdout, "no running sessions")
+	}
+	return nil
+}
+
+func (a *App) processGitHubCleanupRequests(ctx context.Context, sessions []state.Session) ([]state.Session, error) {
+	for i := range sessions {
+		session := &sessions[i]
+
+		comments, err := ghcli.ListIssueComments(ctx, a.env.Runner, session.Repo, session.IssueNumber)
+		if err != nil {
+			a.state.AppendDaemonLog("cleanup comment lookup failed repo=%s issue=%d err=%v", session.Repo, session.IssueNumber, err)
+			session.LastError = err.Error()
+			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			continue
+		}
+		comment := ghcli.FindCleanupComment(comments, session.LastCleanupCommentID)
+		if comment == nil {
+			continue
+		}
+		if err := ghcli.AddIssueCommentReaction(ctx, a.env.Runner, session.Repo, comment.ID, "+1"); err != nil {
+			a.state.AppendDaemonLog("cleanup reaction failed repo=%s issue=%d comment=%d err=%v", session.Repo, session.IssueNumber, comment.ID, err)
+			session.LastError = err.Error()
+			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			continue
+		}
+		session.LastCleanupCommentID = comment.ID
+		session.LastCleanupCommentAt = comment.CreatedAt.UTC().Format(time.RFC3339)
+
+		if session.Status != state.SessionStatusRunning {
+			session.LastCleanupSource = "comment"
+			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Cleanup Checked",
+				Emoji:      "🧭",
+				Percent:    100,
+				ETAMinutes: 1,
+				Items: []string{
+					"Received `@vigilanteai cleanup` for this issue.",
+					"No running Vigilante session matched the request, so there was nothing active to clean up.",
+					"Next step: run `vigilante list --running` locally if dispatch still looks blocked.",
+				},
+				Tagline: "Trust, but verify.",
+			})
+			if err := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); err != nil {
+				a.state.AppendDaemonLog("cleanup no-op comment failed repo=%s issue=%d comment=%d err=%v", session.Repo, session.IssueNumber, comment.ID, err)
+				session.LastError = err.Error()
+				session.UpdatedAt = a.clock().Format(time.RFC3339)
+			}
+			continue
+		}
+
+		cleanupErr := a.cleanupRunningSession(ctx, session, "comment")
+		body := cleanupResultComment(*session, cleanupErr)
+		if err := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); err != nil {
+			a.state.AppendDaemonLog("cleanup result comment failed repo=%s issue=%d comment=%d err=%v", session.Repo, session.IssueNumber, comment.ID, err)
+			session.LastError = err.Error()
+			session.UpdatedAt = a.clock().Format(time.RFC3339)
+		}
+	}
+	return sessions, nil
+}
+
 func (a *App) processGitHubResumeRequests(ctx context.Context, sessions []state.Session) ([]state.Session, error) {
 	for i := range sessions {
 		session := &sessions[i]
@@ -907,6 +1044,52 @@ func (a *App) ResumeAllBlocked(ctx context.Context) error {
 	return nil
 }
 
+func (a *App) CleanupAllRunningSessions(ctx context.Context, source string) error {
+	return a.cleanupSessions(ctx, source, "cleaned up %d running session(s)\n", func(session state.Session) bool {
+		return session.Status == state.SessionStatusRunning
+	})
+}
+
+func (a *App) CleanupRepoRunningSessions(ctx context.Context, repo string, source string) error {
+	return a.cleanupSessions(ctx, source, "cleaned up %d running session(s) in %s\n", func(session state.Session) bool {
+		return session.Status == state.SessionStatusRunning && session.Repo == repo
+	}, repo)
+}
+
+func (a *App) CleanupSession(ctx context.Context, repo string, issue int, source string) error {
+	if err := a.state.EnsureLayout(); err != nil {
+		return err
+	}
+
+	a.sessionMu.Lock()
+	defer a.sessionMu.Unlock()
+
+	sessions, err := a.state.LoadSessions()
+	if err != nil {
+		return err
+	}
+
+	found := false
+	for i := range sessions {
+		if sessions[i].Status != state.SessionStatusRunning || sessions[i].Repo != repo || sessions[i].IssueNumber != issue {
+			continue
+		}
+		if err := a.cleanupRunningSession(ctx, &sessions[i], source); err != nil {
+			return err
+		}
+		found = true
+		break
+	}
+	if !found {
+		return fmt.Errorf("running session not found for %s issue #%d", repo, issue)
+	}
+	if err := a.state.SaveSessions(sessions); err != nil {
+		return err
+	}
+	fmt.Fprintf(a.stdout, "cleaned up running session for %s issue #%d\n", repo, issue)
+	return nil
+}
+
 func (a *App) ResumeSession(ctx context.Context, repo string, issue int, source string) error {
 	if err := a.state.EnsureLayout(); err != nil {
 		return err
@@ -936,6 +1119,73 @@ func (a *App) ResumeSession(ctx context.Context, repo string, issue int, source 
 		return err
 	}
 	fmt.Fprintf(a.stdout, "resume attempted for %s issue #%d\n", repo, issue)
+	return nil
+}
+
+func (a *App) cleanupSessions(ctx context.Context, source string, successFormat string, match func(state.Session) bool, args ...any) error {
+	if err := a.state.EnsureLayout(); err != nil {
+		return err
+	}
+
+	a.sessionMu.Lock()
+	defer a.sessionMu.Unlock()
+
+	sessions, err := a.state.LoadSessions()
+	if err != nil {
+		return err
+	}
+
+	cleaned := 0
+	for i := range sessions {
+		if !match(sessions[i]) {
+			continue
+		}
+		if err := a.cleanupRunningSession(ctx, &sessions[i], source); err != nil {
+			return err
+		}
+		cleaned++
+	}
+	if cleaned == 0 {
+		if len(args) == 2 {
+			return fmt.Errorf("running session not found for %s issue #%d", args[0], args[1])
+		}
+		if len(args) == 1 {
+			return fmt.Errorf("no running sessions found for %s", args[0])
+		}
+		return errors.New("no running sessions found")
+	}
+	if err := a.state.SaveSessions(sessions); err != nil {
+		return err
+	}
+	fmt.Fprintf(a.stdout, successFormat, append([]any{cleaned}, args...)...)
+	return nil
+}
+
+func (a *App) cleanupRunningSession(ctx context.Context, session *state.Session, source string) error {
+	if session.Status != state.SessionStatusRunning {
+		return nil
+	}
+
+	a.cancelRunningSession(session.Repo, session.IssueNumber)
+
+	now := a.clock().Format(time.RFC3339)
+	err := worktree.CleanupIssueArtifacts(ctx, a.env.Runner, session.RepoPath, session.WorktreePath, session.Branch)
+	session.Status = state.SessionStatusFailed
+	session.ProcessID = 0
+	session.LastHeartbeatAt = ""
+	session.EndedAt = now
+	session.UpdatedAt = now
+	session.LastCleanupSource = source
+	session.LastError = fmt.Sprintf("cleanup requested via %s", source)
+	if err != nil {
+		session.CleanupError = err.Error()
+		session.LastError = fmt.Sprintf("cleanup requested via %s; artifact cleanup failed: %s", source, err)
+		a.state.AppendDaemonLog("running session cleanup failed repo=%s issue=%d source=%s branch=%s worktree=%s err=%v", session.Repo, session.IssueNumber, source, session.Branch, session.WorktreePath, err)
+		return nil
+	}
+	session.CleanupCompletedAt = now
+	session.CleanupError = ""
+	a.state.AppendDaemonLog("running session cleanup complete repo=%s issue=%d source=%s branch=%s worktree=%s", session.Repo, session.IssueNumber, source, session.Branch, session.WorktreePath)
 	return nil
 }
 
@@ -1316,11 +1566,70 @@ func blockedStateLabel(session state.Session) string {
 	}
 }
 
+func cleanupResultComment(session state.Session, cleanupErr error) string {
+	if cleanupErr == nil && session.CleanupError == "" {
+		return ghcli.FormatProgressComment(ghcli.ProgressComment{
+			Stage:      "Cleanup Completed",
+			Emoji:      "🧹",
+			Percent:    100,
+			ETAMinutes: 1,
+			Items: []string{
+				fmt.Sprintf("Removed the running Vigilante session for `%s`.", session.Branch),
+				fmt.Sprintf("Cleanup source: `%s`.", session.LastCleanupSource),
+				fmt.Sprintf("Local worktree artifacts were cleaned up at `%s` when present.", session.WorktreePath),
+			},
+			Tagline: "Leave no loose ends.",
+		})
+	}
+	return ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Cleanup Attempted",
+		Emoji:      "🛠️",
+		Percent:    100,
+		ETAMinutes: 1,
+		Items: []string{
+			fmt.Sprintf("Removed the running-session blockage for `%s`.", session.Branch),
+			fmt.Sprintf("Cleanup source: `%s`.", session.LastCleanupSource),
+			fmt.Sprintf("Local artifact cleanup still needs attention: `%s`.", summarizeMaintenanceError(errors.New(fallbackText(session.CleanupError, "unknown cleanup error")))),
+		},
+		Tagline: "Progress over paralysis.",
+	})
+}
+
 func fallbackText(value string, fallback string) string {
 	if strings.TrimSpace(value) == "" {
 		return fallback
 	}
 	return value
+}
+
+func sessionKey(repo string, issue int) string {
+	return fmt.Sprintf("%s#%d", repo, issue)
+}
+
+func (a *App) cancelRunningSession(repo string, issue int) {
+	key := sessionKey(repo, issue)
+	a.cancelMu.Lock()
+	cancel := a.cancels[key]
+	delete(a.cancels, key)
+	a.cancelMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (a *App) clearSessionCancel(key string) {
+	a.cancelMu.Lock()
+	delete(a.cancels, key)
+	a.cancelMu.Unlock()
+}
+
+func findSession(sessions []state.Session, repo string, issue int) (state.Session, bool) {
+	for _, session := range sessions {
+		if session.Repo == repo && session.IssueNumber == issue {
+			return session, true
+		}
+	}
+	return state.Session{}, false
 }
 
 func (a *App) ensureTooling(ctx context.Context, selectedProvider provider.Provider) error {
@@ -1340,7 +1649,9 @@ func (a *App) printUsage() {
 	fmt.Fprintln(a.stderr, "  vigilante setup [-d]")
 	fmt.Fprintln(a.stderr, "  vigilante watch [-d] [--label value] [--assignee value] [--max-parallel value] <path>")
 	fmt.Fprintln(a.stderr, "  vigilante unwatch <path>")
-	fmt.Fprintln(a.stderr, "  vigilante list [--blocked]")
+	fmt.Fprintln(a.stderr, "  vigilante list [--blocked | --running]")
+	fmt.Fprintln(a.stderr, "  vigilante cleanup --repo <owner/name> [--issue <n>]")
+	fmt.Fprintln(a.stderr, "  vigilante cleanup --all")
 	fmt.Fprintln(a.stderr, "  vigilante resume --repo <owner/name> --issue <n>")
 	fmt.Fprintln(a.stderr, "  vigilante resume --all-blocked")
 	fmt.Fprintln(a.stderr, "  vigilante daemon run [--once] [--interval duration]")

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -120,7 +120,7 @@ func TestWatchListAndUnwatch(t *testing.T) {
 	}
 
 	stdout.Reset()
-	if err := app.List(false); err != nil {
+	if err := app.List(false, false); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(stdout.String(), "\"repo\": \"nicobistolfi/vigilante\"") {
@@ -235,7 +235,7 @@ func TestListBlockedSessions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := app.List(true); err != nil {
+	if err := app.List(true, false); err != nil {
 		t.Fatal(err)
 	}
 	got := stdout.String()
@@ -248,6 +248,228 @@ func TestListBlockedSessions(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("expected blocked list output to contain %q, got: %s", want, got)
 		}
+	}
+}
+
+func TestListRunningSessions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{
+		{
+			Repo:         "owner/repo",
+			IssueNumber:  44,
+			Status:       state.SessionStatusRunning,
+			Branch:       "vigilante/issue-44",
+			WorktreePath: "/tmp/repo/.worktrees/vigilante/issue-44",
+			StartedAt:    "2026-03-11T13:20:13Z",
+		},
+		{
+			Repo:        "owner/repo",
+			IssueNumber: 45,
+			Status:      state.SessionStatusBlocked,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.List(false, true); err != nil {
+		t.Fatal(err)
+	}
+	got := stdout.String()
+	for _, want := range []string{
+		"owner/repo issue #44  running",
+		"branch: vigilante/issue-44",
+		"worktree: /tmp/repo/.worktrees/vigilante/issue-44",
+		"started at: 2026-03-11T13:20:13Z",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected running list output to contain %q, got: %s", want, got)
+		}
+	}
+	if strings.Contains(got, "issue #45") {
+		t.Fatalf("unexpected non-running session in output: %s", got)
+	}
+}
+
+func TestCleanupSessionByIssue(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-44")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"git worktree prune":                                          "ok",
+			"git worktree remove --force " + worktreePath:                 "ok",
+			"git worktree list --porcelain":                               "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-44": "ok",
+			"git branch -D vigilante/issue-44":                            "Deleted branch vigilante/issue-44\n",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:     repoPath,
+		Repo:         "owner/repo",
+		IssueNumber:  44,
+		Status:       state.SessionStatusRunning,
+		Branch:       "vigilante/issue-44",
+		WorktreePath: worktreePath,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.CleanupSession(context.Background(), "owner/repo", 44, "cli"); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if sessions[0].Status != state.SessionStatusFailed || sessions[0].CleanupCompletedAt == "" || sessions[0].LastCleanupSource != "cli" {
+		t.Fatalf("expected cleaned session metadata, got: %#v", sessions[0])
+	}
+	if sessions[0].CleanupError != "" {
+		t.Fatalf("unexpected cleanup error: %#v", sessions[0])
+	}
+	if got := stdout.String(); !strings.Contains(got, "cleaned up running session for owner/repo issue #44") {
+		t.Fatalf("unexpected output: %s", got)
+	}
+}
+
+func TestCleanupRepoRunningSessions(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	worktreePath1 := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	worktreePath2 := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-2")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	for _, path := range []string{worktreePath1, worktreePath2} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"git worktree prune":                                         "ok",
+			"git worktree remove --force " + worktreePath1:               "ok",
+			"git worktree remove --force " + worktreePath2:               "ok",
+			"git worktree list --porcelain":                              "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": "ok",
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-2": "ok",
+			"git branch -D vigilante/issue-1":                            "Deleted branch vigilante/issue-1\n",
+			"git branch -D vigilante/issue-2":                            "Deleted branch vigilante/issue-2\n",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{
+		{RepoPath: repoPath, Repo: "owner/repo", IssueNumber: 1, Status: state.SessionStatusRunning, Branch: "vigilante/issue-1", WorktreePath: worktreePath1},
+		{RepoPath: repoPath, Repo: "owner/repo", IssueNumber: 2, Status: state.SessionStatusRunning, Branch: "vigilante/issue-2", WorktreePath: worktreePath2},
+		{RepoPath: repoPath, Repo: "owner/other", IssueNumber: 3, Status: state.SessionStatusRunning, Branch: "vigilante/issue-3", WorktreePath: filepath.Join(repoPath, ".worktrees", "vigilante", "issue-3")},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.CleanupRepoRunningSessions(context.Background(), "owner/repo", "cli"); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions[0].Status != state.SessionStatusFailed || sessions[1].Status != state.SessionStatusFailed || sessions[2].Status != state.SessionStatusRunning {
+		t.Fatalf("unexpected cleanup result: %#v", sessions)
+	}
+	if got := stdout.String(); !strings.Contains(got, "cleaned up 2 running session(s) in owner/repo") {
+		t.Fatalf("unexpected output: %s", got)
+	}
+}
+
+func TestCleanupAllRunningSessions(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	worktreePath1 := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	worktreePath2 := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-2")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	for _, path := range []string{worktreePath1, worktreePath2} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"git worktree prune":                                         "ok",
+			"git worktree remove --force " + worktreePath1:               "ok",
+			"git worktree remove --force " + worktreePath2:               "ok",
+			"git worktree list --porcelain":                              "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": "ok",
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-2": "ok",
+			"git branch -D vigilante/issue-1":                            "Deleted branch vigilante/issue-1\n",
+			"git branch -D vigilante/issue-2":                            "Deleted branch vigilante/issue-2\n",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{
+		{RepoPath: repoPath, Repo: "owner/repo", IssueNumber: 1, Status: state.SessionStatusRunning, Branch: "vigilante/issue-1", WorktreePath: worktreePath1},
+		{RepoPath: repoPath, Repo: "owner/other", IssueNumber: 2, Status: state.SessionStatusRunning, Branch: "vigilante/issue-2", WorktreePath: worktreePath2},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.CleanupAllRunningSessions(context.Background(), "cli"); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions[0].Status != state.SessionStatusFailed || sessions[1].Status != state.SessionStatusFailed {
+		t.Fatalf("unexpected cleanup result: %#v", sessions)
+	}
+	if got := stdout.String(); !strings.Contains(got, "cleaned up 2 running session(s)") {
+		t.Fatalf("unexpected output: %s", got)
 	}
 }
 
@@ -336,6 +558,142 @@ func TestScanOnceProcessesGitHubCommentResumeRequest(t *testing.T) {
 	}
 	if sessions[0].RecoveredAt == "" {
 		t.Fatalf("expected recovery timestamp to be recorded: %#v", sessions[0])
+	}
+}
+
+func TestScanOnceProcessesGitHubCommentCleanupRequest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1/comments": `[{"id":101,"body":"@vigilanteai cleanup","created_at":"2026-03-10T12:30:00Z","user":{"login":"nicobistolfi"}}]`,
+			"gh api --method POST -H Accept: application/vnd.github+json repos/owner/repo/issues/comments/101/reactions -f content=+1": "{}",
+			"git worktree prune":                                         "ok",
+			"git worktree remove --force " + worktreePath:                "ok",
+			"git worktree list --porcelain":                              "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": "ok",
+			"git branch -D vigilante/issue-1":                            "Deleted branch vigilante/issue-1\n",
+			"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Cleanup Completed",
+				Emoji:      "🧹",
+				Percent:    100,
+				ETAMinutes: 1,
+				Items: []string{
+					"Removed the running Vigilante session for `vigilante/issue-1`.",
+					"Cleanup source: `comment`.",
+					"Local worktree artifacts were cleaned up at `" + worktreePath + "` when present.",
+				},
+				Tagline: "Leave no loose ends.",
+			}): "ok",
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: repoPath, Repo: "owner/repo", Branch: "main", Assignee: "me"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:     repoPath,
+		Repo:         "owner/repo",
+		IssueNumber:  1,
+		Branch:       "vigilante/issue-1",
+		WorktreePath: worktreePath,
+		Status:       state.SessionStatusRunning,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if sessions[0].Status != state.SessionStatusFailed || sessions[0].CleanupCompletedAt == "" {
+		t.Fatalf("expected cleanup to remove running session: %#v", sessions[0])
+	}
+	if sessions[0].LastCleanupSource != "comment" || sessions[0].LastCleanupCommentID != 101 {
+		t.Fatalf("expected cleanup comment metadata to be recorded: %#v", sessions[0])
+	}
+}
+
+func TestScanOnceReportsNoMatchingRunningSessionForGitHubCleanupRequest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1/comments": `[{"id":101,"body":"@vigilanteai cleanup","created_at":"2026-03-10T12:30:00Z","user":{"login":"nicobistolfi"}}]`,
+			"gh api --method POST -H Accept: application/vnd.github+json repos/owner/repo/issues/comments/101/reactions -f content=+1": "{}",
+			"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Cleanup Checked",
+				Emoji:      "🧭",
+				Percent:    100,
+				ETAMinutes: 1,
+				Items: []string{
+					"Received `@vigilanteai cleanup` for this issue.",
+					"No running Vigilante session matched the request, so there was nothing active to clean up.",
+					"Next step: run `vigilante list --running` locally if dispatch still looks blocked.",
+				},
+				Tagline: "Trust, but verify.",
+			}): "ok",
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main", Assignee: "me"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:     "/tmp/repo",
+		Repo:         "owner/repo",
+		IssueNumber:  1,
+		Branch:       "vigilante/issue-1",
+		WorktreePath: filepath.Join("/tmp/repo", ".worktrees", "vigilante", "issue-1"),
+		Status:       state.SessionStatusBlocked,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions[0].Status != state.SessionStatusBlocked {
+		t.Fatalf("expected non-running session to remain unchanged: %#v", sessions[0])
+	}
+	if sessions[0].LastCleanupCommentID != 101 || sessions[0].LastCleanupSource != "comment" {
+		t.Fatalf("expected cleanup request to be recorded: %#v", sessions[0])
 	}
 }
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -226,9 +226,17 @@ func HasAnyLabel(labels []Label, wanted ...string) bool {
 }
 
 func FindResumeComment(comments []IssueComment, claimedCommentID int64) *IssueComment {
+	return findCommandComment(comments, "@vigilanteai resume", claimedCommentID)
+}
+
+func FindCleanupComment(comments []IssueComment, claimedCommentID int64) *IssueComment {
+	return findCommandComment(comments, "@vigilanteai cleanup", claimedCommentID)
+}
+
+func findCommandComment(comments []IssueComment, command string, claimedCommentID int64) *IssueComment {
 	for i := len(comments) - 1; i >= 0; i-- {
 		body := strings.TrimSpace(comments[i].Body)
-		if body != "@vigilanteai resume" {
+		if body != command {
 			continue
 		}
 		if claimedCommentID != 0 && comments[i].ID == claimedCommentID {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -204,3 +204,19 @@ func TestFindPullRequestForBranch(t *testing.T) {
 		t.Fatalf("unexpected merged time: %#v", pr.MergedAt)
 	}
 }
+
+func TestFindCleanupComment(t *testing.T) {
+	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	comments := []IssueComment{
+		{ID: 10, Body: "hello", CreatedAt: now.Add(-2 * time.Minute)},
+		{ID: 11, Body: "@vigilanteai cleanup", CreatedAt: now.Add(-1 * time.Minute)},
+	}
+
+	comment := FindCleanupComment(comments, 0)
+	if comment == nil || comment.ID != 11 {
+		t.Fatalf("expected cleanup comment to be found, got: %#v", comment)
+	}
+	if comment := FindCleanupComment(comments, 11); comment != nil {
+		t.Fatalf("expected claimed cleanup comment to be ignored, got: %#v", comment)
+	}
+}

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -67,6 +67,15 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 	}
 	preflightOutput, err := env.Runner.Run(ctx, preflightInvocation.Dir, preflightInvocation.Name, preflightInvocation.Args...)
 	if err != nil {
+		if errors.Is(err, context.Canceled) || ctx.Err() != nil {
+			session.Status = state.SessionStatusFailed
+			session.LastError = "session canceled"
+			session.EndedAt = time.Now().UTC().Format(time.RFC3339)
+			session.LastHeartbeatAt = session.EndedAt
+			session.UpdatedAt = session.EndedAt
+			appendSessionLog(logPath, "issue preflight canceled", session, combineLogDetails(preflightOutput, err.Error()))
+			return session
+		}
 		blocked := classifyBlockedFailure("baseline_preflight", preflightInvocation.Name, preflightOutput, err)
 		markSessionBlocked(&session, "baseline_preflight", blocked, time.Now().UTC())
 		session.LastError = err.Error()
@@ -106,6 +115,12 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 	session.LastHeartbeatAt = session.EndedAt
 	session.UpdatedAt = session.EndedAt
 	if err != nil {
+		if errors.Is(err, context.Canceled) || ctx.Err() != nil {
+			session.Status = state.SessionStatusFailed
+			session.LastError = "session canceled"
+			appendSessionLog(logPath, "session canceled", session, combineLogDetails(output, err.Error()))
+			return session
+		}
 		blocked := classifyBlockedFailure("issue_execution", invocation.Name, output, err)
 		markSessionBlocked(&session, "issue_execution", blocked, time.Now().UTC())
 		session.LastError = err.Error()

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -70,6 +70,9 @@ type Session struct {
 	LastResumeSource     string        `json:"last_resume_source,omitempty"`
 	LastResumeCommentID  int64         `json:"last_resume_comment_id,omitempty"`
 	LastResumeCommentAt  string        `json:"last_resume_comment_at,omitempty"`
+	LastCleanupSource    string        `json:"last_cleanup_source,omitempty"`
+	LastCleanupCommentID int64         `json:"last_cleanup_comment_id,omitempty"`
+	LastCleanupCommentAt string        `json:"last_cleanup_comment_at,omitempty"`
 	RecoveredAt          string        `json:"recovered_at,omitempty"`
 	MonitoringStoppedAt  string        `json:"monitoring_stopped_at,omitempty"`
 	CleanupCompletedAt   string        `json:"cleanup_completed_at,omitempty"`


### PR DESCRIPTION
## Summary
- add `vigilante list --running` plus `vigilante cleanup` commands for issue, repo, and global running-session cleanup
- support `@vigilanteai cleanup` with `+1` acknowledgment and actionable no-match handling
- cancel in-process running sessions before cleanup, preserve cleanup state, and document/test the new flows

Closes #64

## Validation
- `go test ./...`
- `go build ./...`
