### PR TITLE
Add go-task Taskfile for local build, install, and setup workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,12 +171,33 @@ Expected behavior:
 
 For fast local iteration, prefer running `vigilante` in the foreground instead of going through the installed OS service on every change.
 
+If you use [`go-task`](https://taskfile.dev/), the repository includes a root `Taskfile.yml` for the main local workflows. Install `task` with either:
+
+```sh
+brew install go-task/tap/go-task
+```
+
+or:
+
+```sh
+go install github.com/go-task/task/v3/cmd/task@latest
+```
+
+Primary tasks:
+
+- `task test` runs `go test ./...`
+- `task build` builds `./vigilante`
+- `task install` copies the built binary to `~/.local/bin/vigilante`
+- `task setup` runs `./vigilante setup`
+- `task install-setup` runs `~/.local/bin/vigilante setup`
+- `task setup-daemon` runs `~/.local/bin/vigilante setup -d`
+
 Recommended loop:
 
 ```sh
-go test ./...
-go build -o ./vigilante ./cmd/vigilante
-./vigilante setup
+task test
+task build
+task setup
 ./vigilante watch /path/to/repo
 ./vigilante daemon run --once
 ```
@@ -198,14 +219,14 @@ go run ./cmd/vigilante daemon run --interval 30s
 - rebuild the installed binary and refresh the installed Codex skill:
 
 ```sh
-go build -o /Users/$USER/.local/bin/vigilante ./cmd/vigilante
-/Users/$USER/.local/bin/vigilante setup
+task install
+task install-setup
 ```
 
 - reinstall the OS service after changing daemon or service behavior:
 
 ```sh
-/Users/$USER/.local/bin/vigilante setup -d
+task setup-daemon
 ```
 
 Notes:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,41 @@
+version: "3"
+
+vars:
+  LOCAL_BIN_DIR: "{{.HOME}}/.local/bin"
+  INSTALL_PATH: "{{.LOCAL_BIN_DIR}}/vigilante"
+
+tasks:
+  test:
+    desc: Run the Go test suite
+    cmds:
+      - go test ./...
+
+  build:
+    desc: Build the repo-local vigilante binary
+    cmds:
+      - go build -o ./vigilante ./cmd/vigilante
+
+  install:
+    desc: Install the built binary into ~/.local/bin
+    deps: [build]
+    cmds:
+      - mkdir -p "{{.LOCAL_BIN_DIR}}"
+      - cp ./vigilante "{{.INSTALL_PATH}}"
+
+  setup:
+    desc: Run setup with the repo-local binary
+    deps: [build]
+    cmds:
+      - ./vigilante setup
+
+  install-setup:
+    desc: Run setup with the installed local binary
+    deps: [install]
+    cmds:
+      - '{{.INSTALL_PATH}} setup'
+
+  setup-daemon:
+    desc: Refresh the installed daemon or service definition
+    deps: [install]
+    cmds:
+      - '{{.INSTALL_PATH}} setup -d'


### PR DESCRIPTION
## Summary
- add a root `Taskfile.yml` for the main local developer workflows
- document `go-task` installation and the primary task shortcuts in the README
- keep the task commands aligned with the existing documented build/install/setup commands

Closes #83

## Validation
- `task --list`
- `task build`
- `task test`
- `task --dry install`
- `task --dry setup`
- `task --dry install-setup`
- `task --dry setup-daemon`