### PR TITLE
Make progress comment bars render reliably in GitHub markdown

### DIFF
--- a/internal/github/comment_format.go
+++ b/internal/github/comment_format.go
@@ -22,8 +22,8 @@ func FormatProgressComment(comment ProgressComment) string {
 
 	lines := []string{
 		fmt.Sprintf("## %s", header),
-		fmt.Sprintf("`%s %d%%`", progressBar(comment.Percent), clampPercent(comment.Percent)),
-		fmt.Sprintf("`ETA: ~%s`", formatMinutes(comment.ETAMinutes)),
+		fmt.Sprintf("Progress: [%s] %d%%", progressBar(comment.Percent), clampPercent(comment.Percent)),
+		fmt.Sprintf("ETA: ~%s", formatMinutes(comment.ETAMinutes)),
 	}
 	for _, item := range comment.Items {
 		item = strings.TrimSpace(item)
@@ -41,7 +41,7 @@ func FormatProgressComment(comment ProgressComment) string {
 func progressBar(percent int) string {
 	percent = clampPercent(percent)
 	filled := percent / 10
-	return strings.Repeat("█", filled) + strings.Repeat("░", 10-filled)
+	return strings.Repeat("#", filled) + strings.Repeat("-", 10-filled)
 }
 
 func clampPercent(percent int) int {

--- a/internal/github/comment_format_test.go
+++ b/internal/github/comment_format_test.go
@@ -1,6 +1,9 @@
 package ghcli
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestFormatProgressComment(t *testing.T) {
 	comment := FormatProgressComment(ProgressComment{
@@ -15,8 +18,37 @@ func TestFormatProgressComment(t *testing.T) {
 		Tagline: "Success is where preparation and opportunity meet.",
 	})
 
-	expected := "## ✅ Validation Passed\n`█████████░ 90%`\n`ETA: ~5 minutes`\n- Ran `go test ./...`.\n- Pushed `vigilante/issue-12`.\n> \"Success is where preparation and opportunity meet.\""
+	expected := "## ✅ Validation Passed\nProgress: [#########-] 90%\nETA: ~5 minutes\n- Ran `go test ./...`.\n- Pushed `vigilante/issue-12`.\n> \"Success is where preparation and opportunity meet.\""
 	if comment != expected {
 		t.Fatalf("unexpected comment:\n%s", comment)
+	}
+}
+
+func TestFormatProgressCommentProgressBarAcrossPercentages(t *testing.T) {
+	tests := []struct {
+		name    string
+		percent int
+		want    string
+	}{
+		{name: "low", percent: 0, want: "Progress: [----------] 0%"},
+		{name: "mid", percent: 50, want: "Progress: [#####-----] 50%"},
+		{name: "high", percent: 100, want: "Progress: [##########] 100%"},
+		{name: "clamped low", percent: -5, want: "Progress: [----------] 0%"},
+		{name: "clamped high", percent: 135, want: "Progress: [##########] 100%"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comment := FormatProgressComment(ProgressComment{
+				Stage:      "Working",
+				Percent:    tt.percent,
+				ETAMinutes: 2,
+			})
+
+			lines := strings.Split(comment, "\n")
+			if lines[1] != tt.want {
+				t.Fatalf("unexpected progress line: got %q want %q", lines[1], tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- replace the inline-code Unicode progress bar with plain text ASCII progress output
- keep the broader progress comment structure intact while making the ETA line plain text too
- add regression coverage for low, mid, high, and clamped percentage values

## Testing
- go test ./...
- go vet ./...
- go build ./...

Closes #80
