### PR TITLE
Make progress comment bars render reliably in GitHub markdown

### DIFF
--- a/internal/github/comment_format.go
+++ b/internal/github/comment_format.go
@@ -22,7 +22,7 @@ func FormatProgressComment(comment ProgressComment) string {
 
 	lines := []string{
 		fmt.Sprintf("## %s", header),
-		fmt.Sprintf("`%s %d%%`", progressBar(comment.Percent), clampPercent(comment.Percent)),
+		progressLine(comment.Percent),
 		fmt.Sprintf("`ETA: ~%s`", formatMinutes(comment.ETAMinutes)),
 	}
 	for _, item := range comment.Items {
@@ -38,10 +38,15 @@ func FormatProgressComment(comment ProgressComment) string {
 	return strings.Join(lines, "\n")
 }
 
+func progressLine(percent int) string {
+	percent = clampPercent(percent)
+	return fmt.Sprintf("Progress: [%s] %d%%", progressBar(percent), percent)
+}
+
 func progressBar(percent int) string {
 	percent = clampPercent(percent)
 	filled := percent / 10
-	return strings.Repeat("█", filled) + strings.Repeat("░", 10-filled)
+	return strings.Repeat("#", filled) + strings.Repeat("-", 10-filled)
 }
 
 func clampPercent(percent int) int {

--- a/internal/github/comment_format_test.go
+++ b/internal/github/comment_format_test.go
@@ -1,22 +1,63 @@
 package ghcli
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestFormatProgressComment(t *testing.T) {
-	comment := FormatProgressComment(ProgressComment{
-		Stage:      "Validation Passed",
-		Emoji:      "✅",
-		Percent:    90,
-		ETAMinutes: 5,
-		Items: []string{
-			"Ran `go test ./...`.",
-			"Pushed `vigilante/issue-12`.",
-		},
-		Tagline: "Success is where preparation and opportunity meet.",
+	t.Run("formats full comment with markdown-safe progress line", func(t *testing.T) {
+		comment := FormatProgressComment(ProgressComment{
+			Stage:      "Validation Passed",
+			Emoji:      "✅",
+			Percent:    90,
+			ETAMinutes: 5,
+			Items: []string{
+				"Ran `go test ./...`.",
+				"Pushed `vigilante/issue-12`.",
+			},
+			Tagline: "Success is where preparation and opportunity meet.",
+		})
+
+		expected := "## ✅ Validation Passed\nProgress: [#########-] 90%\n`ETA: ~5 minutes`\n- Ran `go test ./...`.\n- Pushed `vigilante/issue-12`.\n> \"Success is where preparation and opportunity meet.\""
+		if comment != expected {
+			t.Fatalf("unexpected comment:\n%s", comment)
+		}
 	})
 
-	expected := "## ✅ Validation Passed\n`█████████░ 90%`\n`ETA: ~5 minutes`\n- Ran `go test ./...`.\n- Pushed `vigilante/issue-12`.\n> \"Success is where preparation and opportunity meet.\""
-	if comment != expected {
-		t.Fatalf("unexpected comment:\n%s", comment)
+	t.Run("supports multiple percentages", func(t *testing.T) {
+		cases := []struct {
+			name    string
+			percent int
+			want    string
+		}{
+			{name: "low", percent: 0, want: "Progress: [----------] 0%"},
+			{name: "mid", percent: 50, want: "Progress: [#####-----] 50%"},
+			{name: "high", percent: 100, want: "Progress: [##########] 100%"},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				comment := FormatProgressComment(ProgressComment{Stage: "Working", Percent: tc.percent, ETAMinutes: 2})
+				if got := firstBodyLine(comment); got != tc.want {
+					t.Fatalf("unexpected progress line: got %q want %q", got, tc.want)
+				}
+			})
+		}
+	})
+
+	t.Run("clamps percent and avoids inline-code progress formatting", func(t *testing.T) {
+		comment := FormatProgressComment(ProgressComment{Stage: "Working", Percent: 135, ETAMinutes: 2})
+		if got := firstBodyLine(comment); got != "Progress: [##########] 100%" {
+			t.Fatalf("unexpected progress line: %q", got)
+		}
+	})
+}
+
+func firstBodyLine(comment string) string {
+	lines := strings.Split(comment, "\n")
+	if len(lines) < 2 {
+		return ""
 	}
+	return lines[1]
 }


### PR DESCRIPTION
## Summary
- replace the fragile inline-code Unicode progress bar with a plain-text ASCII progress line
- keep the percentage explicit while preserving the rest of the progress comment structure
- add regression coverage for multiple bar states and percent clamping

## Testing
- go test ./...