### PR TITLE
Add Claude Code provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For each watched repository:
 3. Ensure required tools are available:
    - `git`
    - `gh`
-   - `codex`
+   - the configured coding-agent provider CLI (`codex` or `claude`)
 4. Ensure the coding-agent issue implementation skill from `skills/vigilante-issue-implementation/` is installed during setup, including its companion agent metadata.
 5. Query GitHub for open issues.
 6. Determine which issues are eligible for execution.
@@ -73,7 +73,7 @@ Upgrade later with:
 brew upgrade --cask vigilante
 ```
 
-### `vigilante watch [--assignee <value>] [--max-parallel <value>] <path>`
+### `vigilante watch [--assignee <value>] [--max-parallel <value>] [--provider <codex|claude>] <path>`
 
 Register a local repository for issue monitoring.
 
@@ -84,6 +84,7 @@ Expected behavior:
 - discovers the GitHub remote from git config
 - defaults the assignee filter to `me` unless overridden
 - defaults `--max-parallel` to `3` when not configured
+- defaults `--provider` to `codex` unless overridden
 - resolves `me` to the authenticated GitHub login at runtime before issue queries
 - stores the target in `~/.vigilante/watchlist.json`
 
@@ -99,6 +100,10 @@ vigilante watch --assignee nicobistolfi ~/hello-world-app
 
 ```sh
 vigilante watch --max-parallel 3 ~/hello-world-app
+```
+
+```sh
+vigilante watch --provider claude ~/hello-world-app
 ```
 
 ### `vigilante watch -d <path>`
@@ -152,7 +157,7 @@ Remove a repository from the watchlist without deleting the repository itself.
 Run the long-lived watcher loop in the foreground. This is the process the OS service should execute.
 By default it scans watched repositories every 1 minute. Use `--interval` to override that cadence for manual runs.
 
-### `vigilante setup`
+### `vigilante setup [--provider <codex|claude>]`
 
 Prepare the machine for autonomous execution.
 
@@ -160,7 +165,7 @@ Expected behavior:
 
 - creates `~/.vigilante/`
 - initializes `watchlist.json`
-- verifies `git`, `gh`, and `codex`
+- verifies `git`, `gh`, and the selected coding-agent provider CLI
 - installs the bundled coding-agent skills for regular runtime use, including any companion files under each skill directory
   - `vigilante-issue-implementation`
   - `vigilante-conflict-resolution`
@@ -195,7 +200,7 @@ go run ./cmd/vigilante daemon run --once
 go run ./cmd/vigilante daemon run --interval 30s
 ```
 
-- rebuild the installed binary and refresh the installed Codex skill:
+- rebuild the installed binary and refresh the installed provider skills:
 
 ```sh
 go build -o /Users/$USER/.local/bin/vigilante ./cmd/vigilante
@@ -210,7 +215,7 @@ go build -o /Users/$USER/.local/bin/vigilante ./cmd/vigilante
 
 Notes:
 
-- foreground runs are the quickest way to iterate on scheduler, worktree, and Codex execution behavior
+- foreground runs are the quickest way to iterate on scheduler, worktree, and coding-agent execution behavior
 - when `vigilante` runs from a repository checkout, `setup` refreshes installed skills from the local repo `skills/` folder so skill edits are picked up immediately
 - when `vigilante` runs as an installed binary outside the repo checkout, `setup` uses skills embedded in the binary so it works from any directory without depending on the source tree
 - after changing service installation logic on macOS, rerun `setup -d` so the `launchd` plist is regenerated with the current shell-derived PATH
@@ -305,7 +310,7 @@ Initial rules:
 - enforce `max_parallel_sessions` independently for each watched repository
 - count both running implementation sessions and open-PR maintenance sessions against that repository limit
 - avoid duplicate work across multiple daemon scans
-- allow an issue label that exactly matches a registered provider id, such as `codex`, to override the watch target provider for that issue only
+- allow an issue label that exactly matches a registered provider id, such as `codex` or `claude`, to override the watch target provider for that issue only
 - if more than one provider-id label is present on the same issue, skip dispatch instead of choosing a provider arbitrarily
 - prefer oldest eligible open issue first unless later prioritization rules are added
 
@@ -322,7 +327,7 @@ When `vigilante` launches a coding agent for an issue, it should:
 - instruct the agent to post progress comments during execution
 - instruct the agent to report failures on the issue if execution aborts
 
-The first implementation can treat the agent invocation as a subprocess wrapper around an installed coding CLI such as `codex`, while keeping the wording compatible with future providers.
+The agent invocation remains a subprocess wrapper around an installed coding CLI such as `codex` or `claude`, while keeping the orchestration behavior provider-neutral.
 
 ## GitHub Integration
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -97,10 +97,11 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 		fs := flag.NewFlagSet("setup", flag.ContinueOnError)
 		fs.SetOutput(a.stderr)
 		installDaemon := fs.Bool("d", false, "install daemon service")
+		selectedProvider := fs.String("provider", provider.DefaultID, "coding agent provider")
 		if err := fs.Parse(args[1:]); err != nil {
 			return err
 		}
-		return a.Setup(ctx, *installDaemon)
+		return a.SetupWithProvider(ctx, *installDaemon, *selectedProvider)
 	case "watch":
 		fs := flag.NewFlagSet("watch", flag.ContinueOnError)
 		fs.SetOutput(a.stderr)
@@ -109,13 +110,14 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 		fs.Var(&labels, "label", "allow only issues with this label; repeatable")
 		assignee := fs.String("assignee", "", "issue assignee filter (defaults to me)")
 		maxParallel := fs.Int("max-parallel", 0, "maximum concurrent issue sessions for this repository")
+		selectedProvider := fs.String("provider", "", "coding agent provider")
 		if err := fs.Parse(args[1:]); err != nil {
 			return err
 		}
 		if fs.NArg() != 1 {
-			return errors.New("usage: vigilante watch [-d] [--label value] [--assignee value] [--max-parallel value] <path>")
+			return errors.New("usage: vigilante watch [-d] [--label value] [--assignee value] [--max-parallel value] [--provider value] <path>")
 		}
-		return a.Watch(ctx, fs.Arg(0), *daemon, labels, *assignee, *maxParallel)
+		return a.WatchWithProvider(ctx, fs.Arg(0), *daemon, labels, *assignee, *maxParallel, *selectedProvider)
 	case "unwatch":
 		if len(args) != 2 {
 			return errors.New("usage: vigilante unwatch <path>")
@@ -210,11 +212,15 @@ func (a *App) runDaemonCommand(ctx context.Context, args []string) error {
 }
 
 func (a *App) Setup(ctx context.Context, installDaemon bool) error {
+	return a.SetupWithProvider(ctx, installDaemon, provider.DefaultID)
+}
+
+func (a *App) SetupWithProvider(ctx context.Context, installDaemon bool, providerID string) error {
 	a.state.AppendDaemonLog("setup start install_daemon=%t", installDaemon)
 	if err := a.state.EnsureLayout(); err != nil {
 		return err
 	}
-	selectedProvider, err := provider.Resolve(provider.DefaultID)
+	selectedProvider, err := provider.Resolve(providerID)
 	if err != nil {
 		return err
 	}
@@ -235,12 +241,23 @@ func (a *App) Setup(ctx context.Context, installDaemon bool) error {
 }
 
 func (a *App) Watch(ctx context.Context, rawPath string, daemon bool, labels []string, assignee string, maxParallel int) error {
+	return a.WatchWithProvider(ctx, rawPath, daemon, labels, assignee, maxParallel, "")
+}
+
+func (a *App) WatchWithProvider(ctx context.Context, rawPath string, daemon bool, labels []string, assignee string, maxParallel int, providerID string) error {
 	a.state.AppendDaemonLog("watch start raw_path=%q daemon=%t assignee=%q max_parallel=%d", rawPath, daemon, assignee, maxParallel)
 	if err := a.state.EnsureLayout(); err != nil {
 		return err
 	}
 	if maxParallel < 0 {
 		return errors.New("max parallel must be at least 1")
+	}
+	if strings.TrimSpace(providerID) != "" {
+		resolvedProvider, err := provider.Resolve(providerID)
+		if err != nil {
+			return err
+		}
+		providerID = resolvedProvider.ID()
 	}
 
 	repoPath, err := ExpandPath(rawPath)
@@ -267,6 +284,9 @@ func (a *App) Watch(ctx context.Context, rawPath string, daemon bool, labels []s
 			targets[i].Branch = info.Branch
 			if strings.TrimSpace(targets[i].Provider) == "" {
 				targets[i].Provider = provider.DefaultID
+			}
+			if providerID != "" {
+				targets[i].Provider = providerID
 			}
 			targets[i].Labels = labels
 			if assignee != "" {
@@ -295,6 +315,9 @@ func (a *App) Watch(ctx context.Context, rawPath string, daemon bool, labels []s
 			DaemonEnabled: daemon,
 			AddedAt:       a.clock().Format(time.RFC3339),
 		}
+		if providerID != "" {
+			target.Provider = providerID
+		}
 		targets = append(targets, target)
 	}
 	sort.Slice(targets, func(i, j int) bool {
@@ -305,7 +328,11 @@ func (a *App) Watch(ctx context.Context, rawPath string, daemon bool, labels []s
 	}
 
 	if daemon {
-		if err := a.Setup(ctx, true); err != nil {
+		setupProvider := providerID
+		if setupProvider == "" {
+			setupProvider = findWatchTargetProvider(targets, info.Path)
+		}
+		if err := a.SetupWithProvider(ctx, true, setupProvider); err != nil {
 			return err
 		}
 	}
@@ -1243,24 +1270,29 @@ func (a *App) resumeBlockedSession(ctx context.Context, session *state.Session, 
 }
 
 func (a *App) preflightResume(ctx context.Context, session state.Session) error {
+	selectedProvider, err := provider.Resolve(session.Provider)
+	if err != nil {
+		return err
+	}
+	tool := providerRuntimeTool(selectedProvider)
 	switch session.BlockedReason.Kind {
 	case "git_auth":
-		_, err := a.env.Runner.Run(ctx, session.WorktreePath, "git", "fetch", "origin", "main")
+		_, err = a.env.Runner.Run(ctx, session.WorktreePath, "git", "fetch", "origin", "main")
 		return err
 	case "gh_auth":
 		if _, err := a.env.Runner.Run(ctx, "", "gh", "auth", "status"); err != nil {
 			return err
 		}
-		_, err := ghcli.GetIssueDetails(ctx, a.env.Runner, session.Repo, session.IssueNumber)
+		_, err = ghcli.GetIssueDetails(ctx, a.env.Runner, session.Repo, session.IssueNumber)
 		return err
 	case "provider_missing":
-		_, err := a.env.Runner.LookPath("codex")
+		_, err = a.env.Runner.LookPath(tool)
 		return err
 	case "provider_auth", "provider_runtime_error":
-		if _, err := a.env.Runner.LookPath("codex"); err != nil {
+		if _, err := a.env.Runner.LookPath(tool); err != nil {
 			return err
 		}
-		_, err := a.env.Runner.Run(ctx, "", "codex", "--version")
+		_, err = a.env.Runner.Run(ctx, "", tool, "--version")
 		return err
 	default:
 		return nil
@@ -1758,10 +1790,18 @@ func (a *App) ensureTooling(ctx context.Context, selectedProvider provider.Provi
 	return nil
 }
 
+func providerRuntimeTool(selectedProvider provider.Provider) string {
+	tools := selectedProvider.RequiredTools()
+	if len(tools) == 0 {
+		return selectedProvider.ID()
+	}
+	return tools[0]
+}
+
 func (a *App) printUsage() {
 	fmt.Fprintln(a.stderr, "usage:")
-	fmt.Fprintln(a.stderr, "  vigilante setup [-d]")
-	fmt.Fprintln(a.stderr, "  vigilante watch [-d] [--label value] [--assignee value] [--max-parallel value] <path>")
+	fmt.Fprintln(a.stderr, "  vigilante setup [-d] [--provider value]")
+	fmt.Fprintln(a.stderr, "  vigilante watch [-d] [--label value] [--assignee value] [--max-parallel value] [--provider value] <path>")
 	fmt.Fprintln(a.stderr, "  vigilante unwatch <path>")
 	fmt.Fprintln(a.stderr, "  vigilante list [--blocked | --running]")
 	fmt.Fprintln(a.stderr, "  vigilante cleanup --repo <owner/name> [--issue <n>]")
@@ -1853,4 +1893,16 @@ func findWatchTargetMaxParallel(targets []state.WatchTarget, path string) int {
 		}
 	}
 	return state.DefaultMaxParallelSessions
+}
+
+func findWatchTargetProvider(targets []state.WatchTarget, path string) string {
+	for _, target := range targets {
+		if target.Path == path {
+			if strings.TrimSpace(target.Provider) == "" {
+				return provider.DefaultID
+			}
+			return target.Provider
+		}
+	}
+	return provider.DefaultID
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -206,6 +206,39 @@ func TestWatchUpdatesExistingTarget(t *testing.T) {
 	}
 }
 
+func TestWatchWithProviderPersistsClaudeSelection(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                  "true\n",
+			testutil.Key("git", "remote", "get-url", "origin"):                         "git@github.com:nicobistolfi/vigilante.git\n",
+			testutil.Key("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"): "origin/main\n",
+		},
+	}
+
+	if err := app.WatchWithProvider(context.Background(), repoPath, false, nil, "", 0, "claude"); err != nil {
+		t.Fatal(err)
+	}
+
+	targets, err := app.state.LoadWatchTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 || targets[0].Provider != "claude" {
+		t.Fatalf("expected claude provider to persist: %#v", targets)
+	}
+}
+
 func TestListBlockedSessions(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))

--- a/internal/provider/claude.go
+++ b/internal/provider/claude.go
@@ -1,0 +1,60 @@
+package provider
+
+import (
+	"github.com/nicobistolfi/vigilante/internal/skill"
+	"github.com/nicobistolfi/vigilante/internal/state"
+)
+
+type claudeProvider struct{}
+
+func (claudeProvider) ID() string {
+	return ClaudeID
+}
+
+func (claudeProvider) DisplayName() string {
+	return "Claude Code"
+}
+
+func (claudeProvider) RequiredTools() []string {
+	return []string{"claude"}
+}
+
+func (claudeProvider) EnsureRuntimeInstalled(store *state.Store) error {
+	return skill.EnsureInstalled(skill.RuntimeClaude, store.ClaudeHome())
+}
+
+func (claudeProvider) BuildIssuePreflightInvocation(task IssueTask) (Invocation, error) {
+	return Invocation{
+		Name: "claude",
+		Args: []string{
+			"--print",
+			"--cwd", task.Session.WorktreePath,
+			"--permission-mode", "acceptEdits",
+			skill.BuildIssuePreflightPrompt(task.Target, task.Issue, task.Session),
+		},
+	}, nil
+}
+
+func (claudeProvider) BuildIssueInvocation(task IssueTask) (Invocation, error) {
+	return Invocation{
+		Name: "claude",
+		Args: []string{
+			"--print",
+			"--cwd", task.Session.WorktreePath,
+			"--permission-mode", "acceptEdits",
+			skill.BuildIssuePromptForRuntime(skill.RuntimeClaude, task.Target, task.Issue, task.Session),
+		},
+	}, nil
+}
+
+func (claudeProvider) BuildConflictResolutionInvocation(task ConflictTask) (Invocation, error) {
+	return Invocation{
+		Name: "claude",
+		Args: []string{
+			"--print",
+			"--cwd", task.Session.WorktreePath,
+			"--permission-mode", "acceptEdits",
+			skill.BuildConflictResolutionPromptForRuntime(skill.RuntimeClaude, task.Target, task.Session, task.PR),
+		},
+	}, nil
+}

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -20,7 +20,7 @@ func (codexProvider) RequiredTools() []string {
 }
 
 func (codexProvider) EnsureRuntimeInstalled(store *state.Store) error {
-	return skill.EnsureInstalled(store.CodexHome())
+	return skill.EnsureInstalled(skill.RuntimeCodex, store.CodexHome())
 }
 
 func (codexProvider) BuildIssuePreflightInvocation(task IssueTask) (Invocation, error) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -10,6 +10,7 @@ import (
 )
 
 const DefaultID = "codex"
+const ClaudeID = "claude"
 
 type Invocation struct {
 	Dir  string
@@ -41,6 +42,7 @@ type Provider interface {
 
 var registry = map[string]Provider{
 	DefaultID: codexProvider{},
+	ClaudeID:  claudeProvider{},
 }
 
 func RegisteredIDs() []string {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -34,6 +34,26 @@ func TestRequiredToolsetIncludesSharedAndProviderTools(t *testing.T) {
 	}
 }
 
+func TestResolveClaudeProvider(t *testing.T) {
+	selectedProvider, err := Resolve(ClaudeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selectedProvider.DisplayName() != "Claude Code" {
+		t.Fatalf("unexpected provider: %#v", selectedProvider)
+	}
+	got := RequiredToolset(selectedProvider)
+	want := []string{"claude", "gh", "git"}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected tool count: %#v", got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected toolset: %#v", got)
+		}
+	}
+}
+
 func TestResolveIssueLabelUsesRegisteredProviderIDs(t *testing.T) {
 	original := registry
 	registry = map[string]Provider{

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -153,6 +153,48 @@ func TestRunConflictResolutionSessionFailureCommentsOnIssue(t *testing.T) {
 	}
 }
 
+func TestRunIssueSessionSuccessWithClaudeProvider(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Vigilante Session Start",
+				Emoji:      "🧢",
+				Percent:    20,
+				ETAMinutes: 25,
+				Items: []string{
+					"Vigilante launched this implementation session in `/tmp/worktree`.",
+					"Branch: `vigilante/issue-7`.",
+					"Current stage: handing the issue off to the configured coding agent (`Claude Code`) for investigation and implementation.",
+				},
+				Tagline: "Make it simple, but significant.",
+			}): "ok",
+			testutil.Key("claude", "--print", "--cwd", "/tmp/worktree", "--permission-mode", "acceptEdits", skill.BuildIssuePreflightPrompt(
+				state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"},
+				ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"},
+				state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "claude"},
+			)): "baseline ok",
+			testutil.Key("claude", "--print", "--cwd", "/tmp/worktree", "--permission-mode", "acceptEdits", skill.BuildIssuePromptForRuntime(
+				skill.RuntimeClaude,
+				state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"},
+				ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"},
+				state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "claude"},
+			)): "done",
+		},
+	}
+	env := &environment.Environment{OS: "darwin", Runner: runner}
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "claude", Status: state.SessionStatusRunning}
+	got := RunIssueSession(context.Background(), env, store, state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+	if got.Status != state.SessionStatusSuccess {
+		t.Fatalf("unexpected status: %#v", got)
+	}
+}
+
 func TestClassifyBlockedFailureDetectsProviderQuota(t *testing.T) {
 	err := errors.New("exit status 1")
 	output := "You've hit your usage limit. Upgrade to Pro or purchase more credits. Try again at 2026-03-13 09:00 PDT."

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -108,3 +108,33 @@ func TestBuildConfigFailsWhenDaemonPathCannotResolveTools(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestBuildConfigSupportsClaudeProvider(t *testing.T) {
+	t.Setenv("HOME", "/Users/test")
+	t.Setenv("SHELL", "/bin/zsh")
+	t.Setenv("PATH", "/usr/bin:/bin")
+
+	env := &environment.Environment{
+		OS: "darwin",
+		Runner: testutil.FakeRunner{
+			Outputs: map[string]string{
+				`/bin/zsh -lic printf "%s" "$PATH"`: "/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin",
+				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'git'`:    "/opt/homebrew/bin/git\n",
+				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'gh'`:     "/opt/homebrew/bin/gh\n",
+				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'claude'`: "/Users/test/.local/bin/claude\n",
+			},
+		},
+	}
+
+	selectedProvider, err := provider.Resolve(provider.ClaudeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := BuildConfig(context.Background(), env, selectedProvider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.PathEnv != "/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" {
+		t.Fatalf("unexpected PATH: %#v", cfg)
+	}
+}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -17,6 +17,9 @@ const VigilanteIssueImplementation = "vigilante-issue-implementation"
 const VigilanteConflictResolution = "vigilante-conflict-resolution"
 const VigilanteCreateIssue = "vigilante-create-issue"
 
+const RuntimeCodex = "codex"
+const RuntimeClaude = "claude"
+
 func VigilanteSkillNames() []string {
 	return []string{
 		VigilanteIssueImplementation,
@@ -25,27 +28,89 @@ func VigilanteSkillNames() []string {
 	}
 }
 
-func EnsureInstalled(codexHome string) error {
+func EnsureInstalled(runtime string, home string) error {
 	for _, name := range VigilanteSkillNames() {
-		skillDir := filepath.Join(codexHome, "skills", name)
 		source, err := resolveSkillSource(name)
 		if err != nil {
 			return err
 		}
-		if err := os.RemoveAll(skillDir); err != nil {
+		targets, err := installTargets(runtime, home, name)
+		if err != nil {
 			return err
 		}
-		if err := source.install(skillDir); err != nil {
-			return err
+		for _, target := range targets {
+			if err := os.RemoveAll(target); err != nil {
+				return err
+			}
+			if err := source.install(target); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
 }
 
+func installTargets(runtime string, home string, name string) ([]string, error) {
+	switch strings.TrimSpace(runtime) {
+	case RuntimeCodex:
+		return []string{filepath.Join(home, "skills", name)}, nil
+	case RuntimeClaude:
+		return []string{
+			filepath.Join(home, "skills", name),
+			filepath.Join(home, "commands", name),
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported skill runtime %q", runtime)
+	}
+}
+
+func skillBody(name string) (string, error) {
+	source, err := resolveSkillSource(name)
+	if err != nil {
+		return "", err
+	}
+	switch s := source.(type) {
+	case dirSkillSource:
+		data, err := os.ReadFile(filepath.Join(string(s), "SKILL.md"))
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(string(data)), nil
+	case embeddedSkillSource:
+		data, err := fs.ReadFile(s.fs, pathJoin(s.root, "SKILL.md"))
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(string(data)), nil
+	default:
+		return "", fmt.Errorf("unsupported skill source %T", source)
+	}
+}
+
+func InlineSkillHeader(name string) string {
+	body, err := skillBody(name)
+	if err != nil {
+		return fmt.Sprintf("The `%s` skill was requested, but the bundled instructions could not be loaded: %v", name, err)
+	}
+	return strings.Join([]string{
+		fmt.Sprintf("Follow these `%s` skill instructions directly for this task:", name),
+		body,
+		"",
+	}, "\n")
+}
+
 func BuildIssuePrompt(target state.WatchTarget, issue ghcli.Issue, session state.Session) string {
-	providerName := displayProviderName(session.Provider)
-	lines := []string{
-		fmt.Sprintf("Use the `%s` skill for this task.", VigilanteIssueImplementation),
+	return BuildIssuePromptForRuntime(RuntimeCodex, target, issue, session)
+}
+
+func BuildIssuePromptForRuntime(runtime string, target state.WatchTarget, issue ghcli.Issue, session state.Session) string {
+	lines := []string{}
+	if strings.TrimSpace(runtime) == RuntimeClaude {
+		lines = append(lines, InlineSkillHeader(VigilanteIssueImplementation))
+	} else {
+		lines = append(lines, fmt.Sprintf("Use the `%s` skill for this task.", VigilanteIssueImplementation))
+	}
+	lines = append(lines,
 		fmt.Sprintf("Repository: %s", target.Repo),
 		fmt.Sprintf("Local repository path: %s", target.Path),
 		fmt.Sprintf("Issue: #%d - %s", issue.Number, issue.Title),
@@ -53,10 +118,10 @@ func BuildIssuePrompt(target state.WatchTarget, issue ghcli.Issue, session state
 		fmt.Sprintf("Worktree path: %s", session.WorktreePath),
 		fmt.Sprintf("Branch: %s", session.Branch),
 		"Use `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.",
-		fmt.Sprintf("For the coding-agent start comment, use `## 🕹️ Coding Agent Launched: %s` instead of a generic session-start title.", providerName),
+		fmt.Sprintf("For the coding-agent start comment, use `## 🕹️ Coding Agent Launched: %s` instead of a generic session-start title.", displayProviderName(session.Provider)),
 		"Use the same GitHub comment structure for every non-terminal milestone comment: a short header with the current stage and optional emoji, a 10-cell progress bar with percentage, an `ETA: ~N minutes` line, 1-3 concise bullets covering what just happened and what is next, and an optional short playful quote or tagline.",
 		"Use the issue as the source of truth for the requested behavior and keep the implementation minimal.",
-	}
+	)
 	return strings.Join(lines, "\n")
 }
 
@@ -83,6 +148,12 @@ func displayProviderName(name string) string {
 	if name == "" {
 		return "Configured Coding Agent"
 	}
+	switch strings.ToLower(name) {
+	case RuntimeClaude:
+		return "Claude Code"
+	case RuntimeCodex:
+		return "Codex"
+	}
 	parts := strings.FieldsFunc(name, func(r rune) bool {
 		return r == '-' || r == '_' || r == ' '
 	})
@@ -96,8 +167,17 @@ func displayProviderName(name string) string {
 }
 
 func BuildConflictResolutionPrompt(target state.WatchTarget, session state.Session, pr ghcli.PullRequest) string {
-	lines := []string{
-		fmt.Sprintf("Use the `%s` skill for this task.", VigilanteConflictResolution),
+	return BuildConflictResolutionPromptForRuntime(RuntimeCodex, target, session, pr)
+}
+
+func BuildConflictResolutionPromptForRuntime(runtime string, target state.WatchTarget, session state.Session, pr ghcli.PullRequest) string {
+	lines := []string{}
+	if strings.TrimSpace(runtime) == RuntimeClaude {
+		lines = append(lines, InlineSkillHeader(VigilanteConflictResolution))
+	} else {
+		lines = append(lines, fmt.Sprintf("Use the `%s` skill for this task.", VigilanteConflictResolution))
+	}
+	lines = append(lines,
 		fmt.Sprintf("Repository: %s", target.Repo),
 		fmt.Sprintf("Local repository path: %s", target.Path),
 		fmt.Sprintf("Issue: #%d - %s", session.IssueNumber, session.IssueTitle),
@@ -109,7 +189,7 @@ func BuildConflictResolutionPrompt(target state.WatchTarget, session state.Sessi
 		"Base branch: origin/main",
 		"Resolve the current rebase conflicts in the assigned worktree, use `gh issue comment` for progress and failures, rerun `go test ./...` after conflict resolution if the rebase succeeds, and push the updated branch when finished.",
 		"Keep the changes minimal and focused on getting the PR back to a merge-ready state.",
-	}
+	)
 	return strings.Join(lines, "\n")
 }
 

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -41,7 +41,7 @@ func TestEnsureInstalledPrefersRepoSkillsWhenAvailable(t *testing.T) {
 		_ = os.Chdir(wd)
 	}()
 
-	if err := EnsureInstalled(dir); err != nil {
+	if err := EnsureInstalled(RuntimeCodex, dir); err != nil {
 		t.Fatal(err)
 	}
 	for _, name := range VigilanteSkillNames() {
@@ -116,7 +116,7 @@ func TestEnsureInstalledUsesEmbeddedAssetsOutsideRepo(t *testing.T) {
 		_ = os.Chdir(wd)
 	}()
 
-	if err := EnsureInstalled(dir); err != nil {
+	if err := EnsureInstalled(RuntimeCodex, dir); err != nil {
 		t.Fatal(err)
 	}
 
@@ -158,6 +158,57 @@ func TestBuildConflictResolutionPrompt(t *testing.T) {
 	pr := ghcli.PullRequest{Number: 88, URL: "https://example.com/pull/88"}
 	prompt := BuildConflictResolutionPrompt(target, session, pr)
 	for _, text := range []string{"Use the `vigilante-conflict-resolution` skill", "Pull Request: #88", "Base branch: origin/main", "go test ./...", "merge-ready state"} {
+		if !strings.Contains(prompt, text) {
+			t.Fatalf("prompt missing %q: %s", text, prompt)
+		}
+	}
+}
+
+func TestEnsureInstalledForClaudeCreatesCommandsAndSkills(t *testing.T) {
+	dir := t.TempDir()
+	repoRoot := t.TempDir()
+	for _, name := range VigilanteSkillNames() {
+		skillSourceDir := filepath.Join(repoRoot, "skills", name)
+		if err := os.MkdirAll(skillSourceDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(skillSourceDir, "SKILL.md"), []byte("# repo skill\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.Chdir(wd)
+	}()
+
+	if err := EnsureInstalled(RuntimeClaude, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range VigilanteSkillNames() {
+		for _, path := range []string{
+			filepath.Join(dir, "skills", name, "SKILL.md"),
+			filepath.Join(dir, "commands", name, "SKILL.md"),
+		} {
+			if _, err := os.Stat(path); err != nil {
+				t.Fatalf("expected %s to exist: %v", path, err)
+			}
+		}
+	}
+}
+
+func TestBuildIssuePromptForClaudeInlinesSkillInstructions(t *testing.T) {
+	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
+	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
+	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "claude"}
+	prompt := BuildIssuePromptForRuntime(RuntimeClaude, target, issue, session)
+	for _, text := range []string{"Follow these `vigilante-issue-implementation` skill instructions directly", "Coding Agent Launched: Claude Code", "Issue: #12 - Fix bug"} {
 		if !strings.Contains(prompt, text) {
 			t.Fatalf("prompt missing %q: %s", text, prompt)
 		}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -110,6 +110,17 @@ func (s *Store) CodexHome() string {
 	return filepath.Join(home, ".codex")
 }
 
+func (s *Store) ClaudeHome() string {
+	if value := os.Getenv("CLAUDE_HOME"); value != "" {
+		return value
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(s.root, ".claude")
+	}
+	return filepath.Join(home, ".claude")
+}
+
 func (s *Store) EnsureLayout() error {
 	for _, dir := range []string{s.root, s.LogsDir()} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {


### PR DESCRIPTION
## Summary
- add Claude Code as a registered provider with provider-specific CLI invocation builders
- make setup/watch runtime handling provider-aware, including skill installation and resume checks
- document and test Claude provider selection, daemon validation, and runner behavior

## Testing
- go test ./...
- go vet ./...
- go build ./...
- goreleaser check *(not run locally: `goreleaser` is not installed in this environment)*

Closes #79.
