### PR TITLE
Add repo classification and issue skill routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Once a folder is registered, `vigilante` should:
 2. Poll or subscribe for open GitHub issues through `gh`.
 3. Select issues that are ready to work and not already being handled.
 4. Launch a headless coding agent session in YOLO mode against a dedicated git worktree.
-5. Use the issue implementation skill from the repo `skills/` folder as part of the execution prompt.
+5. Classify the watched repository, select the appropriate bundled issue implementation skill, and include the repo/process context in the execution prompt.
 6. Post progress comments back to the GitHub issue, including session start and failures.
 7. Track watched repositories locally and optionally run as a daemon.
 
@@ -44,12 +44,15 @@ For each watched repository:
    - `git`
    - `gh`
    - the configured coding-agent provider CLI (`codex` or `claude`)
-4. Ensure the coding-agent issue implementation skill from `skills/vigilante-issue-implementation/` is installed during setup, including its companion agent metadata.
+4. Ensure the bundled coding-agent skills are installed during setup, including their companion agent metadata:
+   - `skills/vigilante-issue-implementation/`
+   - `skills/vigilante-issue-implementation-on-monorepo/`
 5. Query GitHub for open issues.
 6. Determine which issues are eligible for execution.
 7. Create a git worktree for the selected issue.
 8. Launch a supported coding agent headlessly in the worktree with a prompt that:
-   - uses the issue implementation skill
+   - uses the issue implementation skill selected from the repo classification
+   - includes the detected repo shape and process hints
    - instructs the agent to comment on the issue when work starts
    - instructs the agent to keep commenting as progress is made
    - instructs the agent to report errors back to the issue
@@ -168,6 +171,7 @@ Expected behavior:
 - verifies `git`, `gh`, and the selected coding-agent provider CLI
 - installs the bundled coding-agent skills for regular runtime use, including any companion files under each skill directory
   - `vigilante-issue-implementation`
+  - `vigilante-issue-implementation-on-monorepo`
   - `vigilante-conflict-resolution`
   - `vigilante-create-issue`
 - installs or updates the daemon definition when requested

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nicobistolfi/vigilante/internal/repo"
 	issuerunner "github.com/nicobistolfi/vigilante/internal/runner"
 	"github.com/nicobistolfi/vigilante/internal/service"
+	"github.com/nicobistolfi/vigilante/internal/skill"
 	"github.com/nicobistolfi/vigilante/internal/state"
 	"github.com/nicobistolfi/vigilante/internal/worktree"
 )
@@ -282,6 +283,7 @@ func (a *App) WatchWithProvider(ctx context.Context, rawPath string, daemon bool
 		if target.Path == info.Path {
 			targets[i].Repo = info.Repo
 			targets[i].Branch = info.Branch
+			applyRepoInfo(&targets[i], info)
 			if strings.TrimSpace(targets[i].Provider) == "" {
 				targets[i].Provider = provider.DefaultID
 			}
@@ -315,6 +317,7 @@ func (a *App) WatchWithProvider(ctx context.Context, rawPath string, daemon bool
 			DaemonEnabled: daemon,
 			AddedAt:       a.clock().Format(time.RFC3339),
 		}
+		applyRepoInfo(&target, info)
 		if providerID != "" {
 			target.Provider = providerID
 		}
@@ -338,10 +341,10 @@ func (a *App) WatchWithProvider(ctx context.Context, rawPath string, daemon bool
 	}
 
 	if updated {
-		a.state.AppendDaemonLog("watch updated path=%s repo=%s branch=%s assignee=%s max_parallel=%d daemon=%t", info.Path, info.Repo, info.Branch, assigneeOrDefault(findWatchTargetAssignee(targets, info.Path)), findWatchTargetMaxParallel(targets, info.Path), daemon)
+		a.state.AppendDaemonLog("watch updated path=%s repo=%s branch=%s repo_shape=%s assignee=%s max_parallel=%d daemon=%t", info.Path, info.Repo, info.Branch, info.Classification.Shape, assigneeOrDefault(findWatchTargetAssignee(targets, info.Path)), findWatchTargetMaxParallel(targets, info.Path), daemon)
 		fmt.Fprintln(a.stdout, "updated", info.Path)
 	} else {
-		a.state.AppendDaemonLog("watch added path=%s repo=%s branch=%s assignee=%s max_parallel=%d daemon=%t", info.Path, info.Repo, info.Branch, assigneeOrDefault(assignee), configuredMaxParallel(maxParallel), daemon)
+		a.state.AppendDaemonLog("watch added path=%s repo=%s branch=%s repo_shape=%s assignee=%s max_parallel=%d daemon=%t", info.Path, info.Repo, info.Branch, info.Classification.Shape, assigneeOrDefault(assignee), configuredMaxParallel(maxParallel), daemon)
 		fmt.Fprintln(a.stdout, "watching", info.Path)
 	}
 	return nil
@@ -515,6 +518,13 @@ func (a *App) ScanOnce(ctx context.Context) error {
 				if selectedProvider != target.Provider {
 					a.state.AppendDaemonLog("scan repo issue provider override repo=%s issue=%d provider=%s source=label", target.Repo, next.Number, selectedProvider)
 				}
+				a.state.AppendDaemonLog(
+					"scan repo issue skill selected repo=%s issue=%d repo_shape=%s skill=%s",
+					target.Repo,
+					next.Number,
+					fallbackText(target.RepoShape, "traditional"),
+					skill.IssueImplementationSkill(*target),
+				)
 
 				wt, err := worktree.CreateIssueWorktree(ctx, a.env.Runner, *target, next.Number, next.Title)
 				if err != nil {
@@ -1875,6 +1885,13 @@ func normalizeLabels(labels []string) []string {
 	}
 	sort.Strings(normalized)
 	return normalized
+}
+
+func applyRepoInfo(target *state.WatchTarget, info repo.Info) {
+	target.RepoShape = info.Classification.Shape
+	target.WorkspaceFiles = append([]string(nil), info.Classification.ProcessHints.WorkspaceFiles...)
+	target.WorkspaceGlobs = append([]string(nil), info.Classification.ProcessHints.WorkspaceGlobs...)
+	target.ProjectRoots = append([]string(nil), info.Classification.ProcessHints.ProjectRoots...)
 }
 
 func findWatchTargetAssignee(targets []state.WatchTarget, path string) string {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -86,6 +86,7 @@ func TestSetupCreatesStateLayoutAndSkill(t *testing.T) {
 		filepath.Join(app.state.Root(), "sessions.json"),
 		filepath.Join(app.state.Root(), "logs"),
 		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteIssueImplementation, "SKILL.md"),
+		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteIssueImplementationOnMonorepo, "SKILL.md"),
 		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteConflictResolution, "SKILL.md"),
 	} {
 		if _, err := os.Stat(path); err != nil {
@@ -134,6 +135,9 @@ func TestWatchListAndUnwatch(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "\"max_parallel_sessions\": 3") {
 		t.Fatalf("expected default max_parallel_sessions in list output: %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "\"repo_shape\": \"traditional\"") {
+		t.Fatalf("expected repo classification in list output: %s", stdout.String())
 	}
 
 	if err := app.Unwatch(repoPath); err != nil {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,9 +1,11 @@
 package provider
 
 import (
+	"strings"
 	"testing"
 
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
+	"github.com/nicobistolfi/vigilante/internal/skill"
 	"github.com/nicobistolfi/vigilante/internal/state"
 )
 
@@ -89,6 +91,25 @@ func TestResolveIssueLabelRejectsConflictingProviderLabels(t *testing.T) {
 	}
 	if got := err.Error(); got != "multiple provider labels: codex, cursor" {
 		t.Fatalf("unexpected conflict error: %s", got)
+	}
+}
+
+func TestCodexBuildIssueInvocationUsesMonorepoSkill(t *testing.T) {
+	invocation, err := codexProvider{}.BuildIssueInvocation(IssueTask{
+		Target: state.WatchTarget{
+			Path:      "/tmp/repo",
+			Repo:      "owner/repo",
+			RepoShape: "monorepo",
+		},
+		Issue:   ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"},
+		Session: state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prompt := invocation.Args[len(invocation.Args)-1]
+	if !strings.Contains(prompt, "Use the `"+skill.VigilanteIssueImplementationOnMonorepo+"` skill for this task.") {
+		t.Fatalf("unexpected prompt: %s", prompt)
 	}
 }
 

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -2,19 +2,39 @@ package repo
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/nicobistolfi/vigilante/internal/environment"
 )
 
+const (
+	ShapeTraditional = "traditional"
+	ShapeMonorepo    = "monorepo"
+)
+
+type ProcessHints struct {
+	WorkspaceFiles []string `json:"workspace_files,omitempty"`
+	WorkspaceGlobs []string `json:"workspace_globs,omitempty"`
+	ProjectRoots   []string `json:"project_roots,omitempty"`
+}
+
+type Classification struct {
+	Shape        string       `json:"shape"`
+	ProcessHints ProcessHints `json:"process_hints,omitempty"`
+}
+
 type Info struct {
-	Path   string
-	Repo   string
-	Branch string
+	Path           string
+	Repo           string
+	Branch         string
+	Classification Classification
 }
 
 func Discover(ctx context.Context, runner environment.Runner, path string) (Info, error) {
@@ -42,11 +62,139 @@ func Discover(ctx context.Context, runner environment.Runner, path string) (Info
 		branch = strings.TrimSpace(current)
 	}
 
+	classification, err := Classify(absPath)
+	if err != nil {
+		return Info{}, err
+	}
+
 	return Info{
-		Path:   absPath,
-		Repo:   repo,
-		Branch: branch,
+		Path:           absPath,
+		Repo:           repo,
+		Branch:         branch,
+		Classification: classification,
 	}, nil
+}
+
+func Classify(root string) (Classification, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return Classification{}, err
+	}
+
+	classification := Classification{
+		Shape:        ShapeTraditional,
+		ProcessHints: ProcessHints{},
+	}
+	classification.ProcessHints.WorkspaceFiles = detectWorkspaceFiles(absRoot)
+	classification.ProcessHints.WorkspaceGlobs = detectWorkspaceGlobs(absRoot)
+	classification.ProcessHints.ProjectRoots = detectProjectRoots(absRoot)
+
+	if len(classification.ProcessHints.WorkspaceFiles) > 0 || len(classification.ProcessHints.WorkspaceGlobs) > 0 || len(classification.ProcessHints.ProjectRoots) >= 2 {
+		classification.Shape = ShapeMonorepo
+	}
+	return classification, nil
+}
+
+func detectWorkspaceFiles(root string) []string {
+	candidates := []string{
+		"pnpm-workspace.yaml",
+		"turbo.json",
+		"nx.json",
+		"lerna.json",
+		"rush.json",
+		"go.work",
+	}
+	found := make([]string, 0, len(candidates)+1)
+	for _, name := range candidates {
+		if fileExists(filepath.Join(root, name)) {
+			found = append(found, name)
+		}
+	}
+	if packageJSONDeclaresWorkspaces(filepath.Join(root, "package.json")) {
+		found = append(found, "package.json#workspaces")
+	}
+	sort.Strings(found)
+	return found
+}
+
+func detectWorkspaceGlobs(root string) []string {
+	return readPackageJSONWorkspaces(filepath.Join(root, "package.json"))
+}
+
+func detectProjectRoots(root string) []string {
+	candidates := []string{"apps", "packages", "services"}
+	projects := []string{}
+	for _, dir := range candidates {
+		entries, err := os.ReadDir(filepath.Join(root, dir))
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+				continue
+			}
+			projects = append(projects, filepath.ToSlash(filepath.Join(dir, entry.Name())))
+		}
+	}
+	return compactSorted(projects)
+}
+
+type packageJSONWorkspaces struct {
+	Workspaces json.RawMessage `json:"workspaces"`
+}
+
+func packageJSONDeclaresWorkspaces(path string) bool {
+	return len(readPackageJSONWorkspaces(path)) > 0
+}
+
+func readPackageJSONWorkspaces(path string) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var pkg packageJSONWorkspaces
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return nil
+	}
+	if len(pkg.Workspaces) == 0 {
+		return nil
+	}
+
+	var globs []string
+	if err := json.Unmarshal(pkg.Workspaces, &globs); err == nil {
+		return compactSorted(globs)
+	}
+
+	var object struct {
+		Packages []string `json:"packages"`
+	}
+	if err := json.Unmarshal(pkg.Workspaces, &object); err == nil {
+		return compactSorted(object.Packages)
+	}
+	return nil
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func compactSorted(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func ParseGitHubRepo(remote string) (string, error) {

--- a/internal/repo/repo_test.go
+++ b/internal/repo/repo_test.go
@@ -2,6 +2,7 @@ package repo
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -42,6 +43,9 @@ func TestDiscoverRepositoryWithRealGit(t *testing.T) {
 	if info.Branch != "main" {
 		t.Fatalf("unexpected branch: %#v", info)
 	}
+	if info.Classification.Shape != ShapeTraditional {
+		t.Fatalf("unexpected classification: %#v", info.Classification)
+	}
 }
 
 func TestExpandPath(t *testing.T) {
@@ -65,4 +69,84 @@ func mustRun(t *testing.T, runner environment.Runner, ctx context.Context, dir, 
 	if _, err := runner.Run(ctx, dir, name, args...); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestClassifyTraditionalRepository(t *testing.T) {
+	dir := t.TempDir()
+
+	got, err := Classify(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Shape != ShapeTraditional {
+		t.Fatalf("unexpected shape: %#v", got)
+	}
+	if len(got.ProcessHints.WorkspaceFiles) != 0 || len(got.ProcessHints.WorkspaceGlobs) != 0 || len(got.ProcessHints.ProjectRoots) != 0 {
+		t.Fatalf("expected no process hints: %#v", got)
+	}
+}
+
+func TestClassifyMonorepoWithWorkspaceSignals(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"workspaces":["apps/*","packages/*"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{
+		filepath.Join(dir, "apps", "web"),
+		filepath.Join(dir, "packages", "ui"),
+	} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := Classify(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Shape != ShapeMonorepo {
+		t.Fatalf("unexpected shape: %#v", got)
+	}
+	for _, want := range []string{"package.json#workspaces"} {
+		if !contains(got.ProcessHints.WorkspaceFiles, want) {
+			t.Fatalf("expected workspace file %q in %#v", want, got.ProcessHints)
+		}
+	}
+	for _, want := range []string{"apps/*", "packages/*"} {
+		if !contains(got.ProcessHints.WorkspaceGlobs, want) {
+			t.Fatalf("expected workspace glob %q in %#v", want, got.ProcessHints)
+		}
+	}
+	for _, want := range []string{"apps/web", "packages/ui"} {
+		if !contains(got.ProcessHints.ProjectRoots, want) {
+			t.Fatalf("expected project root %q in %#v", want, got.ProcessHints)
+		}
+	}
+}
+
+func TestClassifyAmbiguousRepositoryFallsBackToTraditional(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "packages", "single"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Classify(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Shape != ShapeTraditional {
+		t.Fatalf("unexpected shape: %#v", got)
+	}
+	if !contains(got.ProcessHints.ProjectRoots, "packages/single") {
+		t.Fatalf("expected project root hint: %#v", got.ProcessHints)
+	}
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	skillassets "github.com/nicobistolfi/vigilante"
@@ -14,6 +15,7 @@ import (
 )
 
 const VigilanteIssueImplementation = "vigilante-issue-implementation"
+const VigilanteIssueImplementationOnMonorepo = "vigilante-issue-implementation-on-monorepo"
 const VigilanteConflictResolution = "vigilante-conflict-resolution"
 const VigilanteCreateIssue = "vigilante-create-issue"
 
@@ -23,6 +25,7 @@ const RuntimeClaude = "claude"
 func VigilanteSkillNames() []string {
 	return []string{
 		VigilanteIssueImplementation,
+		VigilanteIssueImplementationOnMonorepo,
 		VigilanteConflictResolution,
 		VigilanteCreateIssue,
 	}
@@ -104,15 +107,19 @@ func BuildIssuePrompt(target state.WatchTarget, issue ghcli.Issue, session state
 }
 
 func BuildIssuePromptForRuntime(runtime string, target state.WatchTarget, issue ghcli.Issue, session state.Session) string {
+	selectedSkill := IssueImplementationSkill(target)
 	lines := []string{}
 	if strings.TrimSpace(runtime) == RuntimeClaude {
-		lines = append(lines, InlineSkillHeader(VigilanteIssueImplementation))
+		lines = append(lines, InlineSkillHeader(selectedSkill))
 	} else {
-		lines = append(lines, fmt.Sprintf("Use the `%s` skill for this task.", VigilanteIssueImplementation))
+		lines = append(lines, fmt.Sprintf("Use the `%s` skill for this task.", selectedSkill))
 	}
 	lines = append(lines,
 		fmt.Sprintf("Repository: %s", target.Repo),
 		fmt.Sprintf("Local repository path: %s", target.Path),
+		fmt.Sprintf("Repository shape: %s", issueRepoShape(target)),
+		fmt.Sprintf("Selected issue implementation skill: %s", selectedSkill),
+		fmt.Sprintf("Detected process hints: %s", formatProcessHints(target)),
 		fmt.Sprintf("Issue: #%d - %s", issue.Number, issue.Title),
 		fmt.Sprintf("Issue URL: %s", issue.URL),
 		fmt.Sprintf("Worktree path: %s", session.WorktreePath),
@@ -123,6 +130,13 @@ func BuildIssuePromptForRuntime(runtime string, target state.WatchTarget, issue 
 		"Use the issue as the source of truth for the requested behavior and keep the implementation minimal.",
 	)
 	return strings.Join(lines, "\n")
+}
+
+func IssueImplementationSkill(target state.WatchTarget) string {
+	if strings.TrimSpace(target.RepoShape) == "monorepo" {
+		return VigilanteIssueImplementationOnMonorepo
+	}
+	return VigilanteIssueImplementation
 }
 
 func BuildIssuePreflightPrompt(target state.WatchTarget, issue ghcli.Issue, session state.Session) string {
@@ -164,6 +178,37 @@ func displayProviderName(name string) string {
 		parts[i] = strings.ToUpper(part[:1]) + strings.ToLower(part[1:])
 	}
 	return strings.Join(parts, " ")
+}
+
+func issueRepoShape(target state.WatchTarget) string {
+	shape := strings.TrimSpace(target.RepoShape)
+	if shape == "" {
+		return "traditional (defaulted)"
+	}
+	return shape
+}
+
+func formatProcessHints(target state.WatchTarget) string {
+	parts := []string{}
+	if len(target.WorkspaceFiles) > 0 {
+		parts = append(parts, "workspace_files="+strings.Join(sortedCopy(target.WorkspaceFiles), ","))
+	}
+	if len(target.WorkspaceGlobs) > 0 {
+		parts = append(parts, "workspace_globs="+strings.Join(sortedCopy(target.WorkspaceGlobs), ","))
+	}
+	if len(target.ProjectRoots) > 0 {
+		parts = append(parts, "project_roots="+strings.Join(sortedCopy(target.ProjectRoots), ","))
+	}
+	if len(parts) == 0 {
+		return "none detected; default to traditional repo skill"
+	}
+	return strings.Join(parts, "; ")
+}
+
+func sortedCopy(values []string) []string {
+	out := append([]string(nil), values...)
+	sort.Strings(out)
+	return out
 }
 
 func BuildConflictResolutionPrompt(target state.WatchTarget, session state.Session, pr ghcli.PullRequest) string {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -133,7 +133,34 @@ func TestBuildIssuePrompt(t *testing.T) {
 	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
 	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
 	prompt := BuildIssuePrompt(target, issue, session)
-	for _, text := range []string{"Use the `vigilante-issue-implementation` skill", "Issue: #12 - Fix bug", "Worktree path: /tmp/worktree", "gh issue comment", "implementation plan", "open a pull request", "Coding Agent Launched: Codex", "10-cell progress bar", "ETA: ~N minutes"} {
+	for _, text := range []string{"Use the `vigilante-issue-implementation` skill", "Repository shape: traditional (defaulted)", "Selected issue implementation skill: vigilante-issue-implementation", "Detected process hints: none detected; default to traditional repo skill", "Issue: #12 - Fix bug", "Worktree path: /tmp/worktree", "gh issue comment", "implementation plan", "open a pull request", "Coding Agent Launched: Codex", "10-cell progress bar", "ETA: ~N minutes"} {
+		if !strings.Contains(prompt, text) {
+			t.Fatalf("prompt missing %q: %s", text, prompt)
+		}
+	}
+}
+
+func TestBuildIssuePromptSelectsMonorepoSkill(t *testing.T) {
+	target := state.WatchTarget{
+		Path:           "/tmp/repo",
+		Repo:           "owner/repo",
+		RepoShape:      "monorepo",
+		WorkspaceFiles: []string{"pnpm-workspace.yaml"},
+		WorkspaceGlobs: []string{"apps/*", "packages/*"},
+		ProjectRoots:   []string{"apps/web", "packages/ui"},
+	}
+	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
+	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
+
+	prompt := BuildIssuePrompt(target, issue, session)
+	for _, text := range []string{
+		"Use the `vigilante-issue-implementation-on-monorepo` skill",
+		"Repository shape: monorepo",
+		"Selected issue implementation skill: vigilante-issue-implementation-on-monorepo",
+		"workspace_files=pnpm-workspace.yaml",
+		"workspace_globs=apps/*,packages/*",
+		"project_roots=apps/web,packages/ui",
+	} {
 		if !strings.Contains(prompt, text) {
 			t.Fatalf("prompt missing %q: %s", text, prompt)
 		}
@@ -212,6 +239,18 @@ func TestBuildIssuePromptForClaudeInlinesSkillInstructions(t *testing.T) {
 		if !strings.Contains(prompt, text) {
 			t.Fatalf("prompt missing %q: %s", text, prompt)
 		}
+	}
+}
+
+func TestIssueImplementationSkillDefaultsToTraditional(t *testing.T) {
+	if got := IssueImplementationSkill(state.WatchTarget{}); got != VigilanteIssueImplementation {
+		t.Fatalf("unexpected skill: %s", got)
+	}
+}
+
+func TestIssueImplementationSkillUsesMonorepoVariant(t *testing.T) {
+	if got := IssueImplementationSkill(state.WatchTarget{RepoShape: "monorepo"}); got != VigilanteIssueImplementationOnMonorepo {
+		t.Fatalf("unexpected skill: %s", got)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -14,16 +14,20 @@ import (
 )
 
 type WatchTarget struct {
-	Path          string   `json:"path"`
-	Repo          string   `json:"repo"`
-	Branch        string   `json:"branch"`
-	Provider      string   `json:"provider,omitempty"`
-	Labels        []string `json:"labels,omitempty"`
-	Assignee      string   `json:"assignee,omitempty"`
-	MaxParallel   int      `json:"max_parallel_sessions"`
-	DaemonEnabled bool     `json:"daemon_enabled"`
-	LastScanAt    string   `json:"last_scan_at,omitempty"`
-	AddedAt       string   `json:"added_at,omitempty"`
+	Path           string   `json:"path"`
+	Repo           string   `json:"repo"`
+	Branch         string   `json:"branch"`
+	RepoShape      string   `json:"repo_shape,omitempty"`
+	WorkspaceFiles []string `json:"workspace_files,omitempty"`
+	WorkspaceGlobs []string `json:"workspace_globs,omitempty"`
+	ProjectRoots   []string `json:"project_roots,omitempty"`
+	Provider       string   `json:"provider,omitempty"`
+	Labels         []string `json:"labels,omitempty"`
+	Assignee       string   `json:"assignee,omitempty"`
+	MaxParallel    int      `json:"max_parallel_sessions"`
+	DaemonEnabled  bool     `json:"daemon_enabled"`
+	LastScanAt     string   `json:"last_scan_at,omitempty"`
+	AddedAt        string   `json:"added_at,omitempty"`
 }
 
 const DefaultMaxParallelSessions = 3

--- a/skillassets.go
+++ b/skillassets.go
@@ -4,5 +4,5 @@ import "embed"
 
 // Skills contains built-in runtime skill files for installed binaries.
 //
-//go:embed skills/vigilante-issue-implementation skills/vigilante-conflict-resolution skills/vigilante-create-issue
+//go:embed skills/vigilante-issue-implementation skills/vigilante-issue-implementation-on-monorepo skills/vigilante-conflict-resolution skills/vigilante-create-issue
 var Skills embed.FS

--- a/skills/vigilante-issue-implementation-on-monorepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-monorepo/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: vigilante-issue-implementation-on-monorepo
+description: Implement a GitHub issue end-to-end for a Vigilante-dispatched monorepo. Use the provided worktree, keep changes scoped to the affected package or app, comment on the issue as work progresses, and report failures back to GitHub.
+---
+
+# Vigilante Issue Implementation On Monorepo
+
+## Overview
+Implement one GitHub issue from Vigilante dispatch through validated code changes, a pushed branch, and an opened pull request from the provided worktree. Always work inside the assigned worktree, keep changes focused on the affected app or package, respect repository instructions, and keep the GitHub issue updated with start, plan, progress, PR, and failure comments.
+
+## Workflow
+1. Inspect issue and repository constraints
+- Read the issue details supplied by Vigilante and confirm the issue scope before coding.
+- Read `AGENTS.md`, `README.md`, and any touched-area docs before making changes.
+- Use the repo classification and process hints in the prompt to identify the most likely app/package boundary before editing.
+
+2. Announce session start and plan on GitHub
+- Post a start comment with `gh issue comment` as soon as work begins.
+- Post a concise implementation plan before substantial coding.
+
+3. Implement inside the assigned worktree only
+- Use only the provided worktree path.
+- Keep changes scoped to the relevant app/package/workspace unless the issue requires a broader cross-cutting fix.
+- Prefer existing monorepo tooling and scripts instead of inventing new entrypoints.
+
+4. Validate incrementally
+- Run the narrowest relevant checks first for the touched package/app, then broader workspace validation only when needed.
+- If the monorepo provides filtered or targeted commands, prefer those over whole-repo commands.
+
+5. Finish the issue lifecycle
+- Push the assigned branch.
+- Open a pull request against the default branch unless repo instructions say otherwise.
+- Comment on meaningful milestones and report any blocker or validation failure back to the issue.
+
+## Guardrails
+- Never work outside the assigned worktree.
+- Never ignore repository instructions or area-specific docs.
+- Never broaden the change beyond the issue without a concrete reason.
+- Never claim validation passed unless the corresponding command actually succeeded.
+
+## Output Expectations
+- code changes in the assigned worktree
+- a pushed branch containing those changes
+- an opened pull request for those changes
+- a clear issue comment trail produced through `gh issue comment`
+- accurate success or failure reporting

--- a/skills/vigilante-issue-implementation-on-monorepo/agents/openai.yaml
+++ b/skills/vigilante-issue-implementation-on-monorepo/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Vigilante Monorepo Issue Implementation"
+  short_description: "Implement a Vigilante-dispatched GitHub issue in a monorepo with scoped validation, pushed changes, and a PR"
+  default_prompt: "Use $vigilante-issue-implementation-on-monorepo to implement the assigned issue in the provided worktree, keep changes scoped to the relevant app or package, push the branch, open a PR, comment on the issue as progress is made, and report failures clearly."


### PR DESCRIPTION
## Summary
- add reusable repository classification with conservative monorepo detection and structured process hints
- persist repo shape metadata on watched targets and select the issue implementation skill from it at dispatch time
- install/embed the new monorepo issue skill and update tests/docs for repo-aware prompting

## Testing
- go test ./...

Closes #63