### PR TITLE
Add Homebrew tap publishing for vigilante

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,17 @@ jobs:
       - name: Validate GoReleaser config
         run: goreleaser check
 
+      - name: Get token for Homebrew tap
+        uses: actions/create-github-app-token@v2
+        id: tap_token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: homebrew-spaceship
+
       - name: Build and publish GitHub release
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ steps.tap_token.outputs.token }}
         run: goreleaser release --clean

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,8 +32,20 @@ checksum:
 
 release:
   github:
-    owner: nicobistolfi
+    owner: aliengiraffe
     name: vigilante
+
+homebrew_casks:
+  - name: vigilante
+    repository:
+      owner: aliengiraffe
+      name: homebrew-spaceship
+      token: "{{ .Env.HOMEBREW_GITHUB_API_TOKEN }}"
+    homepage: "https://github.com/aliengiraffe/vigilante"
+    description: "Autonomous GitHub issue runner for headless coding agents"
+    license: "Apache-2.0"
+    binaries:
+      - vigilante
 
 changelog:
   use: github-native

--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ For each watched repository:
 
 ## Commands
 
+## Installation
+
+Install `vigilante` from the existing Homebrew tap:
+
+```sh
+brew tap aliengiraffe/spaceship
+brew install --cask vigilante
+```
+
+Upgrade later with:
+
+```sh
+brew upgrade --cask vigilante
+```
+
 ### `vigilante watch [--assignee <value>] [--max-parallel <value>] <path>`
 
 Register a local repository for issue monitoring.
@@ -217,6 +232,14 @@ Tagged releases are built and published with GoReleaser. Pushing a version tag t
 - `darwin/arm64`
 - `linux/amd64`
 - a `checksums.txt` file for the published archives
+- an updated Homebrew cask in `aliengiraffe/homebrew-spaceship` so `brew install --cask vigilante` installs the tagged release from `aliengiraffe/spaceship`
+
+The release workflow requires a GitHub App that can write to the tap repository:
+
+- `APP_ID`: the GitHub App ID
+- `APP_PRIVATE_KEY`: the GitHub App private key
+
+During a tagged release, GitHub Actions exchanges those secrets for a short-lived token scoped to `aliengiraffe/homebrew-spaceship` and passes it to GoReleaser as `HOMEBREW_GITHUB_API_TOKEN`.
 
 Recommended release flow:
 
@@ -228,6 +251,18 @@ git push origin 1.2.3
 ```
 
 Tags that do not match the required version format, such as `v1.2.3` or `release-1.2.3`, may start the release workflow but are rejected by the tag validation step before GoReleaser publishes artifacts. The release workflow also validates that the tagged commit is already merged into `main` before publishing to GitHub Releases.
+
+Before cutting a release, validate the packaging config locally with:
+
+```sh
+goreleaser check
+```
+
+You can also confirm the Homebrew cask will target the published release archive names by checking the GoReleaser archive template:
+
+- `vigilante_<version>_macOS_amd64.tar.gz`
+- `vigilante_<version>_macOS_arm64.tar.gz`
+- `vigilante_<version>_Linux_amd64.tar.gz`
 
 ## Local State
 


### PR DESCRIPTION
## Summary
- add GoReleaser Homebrew cask publishing to `aliengiraffe/homebrew-spaceship`
- mint a short-lived tap repo token in the release workflow and pass it to GoReleaser
- document the Homebrew install flow, release secrets, and local validation steps

Closes #59.

## Validation
- `go run github.com/goreleaser/goreleaser/v2@latest check`
- `go run github.com/goreleaser/goreleaser/v2@latest release --snapshot --clean --skip=publish`
- `go build ./...`
- `go test ./...` *(fails on the existing `internal/provider` test double missing `BuildIssuePreflightInvocation`; unrelated to this change)*
