### PR TITLE
Change default per-repo session concurrency to 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Expected behavior:
 - validates the folder is a git repository
 - discovers the GitHub remote from git config
 - defaults the assignee filter to `me` unless overridden
-- defaults `--max-parallel` to `1` when not configured
+- defaults `--max-parallel` to `3` when not configured
 - resolves `me` to the authenticated GitHub login at runtime before issue queries
 - stores the target in `~/.vigilante/watchlist.json`
 
@@ -287,7 +287,7 @@ Suggested `watchlist.json` shape:
     "repo": "owner/hello-world-app",
     "branch": "main",
     "assignee": "me",
-    "max_parallel_sessions": 1,
+    "max_parallel_sessions": 3,
     "daemon_enabled": true,
     "last_scan_at": "2026-03-10T12:00:00Z"
   }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -132,7 +132,7 @@ func TestWatchListAndUnwatch(t *testing.T) {
 	if !strings.Contains(stdout.String(), "\"assignee\": \"me\"") {
 		t.Fatalf("expected default assignee in list output: %s", stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "\"max_parallel_sessions\": 1") {
+	if !strings.Contains(stdout.String(), "\"max_parallel_sessions\": 3") {
 		t.Fatalf("expected default max_parallel_sessions in list output: %s", stdout.String())
 	}
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -26,7 +26,7 @@ type WatchTarget struct {
 	AddedAt       string   `json:"added_at,omitempty"`
 }
 
-const DefaultMaxParallelSessions = 1
+const DefaultMaxParallelSessions = 3
 
 type SessionStatus string
 

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -58,3 +58,15 @@ func TestAppendLogFileUsesLocalTimezone(t *testing.T) {
 		t.Fatalf("expected local timezone log entry, got %q", text)
 	}
 }
+
+func TestWatchTargetMaxParallelDefaultsToSharedValue(t *testing.T) {
+	if got := normalizeMaxParallelSessions(0); got != DefaultMaxParallelSessions {
+		t.Fatalf("expected zero max_parallel_sessions to normalize to default %d, got %d", DefaultMaxParallelSessions, got)
+	}
+	if got := normalizeMaxParallelSessions(-1); got != DefaultMaxParallelSessions {
+		t.Fatalf("expected negative max_parallel_sessions to normalize to default %d, got %d", DefaultMaxParallelSessions, got)
+	}
+	if got := normalizeMaxParallelSessions(1); got != 1 {
+		t.Fatalf("expected explicit max_parallel_sessions to be preserved, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary
- change the shared default per-repo session concurrency from 1 to 3
- keep normalization and implicit watch behavior derived from the shared default
- update tests and README examples to reflect the new default

Closes #84

## Validation
- go test ./...
