### PR TITLE
Detect coding-agent subscription and usage-limit failures

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/nicobistolfi/vigilante/internal/blocking"
 	"github.com/nicobistolfi/vigilante/internal/environment"
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
 	"github.com/nicobistolfi/vigilante/internal/provider"
@@ -696,8 +697,8 @@ func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session
 						Percent:    85,
 						ETAMinutes: 15,
 						Items: []string{
-							fmt.Sprintf("Vigilante could not keep PR #%d merge-ready on `%s`.", pr.Number, session.Branch),
-							fmt.Sprintf("Cause class: `%s`.", blocked.Kind),
+							maintenanceBlockedMessage(blocked, pr.Number, session.Branch),
+							blocking.CauseLine(blocked),
 							fmt.Sprintf("Next step: fix the blocker, then run `%s` or request resume from GitHub.", session.ResumeHint),
 						},
 						Tagline: "Difficulties strengthen the mind, as labor does the body.",
@@ -859,6 +860,9 @@ func (a *App) listBlockedSessions() error {
 		count++
 		fmt.Fprintf(a.stdout, "%s issue #%d  %s\n", session.Repo, session.IssueNumber, blockedStateLabel(session))
 		fmt.Fprintf(a.stdout, "  cause: %s\n", fallbackText(session.BlockedReason.Kind, "unknown_operator_action_required"))
+		if session.BlockedReason.Summary != "" {
+			fmt.Fprintf(a.stdout, "  summary: %s\n", session.BlockedReason.Summary)
+		}
 		if session.BlockedReason.Operation != "" {
 			fmt.Fprintf(a.stdout, "  failed op: %s\n", session.BlockedReason.Operation)
 		}
@@ -1207,8 +1211,8 @@ func (a *App) resumeBlockedSession(ctx context.Context, session *state.Session, 
 			Percent:    88,
 			ETAMinutes: 10,
 			Items: []string{
-				fmt.Sprintf("Resume preflight did not pass for `%s`.", session.Branch),
-				fmt.Sprintf("Cause class: `%s`.", blocked.Kind),
+				resumePreflightBlockedMessage(blocked, session.Branch),
+				blocking.CauseLine(blocked),
 				fmt.Sprintf("Next step: fix the blocker, then run `%s` or request resume from GitHub again.", session.ResumeHint),
 			},
 			Tagline: "Clear eyes, full hearts, can’t lose.",
@@ -1235,8 +1239,8 @@ func (a *App) resumeBlockedSession(ctx context.Context, session *state.Session, 
 			Percent:    90,
 			ETAMinutes: 12,
 			Items: []string{
-				fmt.Sprintf("Resume did not complete for `%s`.", session.Branch),
-				fmt.Sprintf("Cause class: `%s`.", blocked.Kind),
+				resumeBlockedMessage(blocked, session.Branch),
+				blocking.CauseLine(blocked),
 				fmt.Sprintf("Next step: fix the blocker, then run `%s` or request resume from GitHub again.", session.ResumeHint),
 			},
 			Tagline: "The comeback is always stronger than the setback.",
@@ -1497,32 +1501,7 @@ func (a *App) recordSessionFailure(session *state.Session, stage string, operati
 }
 
 func classifyBlockedReason(stage string, operation string, err error) state.BlockedReason {
-	text := strings.ToLower(strings.TrimSpace(err.Error()))
-	reason := state.BlockedReason{
-		Kind:      "unknown_operator_action_required",
-		Operation: operation,
-		Summary:   summarizeMaintenanceError(err),
-		Detail:    summarizeMaintenanceError(err),
-	}
-	switch {
-	case strings.Contains(text, "permission denied (publickey)") || strings.Contains(text, "sign_and_send_pubkey") || strings.Contains(text, "could not read from remote repository"):
-		reason.Kind = "git_auth"
-	case strings.Contains(text, "gh auth") || strings.Contains(text, "not logged into") || strings.Contains(text, "authentication failed"):
-		reason.Kind = "gh_auth"
-	case strings.Contains(text, "session expired") || strings.Contains(text, "re-auth") || strings.Contains(text, "login required") || strings.Contains(text, "unauthorized"):
-		reason.Kind = "provider_auth"
-	case strings.Contains(text, "executable file not found") || strings.Contains(text, "no such file or directory"):
-		reason.Kind = "provider_missing"
-	case strings.Contains(text, "worktree is not clean"):
-		reason.Kind = "dirty_worktree"
-	case strings.Contains(text, "go test") || strings.Contains(text, "validation") || strings.Contains(text, "build failed") || strings.Contains(text, "tests failed"):
-		reason.Kind = "validation_failed"
-	case strings.Contains(text, "network is unreachable") || strings.Contains(text, "timed out"):
-		reason.Kind = "network_unreachable"
-	case stage == "issue_execution" || stage == "conflict_resolution" || stage == "baseline_preflight":
-		reason.Kind = "provider_runtime_error"
-	}
-	return reason
+	return blocking.Classify(stage, operation, err.Error(), summarizeMaintenanceError(err))
 }
 
 func markSessionBlocked(session *state.Session, stage string, blocked state.BlockedReason, now time.Time) {
@@ -1552,18 +1531,28 @@ func clearBlockedState(session *state.Session, now time.Time, source string) {
 }
 
 func blockedStateLabel(session state.Session) string {
-	switch session.BlockedReason.Kind {
-	case "git_auth":
-		return "blocked_waiting_for_credentials"
-	case "gh_auth":
-		return "blocked_waiting_for_github_auth"
-	case "provider_auth":
-		return "blocked_waiting_for_provider_auth"
-	case "provider_missing":
-		return "blocked_waiting_for_provider_binary"
-	default:
-		return "blocked_waiting_for_operator"
+	return blocking.StateLabel(session.BlockedReason.Kind)
+}
+
+func maintenanceBlockedMessage(blocked state.BlockedReason, prNumber int, branch string) string {
+	if blocked.Kind == "provider_quota" {
+		return fmt.Sprintf("Vigilante could not keep PR #%d merge-ready on `%s` because the coding-agent account hit a usage or subscription limit.", prNumber, branch)
 	}
+	return fmt.Sprintf("Vigilante could not keep PR #%d merge-ready on `%s`.", prNumber, branch)
+}
+
+func resumePreflightBlockedMessage(blocked state.BlockedReason, branch string) string {
+	if blocked.Kind == "provider_quota" {
+		return fmt.Sprintf("Resume preflight stopped for `%s` because the coding-agent account hit a usage or subscription limit.", branch)
+	}
+	return fmt.Sprintf("Resume preflight did not pass for `%s`.", branch)
+}
+
+func resumeBlockedMessage(blocked state.BlockedReason, branch string) string {
+	if blocked.Kind == "provider_quota" {
+		return fmt.Sprintf("Resume stopped for `%s` because the coding-agent account hit a usage or subscription limit.", branch)
+	}
+	return fmt.Sprintf("Resume did not complete for `%s`.", branch)
 }
 
 func cleanupResultComment(session state.Session, cleanupErr error) string {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -251,6 +251,64 @@ func TestListBlockedSessions(t *testing.T) {
 	}
 }
 
+func TestListBlockedSessionsShowsProviderQuotaSummary(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		Repo:         "owner/repo",
+		IssueNumber:  45,
+		Status:       state.SessionStatusBlocked,
+		BlockedAt:    "2026-03-11T13:20:13Z",
+		BlockedStage: "issue_execution",
+		BlockedReason: state.BlockedReason{
+			Kind:      "provider_quota",
+			Operation: "codex exec",
+			Summary:   "Coding-agent account hit a usage or subscription limit. Try again at 2026-03-13 09:00 PDT.",
+		},
+		ResumeHint:     "vigilante resume --repo owner/repo --issue 45",
+		ResumeRequired: true,
+		RetryPolicy:    "paused",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.List(true, false); err != nil {
+		t.Fatal(err)
+	}
+	got := stdout.String()
+	for _, want := range []string{
+		"owner/repo issue #45  blocked_waiting_for_provider_quota",
+		"cause: provider_quota",
+		"summary: Coding-agent account hit a usage or subscription limit. Try again at 2026-03-13 09:00 PDT.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected blocked list output to contain %q, got: %s", want, got)
+		}
+	}
+}
+
+func TestClassifyBlockedReasonDetectsProviderQuota(t *testing.T) {
+	err := errors.New("You've hit your usage limit. Upgrade to Pro or purchase more credits. Try again at 2026-03-13 09:00 PDT.")
+
+	got := classifyBlockedReason("issue_execution", "codex exec", err)
+
+	if got.Kind != "provider_quota" {
+		t.Fatalf("expected provider_quota, got %#v", got)
+	}
+	if !strings.Contains(got.Summary, "Try again at 2026-03-13 09:00 PDT.") {
+		t.Fatalf("expected retry hint in summary, got %q", got.Summary)
+	}
+}
+
 func TestListRunningSessions(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))

--- a/internal/blocking/reason.go
+++ b/internal/blocking/reason.go
@@ -1,0 +1,147 @@
+package blocking
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/nicobistolfi/vigilante/internal/state"
+)
+
+var providerRetryHintPattern = regexp.MustCompile(`(?i)(try again at[^.\n]*|retry(?: after| at)?[^.\n]*|resets? at[^.\n]*)`)
+
+func Classify(stage string, operation string, text string, fallbackSummary string) state.BlockedReason {
+	normalized := strings.TrimSpace(text)
+	lower := strings.ToLower(normalized)
+	reason := state.BlockedReason{
+		Kind:      "unknown_operator_action_required",
+		Operation: operation,
+		Summary:   summarize(fallbackSummary),
+		Detail:    summarize(normalized),
+	}
+	switch {
+	case strings.Contains(lower, "permission denied (publickey)") || strings.Contains(lower, "sign_and_send_pubkey") || strings.Contains(lower, "could not read from remote repository"):
+		reason.Kind = "git_auth"
+	case strings.Contains(lower, "gh auth") || strings.Contains(lower, "not logged into") || strings.Contains(lower, "authentication failed"):
+		reason.Kind = "gh_auth"
+	case strings.Contains(lower, "session expired") || strings.Contains(lower, "re-auth") || strings.Contains(lower, "login required") || strings.Contains(lower, "unauthorized"):
+		reason.Kind = "provider_auth"
+	case isProviderQuotaFailure(lower):
+		reason.Kind = "provider_quota"
+		reason.Summary = summarize(providerQuotaSummary(normalized))
+	case strings.Contains(lower, "executable file not found") || strings.Contains(lower, "no such file or directory"):
+		reason.Kind = "provider_missing"
+	case strings.Contains(lower, "worktree is not clean"):
+		reason.Kind = "dirty_worktree"
+	case strings.Contains(lower, "go test") || strings.Contains(lower, "validation") || strings.Contains(lower, "build failed") || strings.Contains(lower, "tests failed"):
+		reason.Kind = "validation_failed"
+	case strings.Contains(lower, "network is unreachable") || strings.Contains(lower, "timed out"):
+		reason.Kind = "network_unreachable"
+	case stage == "issue_execution" || stage == "conflict_resolution" || stage == "baseline_preflight":
+		reason.Kind = "provider_runtime_error"
+	}
+	if reason.Summary == "" {
+		reason.Summary = reason.Detail
+	}
+	if reason.Detail == "" {
+		reason.Detail = reason.Summary
+	}
+	return reason
+}
+
+func StateLabel(kind string) string {
+	switch kind {
+	case "git_auth":
+		return "blocked_waiting_for_credentials"
+	case "gh_auth":
+		return "blocked_waiting_for_github_auth"
+	case "provider_auth":
+		return "blocked_waiting_for_provider_auth"
+	case "provider_quota":
+		return "blocked_waiting_for_provider_quota"
+	case "provider_missing":
+		return "blocked_waiting_for_provider_binary"
+	default:
+		return "blocked_waiting_for_operator"
+	}
+}
+
+func CauseLine(reason state.BlockedReason) string {
+	line := fmt.Sprintf("Cause class: `%s`.", fallback(reason.Kind, "unknown_operator_action_required"))
+	if strings.TrimSpace(reason.Summary) == "" || reason.Kind != "provider_quota" {
+		return line
+	}
+	return fmt.Sprintf("%s Provider detail: `%s`.", line, reason.Summary)
+}
+
+func isProviderQuotaFailure(lower string) bool {
+	if strings.Contains(lower, "usage limit") || strings.Contains(lower, "rate limit reached") || strings.Contains(lower, "quota exceeded") {
+		return true
+	}
+	return (strings.Contains(lower, "upgrade to") || strings.Contains(lower, "purchase more credits") || strings.Contains(lower, "buy more credits")) &&
+		(strings.Contains(lower, "credits") || strings.Contains(lower, "quota") || strings.Contains(lower, "usage"))
+}
+
+func providerQuotaSummary(text string) string {
+	compact := compactWhitespace(text)
+	lower := strings.ToLower(compact)
+	parts := []string{"Coding-agent account hit a usage or subscription limit."}
+	if match := strings.TrimSpace(providerRetryHintPattern.FindString(compact)); match != "" {
+		parts = append(parts, sentence(match))
+	}
+	if strings.Contains(lower, "upgrade to") {
+		parts = append(parts, "Provider suggests upgrading the subscription.")
+	}
+	if strings.Contains(lower, "purchase more credits") || strings.Contains(lower, "buy more credits") {
+		parts = append(parts, "Provider suggests purchasing more credits.")
+	}
+	return strings.Join(unique(parts), " ")
+}
+
+func compactWhitespace(text string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(text)), " ")
+}
+
+func sentence(text string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	last := text[len(text)-1]
+	if last == '.' || last == '!' || last == '?' {
+		return text
+	}
+	return text + "."
+}
+
+func summarize(text string) string {
+	text = compactWhitespace(text)
+	if len(text) > 400 {
+		return text[:400]
+	}
+	return text
+}
+
+func fallback(value string, defaultValue string) string {
+	if strings.TrimSpace(value) == "" {
+		return defaultValue
+	}
+	return value
+}
+
+func unique(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nicobistolfi/vigilante/internal/blocking"
 	"github.com/nicobistolfi/vigilante/internal/environment"
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
 	"github.com/nicobistolfi/vigilante/internal/logtime"
@@ -89,8 +90,8 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 			Percent:    25,
 			ETAMinutes: 15,
 			Items: []string{
-				"Repository baseline validation failed before issue implementation began.",
-				fmt.Sprintf("Cause class: `%s`.", blocked.Kind),
+				blockedPreflightMessage(blocked, selectedProvider.ID()),
+				blocking.CauseLine(blocked),
 				fmt.Sprintf("Next step: restore the repository baseline, then run `%s` or request resume from GitHub.", session.ResumeHint),
 			},
 			Tagline: "Strong foundations make calm debugging sessions.",
@@ -131,8 +132,8 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 			Percent:    95,
 			ETAMinutes: 10,
 			Items: []string{
-				fmt.Sprintf("The `%s` provider stopped before the issue implementation completed.", selectedProvider.ID()),
-				fmt.Sprintf("Cause class: `%s`.", blocked.Kind),
+				blockedExecutionMessage(blocked, selectedProvider.ID()),
+				blocking.CauseLine(blocked),
 				fmt.Sprintf("Next step: fix the blocker, then run `%s` or request resume from GitHub.", session.ResumeHint),
 			},
 			Tagline: "Plans are only good intentions unless they immediately degenerate into hard work.",
@@ -171,8 +172,8 @@ func RunConflictResolutionSession(ctx context.Context, env *environment.Environm
 			Percent:    90,
 			ETAMinutes: 12,
 			Items: []string{
-				fmt.Sprintf("Conflict resolution for PR #%d on `%s` through provider `%s` did not complete.", pr.Number, session.Branch, selectedProvider.ID()),
-				fmt.Sprintf("Cause class: `%s`.", blocked.Kind),
+				blockedConflictMessage(blocked, pr.Number, session.Branch, selectedProvider.ID()),
+				blocking.CauseLine(blocked),
 				fmt.Sprintf("Next step: fix the blocker, then run `%s` or request resume from GitHub.", buildResumeHint(session)),
 			},
 			Tagline: "An obstacle is often a stepping stone.",
@@ -210,35 +211,28 @@ func buildResumeHint(session state.Session) string {
 }
 
 func classifyBlockedFailure(stage string, operation string, output string, err error) state.BlockedReason {
-	text := strings.ToLower(strings.TrimSpace(output + "\n" + err.Error()))
-	reason := state.BlockedReason{
-		Kind:      "unknown_operator_action_required",
-		Operation: operation,
-		Summary:   summarizeError(err),
-		Detail:    summarizeError(errors.New(strings.TrimSpace(output))),
+	return blocking.Classify(stage, operation, strings.TrimSpace(output+"\n"+err.Error()), summarizeError(err))
+}
+
+func blockedPreflightMessage(blocked state.BlockedReason, providerID string) string {
+	if blocked.Kind == "provider_quota" {
+		return fmt.Sprintf("The `%s` provider hit a usage or subscription limit during issue preflight.", providerID)
 	}
-	switch {
-	case strings.Contains(text, "permission denied (publickey)") || strings.Contains(text, "sign_and_send_pubkey") || strings.Contains(text, "could not read from remote repository"):
-		reason.Kind = "git_auth"
-	case strings.Contains(text, "gh auth") || strings.Contains(text, "not logged into") || strings.Contains(text, "authentication failed"):
-		reason.Kind = "gh_auth"
-	case strings.Contains(text, "session expired") || strings.Contains(text, "re-auth") || strings.Contains(text, "login required") || strings.Contains(text, "unauthorized"):
-		reason.Kind = "provider_auth"
-	case strings.Contains(text, "executable file not found") || strings.Contains(text, "no such file or directory"):
-		reason.Kind = "provider_missing"
-	case strings.Contains(text, "worktree is not clean"):
-		reason.Kind = "dirty_worktree"
-	case strings.Contains(text, "go test") || strings.Contains(text, "validation") || strings.Contains(text, "build failed") || strings.Contains(text, "tests failed"):
-		reason.Kind = "validation_failed"
-	case strings.Contains(text, "network is unreachable") || strings.Contains(text, "timed out"):
-		reason.Kind = "network_unreachable"
-	case strings.Contains(strings.ToLower(stage), "issue") || strings.Contains(strings.ToLower(stage), "conflict") || strings.Contains(strings.ToLower(stage), "preflight"):
-		reason.Kind = "provider_runtime_error"
+	return "Repository baseline validation failed before issue implementation began."
+}
+
+func blockedExecutionMessage(blocked state.BlockedReason, providerID string) string {
+	if blocked.Kind == "provider_quota" {
+		return fmt.Sprintf("The `%s` provider hit a usage or subscription limit before the issue implementation completed.", providerID)
 	}
-	if reason.Detail == "" {
-		reason.Detail = reason.Summary
+	return fmt.Sprintf("The `%s` provider stopped before the issue implementation completed.", providerID)
+}
+
+func blockedConflictMessage(blocked state.BlockedReason, prNumber int, branch string, providerID string) string {
+	if blocked.Kind == "provider_quota" {
+		return fmt.Sprintf("Conflict resolution for PR #%d on `%s` stopped because provider `%s` hit a usage or subscription limit.", prNumber, branch, providerID)
 	}
-	return reason
+	return fmt.Sprintf("Conflict resolution for PR #%d on `%s` through provider `%s` did not complete.", prNumber, branch, providerID)
 }
 
 func appendSessionLog(path string, event string, session state.Session, details string) {

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -153,6 +153,30 @@ func TestRunConflictResolutionSessionFailureCommentsOnIssue(t *testing.T) {
 	}
 }
 
+func TestClassifyBlockedFailureDetectsProviderQuota(t *testing.T) {
+	err := errors.New("exit status 1")
+	output := "You've hit your usage limit. Upgrade to Pro or purchase more credits. Try again at 2026-03-13 09:00 PDT."
+
+	got := classifyBlockedFailure("issue_execution", "codex exec", output, err)
+
+	if got.Kind != "provider_quota" {
+		t.Fatalf("expected provider_quota, got %#v", got)
+	}
+	for _, want := range []string{
+		"usage or subscription limit",
+		"Try again at 2026-03-13 09:00 PDT.",
+		"upgrading the subscription",
+		"purchasing more credits",
+	} {
+		if !strings.Contains(got.Summary, want) {
+			t.Fatalf("expected summary to contain %q, got %q", want, got.Summary)
+		}
+	}
+	if !strings.Contains(got.Detail, "You've hit your usage limit.") {
+		t.Fatalf("expected detail to preserve provider output, got %q", got.Detail)
+	}
+}
+
 func TestAppendSessionLogUsesLocalTimezone(t *testing.T) {
 	originalLocal := time.Local
 	time.Local = time.FixedZone("TEST", -8*60*60)


### PR DESCRIPTION
## Summary
- add a shared blocked-failure classifier and a first-class `provider_quota` blocked kind for coding-agent usage-limit, subscription-limit, and credit exhaustion failures
- preserve actionable provider hints such as retry timing in blocked summaries and surface them in blocked issue comments and `vigilante list --blocked`
- add targeted runner and app tests for quota detection while preserving existing auth and generic fallback behavior

## Testing
- `go test ./...`

Closes #90.
