### PR TITLE
Add Gemini CLI as a first-class provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 `vigilante` is a Go CLI and background service that watches local Git repositories, discovers their GitHub remotes, monitors open issues with the GitHub CLI, and orchestrates headless coding agent sessions in isolated git worktrees.
 
-The initial target platforms are macOS and Ubuntu. The first implementation should keep dependencies minimal and lean on existing system tools where possible: `git`, `gh`, one or more headless coding agent CLIs such as `claude code` and `codex`.
+The initial target platforms are macOS and Ubuntu. The first implementation should keep dependencies minimal and lean on existing system tools where possible: `git`, `gh`, one or more headless coding agent CLIs such as `claude code`, `codex`, and `gemini`.
 
 ## What Vigilante Is
 
@@ -43,7 +43,7 @@ For each watched repository:
 3. Ensure required tools are available:
    - `git`
    - `gh`
-   - the configured coding-agent provider CLI (`codex` or `claude`)
+   - the configured coding-agent provider CLI (`codex`, `claude`, or `gemini`)
 4. Ensure the coding-agent issue implementation skill from `skills/vigilante-issue-implementation/` is installed during setup, including its companion agent metadata.
 5. Query GitHub for open issues.
 6. Determine which issues are eligible for execution.
@@ -73,7 +73,7 @@ Upgrade later with:
 brew upgrade --cask vigilante
 ```
 
-### `vigilante watch [--assignee <value>] [--max-parallel <value>] [--provider <codex|claude>] <path>`
+### `vigilante watch [--assignee <value>] [--max-parallel <value>] [--provider <codex|claude|gemini>] <path>`
 
 Register a local repository for issue monitoring.
 
@@ -104,6 +104,10 @@ vigilante watch --max-parallel 3 ~/hello-world-app
 
 ```sh
 vigilante watch --provider claude ~/hello-world-app
+```
+
+```sh
+vigilante watch --provider gemini ~/hello-world-app
 ```
 
 ### `vigilante watch -d <path>`
@@ -157,7 +161,7 @@ Remove a repository from the watchlist without deleting the repository itself.
 Run the long-lived watcher loop in the foreground. This is the process the OS service should execute.
 By default it scans watched repositories every 1 minute. Use `--interval` to override that cadence for manual runs.
 
-### `vigilante setup [--provider <codex|claude>]`
+### `vigilante setup [--provider <codex|claude|gemini>]`
 
 Prepare the machine for autonomous execution.
 
@@ -333,7 +337,7 @@ Initial rules:
 - enforce `max_parallel_sessions` independently for each watched repository
 - count both running implementation sessions and open-PR maintenance sessions against that repository limit
 - avoid duplicate work across multiple daemon scans
-- allow an issue label that exactly matches a registered provider id, such as `codex` or `claude`, to override the watch target provider for that issue only
+- allow an issue label that exactly matches a registered provider id, such as `codex`, `claude`, or `gemini`, to override the watch target provider for that issue only
 - if more than one provider-id label is present on the same issue, skip dispatch instead of choosing a provider arbitrarily
 - prefer oldest eligible open issue first unless later prioritization rules are added
 
@@ -350,7 +354,7 @@ When `vigilante` launches a coding agent for an issue, it should:
 - instruct the agent to post progress comments during execution
 - instruct the agent to report failures on the issue if execution aborts
 
-The agent invocation remains a subprocess wrapper around an installed coding CLI such as `codex` or `claude`, while keeping the orchestration behavior provider-neutral.
+The agent invocation remains a subprocess wrapper around an installed coding CLI such as `codex`, `claude`, or `gemini`, while keeping the orchestration behavior provider-neutral.
 
 ## GitHub Integration
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1646,15 +1646,15 @@ func (a *App) generateResumeFailureDiagnostic(ctx context.Context, session state
 	if workdir == "" {
 		workdir = session.RepoPath
 	}
-	output, err := a.env.Runner.Run(
-		ctx,
-		workdir,
-		"codex",
-		"exec",
-		"--cd", workdir,
-		"--dangerously-bypass-approvals-and-sandbox",
-		buildResumeFailureSummaryPrompt(session, previousStage),
-	)
+	selectedProvider, err := provider.Resolve(session.Provider)
+	if err != nil {
+		return resumeFailureDiagnostic{}, err
+	}
+	invocation, err := buildResumeFailureSummaryInvocation(selectedProvider, workdir, buildResumeFailureSummaryPrompt(session, previousStage))
+	if err != nil {
+		return resumeFailureDiagnostic{}, err
+	}
+	output, err := a.env.Runner.Run(ctx, invocation.Dir, invocation.Name, invocation.Args...)
 	if err != nil {
 		return resumeFailureDiagnostic{}, err
 	}
@@ -1667,6 +1667,43 @@ func (a *App) generateResumeFailureDiagnostic(ctx context.Context, session state
 		return resumeFailureDiagnostic{}, errors.New("resume diagnostic summary missing required fields")
 	}
 	return diagnostic, nil
+}
+
+func buildResumeFailureSummaryInvocation(selectedProvider provider.Provider, workdir string, prompt string) (provider.Invocation, error) {
+	switch selectedProvider.ID() {
+	case provider.ClaudeID:
+		return provider.Invocation{
+			Name: "claude",
+			Args: []string{
+				"--print",
+				"--cwd", workdir,
+				"--permission-mode", "acceptEdits",
+				prompt,
+			},
+		}, nil
+	case provider.GeminiID:
+		return provider.Invocation{
+			Dir:  workdir,
+			Name: "gemini",
+			Args: []string{
+				"--prompt",
+				prompt,
+				"--yolo",
+			},
+		}, nil
+	case provider.DefaultID:
+		fallthrough
+	default:
+		return provider.Invocation{
+			Name: "codex",
+			Args: []string{
+				"exec",
+				"--cd", workdir,
+				"--dangerously-bypass-approvals-and-sandbox",
+				prompt,
+			},
+		}, nil
+	}
 }
 
 func buildResumeFailureSummaryPrompt(session state.Session, previousStage string) string {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -94,6 +94,38 @@ func TestSetupCreatesStateLayoutAndSkill(t *testing.T) {
 	}
 }
 
+func TestSetupWithGeminiCreatesGeminiSkillAssets(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Setenv("GEMINI_HOME", filepath.Join(home, ".gemini"))
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "gemini": "/usr/bin/gemini"},
+		Outputs: map[string]string{
+			"gh auth status": "ok",
+		},
+	}
+
+	if err := app.SetupWithProvider(context.Background(), false, "gemini"); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range []string{
+		filepath.Join(app.state.GeminiHome(), "skills", skill.VigilanteIssueImplementation, "SKILL.md"),
+		filepath.Join(app.state.GeminiHome(), "commands", skill.VigilanteIssueImplementation+".toml"),
+		filepath.Join(app.state.GeminiHome(), "skills", skill.VigilanteConflictResolution, "SKILL.md"),
+		filepath.Join(app.state.GeminiHome(), "commands", skill.VigilanteConflictResolution+".toml"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected %s to exist: %v", path, err)
+		}
+	}
+}
+
 func TestWatchListAndUnwatch(t *testing.T) {
 	home := t.TempDir()
 	repoPath := filepath.Join(home, "repo")
@@ -236,6 +268,39 @@ func TestWatchWithProviderPersistsClaudeSelection(t *testing.T) {
 	}
 	if len(targets) != 1 || targets[0].Provider != "claude" {
 		t.Fatalf("expected claude provider to persist: %#v", targets)
+	}
+}
+
+func TestWatchWithGeminiProviderPersistsSelection(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                  "true\n",
+			testutil.Key("git", "remote", "get-url", "origin"):                         "git@github.com:nicobistolfi/vigilante.git\n",
+			testutil.Key("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"): "origin/main\n",
+		},
+	}
+
+	if err := app.WatchWithProvider(context.Background(), repoPath, false, nil, "", 0, "gemini"); err != nil {
+		t.Fatal(err)
+	}
+
+	targets, err := app.state.LoadWatchTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 || targets[0].Provider != "gemini" {
+		t.Fatalf("expected gemini provider to persist: %#v", targets)
 	}
 }
 
@@ -826,6 +891,75 @@ func TestResumeBlockedSessionFallsBackWhenDiagnosticSummaryFails(t *testing.T) {
 	}
 	if session.LastResumeFailureFingerprint == "" || session.LastResumeFailureCommentedAt == "" {
 		t.Fatalf("expected fallback comment metadata to be tracked: %#v", session)
+	}
+}
+
+func TestResumeBlockedSessionUsesGeminiForDiagnosticSummary(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	session := state.Session{
+		RepoPath:       repoPath,
+		Repo:           "owner/repo",
+		Provider:       "gemini",
+		IssueNumber:    1,
+		IssueTitle:     "first",
+		IssueURL:       "https://github.com/owner/repo/issues/1",
+		Branch:         "vigilante/issue-1",
+		WorktreePath:   worktreePath,
+		Status:         state.SessionStatusBlocked,
+		BlockedStage:   "issue_execution",
+		BlockedReason:  state.BlockedReason{Kind: "provider_auth", Operation: "gemini --prompt", Summary: "session expired", Detail: "session expired"},
+		ResumeRequired: true,
+		ResumeHint:     "vigilante resume --repo owner/repo --issue 1",
+	}
+	failedSession := session
+	failedSession.LastResumeSource = "comment"
+	failedSession.LastError = "session expired again"
+	failedSession.BlockedReason = state.BlockedReason{Kind: "provider_auth", Operation: "gemini --prompt", Summary: "session expired again", Detail: "session expired again"}
+	expectedComment := ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Resume Blocked",
+		Emoji:      "🧱",
+		Percent:    90,
+		ETAMinutes: 10,
+		Items: []string{
+			"Resume could not rerun `gemini --prompt` for `vigilante/issue-1`.",
+			"Gemini reported an expired session, so Vigilante could not continue the blocked work.",
+			"Failure type: `provider_related` (`provider_auth`). Re-authenticate Gemini locally, then retry `@vigilanteai resume`.",
+		},
+		Tagline: "No mystery errors left behind.",
+	})
+
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"gemini": "/usr/bin/gemini"},
+		Outputs: map[string]string{
+			"gemini --version": "gemini 1.0.0",
+			resumeDiagnosticSummaryCommandForProvider(worktreePath, "gemini", failedSession, "issue_execution"): `{"step":"Resume could not rerun ` + "`gemini --prompt`" + ` for ` + "`vigilante/issue-1`" + `.","why":"Gemini reported an expired session, so Vigilante could not continue the blocked work.","classification":"provider_related","next_step":"Re-authenticate Gemini locally, then retry ` + "`@vigilanteai resume`" + `."}`,
+			"gh issue comment --repo owner/repo 1 --body " + expectedComment:                                    "ok",
+		},
+		Errors: map[string]error{
+			issuePromptCommandForProvider("gemini", worktreePath, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1"): errors.New("session expired again"),
+		},
+	}
+
+	if err := app.resumeBlockedSession(context.Background(), &session, "comment"); err != nil {
+		t.Fatal(err)
+	}
+	if session.Status != state.SessionStatusBlocked {
+		t.Fatalf("expected session to remain blocked: %#v", session)
+	}
+	if session.LastResumeFailureFingerprint == "" || session.LastResumeFailureCommentedAt == "" {
+		t.Fatalf("expected Gemini failure comment metadata to be tracked: %#v", session)
 	}
 }
 
@@ -2101,6 +2235,20 @@ func issuePromptCommand(worktreePath string, repo string, repoPath string, issue
 	))
 }
 
+func issuePromptCommandForProvider(providerID string, worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, branch string) string {
+	switch providerID {
+	case "gemini":
+		return testutil.Key("gemini", "--prompt", skill.BuildIssuePromptForRuntime(
+			skill.RuntimeGemini,
+			state.WatchTarget{Path: repoPath, Repo: repo},
+			ghcli.Issue{Number: issueNumber, Title: title, URL: issueURL},
+			state.Session{WorktreePath: worktreePath, Branch: branch, Provider: "gemini"},
+		), "--yolo")
+	default:
+		return issuePromptCommand(worktreePath, repo, repoPath, issueNumber, title, issueURL, branch)
+	}
+}
+
 func preflightPromptCommand(worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, branch string) string {
 	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePreflightPrompt(
 		state.WatchTarget{Path: repoPath, Repo: repo},
@@ -2111,4 +2259,13 @@ func preflightPromptCommand(worktreePath string, repo string, repoPath string, i
 
 func resumeDiagnosticSummaryCommand(worktreePath string, session state.Session, previousStage string) string {
 	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", buildResumeFailureSummaryPrompt(session, previousStage))
+}
+
+func resumeDiagnosticSummaryCommandForProvider(worktreePath string, providerID string, session state.Session, previousStage string) string {
+	switch providerID {
+	case "gemini":
+		return testutil.Key("gemini", "--prompt", buildResumeFailureSummaryPrompt(session, previousStage), "--yolo")
+	default:
+		return resumeDiagnosticSummaryCommand(worktreePath, session, previousStage)
+	}
 }

--- a/internal/provider/gemini.go
+++ b/internal/provider/gemini.go
@@ -1,0 +1,60 @@
+package provider
+
+import (
+	"github.com/nicobistolfi/vigilante/internal/skill"
+	"github.com/nicobistolfi/vigilante/internal/state"
+)
+
+type geminiProvider struct{}
+
+func (geminiProvider) ID() string {
+	return GeminiID
+}
+
+func (geminiProvider) DisplayName() string {
+	return "Gemini CLI"
+}
+
+func (geminiProvider) RequiredTools() []string {
+	return []string{"gemini"}
+}
+
+func (geminiProvider) EnsureRuntimeInstalled(store *state.Store) error {
+	return skill.EnsureInstalled(skill.RuntimeGemini, store.GeminiHome())
+}
+
+func (geminiProvider) BuildIssuePreflightInvocation(task IssueTask) (Invocation, error) {
+	return Invocation{
+		Dir:  task.Session.WorktreePath,
+		Name: "gemini",
+		Args: []string{
+			"--prompt",
+			skill.BuildIssuePreflightPrompt(task.Target, task.Issue, task.Session),
+			"--yolo",
+		},
+	}, nil
+}
+
+func (geminiProvider) BuildIssueInvocation(task IssueTask) (Invocation, error) {
+	return Invocation{
+		Dir:  task.Session.WorktreePath,
+		Name: "gemini",
+		Args: []string{
+			"--prompt",
+			skill.BuildIssuePromptForRuntime(skill.RuntimeGemini, task.Target, task.Issue, task.Session),
+			"--yolo",
+		},
+	}, nil
+}
+
+func (geminiProvider) BuildConflictResolutionInvocation(task ConflictTask) (Invocation, error) {
+	return Invocation{
+		Dir:  task.Session.WorktreePath,
+		Name: "gemini",
+		Args: []string{
+			"--prompt",
+			skill.BuildConflictResolutionPromptForRuntime(skill.RuntimeGemini, task.Target, task.Session, task.PR),
+			"--yolo",
+		},
+	}, nil
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -11,6 +11,7 @@ import (
 
 const DefaultID = "codex"
 const ClaudeID = "claude"
+const GeminiID = "gemini"
 
 type Invocation struct {
 	Dir  string
@@ -43,6 +44,7 @@ type Provider interface {
 var registry = map[string]Provider{
 	DefaultID: codexProvider{},
 	ClaudeID:  claudeProvider{},
+	GeminiID:  geminiProvider{},
 }
 
 func RegisteredIDs() []string {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -54,6 +54,26 @@ func TestResolveClaudeProvider(t *testing.T) {
 	}
 }
 
+func TestResolveGeminiProvider(t *testing.T) {
+	selectedProvider, err := Resolve(GeminiID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selectedProvider.DisplayName() != "Gemini CLI" {
+		t.Fatalf("unexpected provider: %#v", selectedProvider)
+	}
+	got := RequiredToolset(selectedProvider)
+	want := []string{"gemini", "gh", "git"}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected tool count: %#v", got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected toolset: %#v", got)
+		}
+	}
+}
+
 func TestResolveIssueLabelUsesRegisteredProviderIDs(t *testing.T) {
 	original := registry
 	registry = map[string]Provider{

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -195,6 +195,48 @@ func TestRunIssueSessionSuccessWithClaudeProvider(t *testing.T) {
 	}
 }
 
+func TestRunIssueSessionSuccessWithGeminiProvider(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Vigilante Session Start",
+				Emoji:      "🧢",
+				Percent:    20,
+				ETAMinutes: 25,
+				Items: []string{
+					"Vigilante launched this implementation session in `/tmp/worktree`.",
+					"Branch: `vigilante/issue-7`.",
+					"Current stage: handing the issue off to the configured coding agent (`Gemini CLI`) for investigation and implementation.",
+				},
+				Tagline: "Make it simple, but significant.",
+			}): "ok",
+			testutil.Key("gemini", "--prompt", skill.BuildIssuePreflightPrompt(
+				state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"},
+				ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"},
+				state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "gemini"},
+			), "--yolo"): "baseline ok",
+			testutil.Key("gemini", "--prompt", skill.BuildIssuePromptForRuntime(
+				skill.RuntimeGemini,
+				state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"},
+				ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"},
+				state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "gemini"},
+			), "--yolo"): "done",
+		},
+	}
+	env := &environment.Environment{OS: "darwin", Runner: runner}
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "gemini", Status: state.SessionStatusRunning}
+	got := RunIssueSession(context.Background(), env, store, state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+	if got.Status != state.SessionStatusSuccess {
+		t.Fatalf("unexpected status: %#v", got)
+	}
+}
+
 func TestClassifyBlockedFailureDetectsProviderQuota(t *testing.T) {
 	err := errors.New("exit status 1")
 	output := "You've hit your usage limit. Upgrade to Pro or purchase more credits. Try again at 2026-03-13 09:00 PDT."

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -138,3 +138,33 @@ func TestBuildConfigSupportsClaudeProvider(t *testing.T) {
 		t.Fatalf("unexpected PATH: %#v", cfg)
 	}
 }
+
+func TestBuildConfigSupportsGeminiProvider(t *testing.T) {
+	t.Setenv("HOME", "/Users/test")
+	t.Setenv("SHELL", "/bin/zsh")
+	t.Setenv("PATH", "/usr/bin:/bin")
+
+	env := &environment.Environment{
+		OS: "darwin",
+		Runner: testutil.FakeRunner{
+			Outputs: map[string]string{
+				`/bin/zsh -lic printf "%s" "$PATH"`: "/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin",
+				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'git'`:    "/opt/homebrew/bin/git\n",
+				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'gh'`:     "/opt/homebrew/bin/gh\n",
+				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'gemini'`: "/Users/test/.local/bin/gemini\n",
+			},
+		},
+	}
+
+	selectedProvider, err := provider.Resolve(provider.GeminiID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := BuildConfig(context.Background(), env, selectedProvider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.PathEnv != "/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" {
+		t.Fatalf("unexpected PATH: %#v", cfg)
+	}
+}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -19,6 +19,7 @@ const VigilanteCreateIssue = "vigilante-create-issue"
 
 const RuntimeCodex = "codex"
 const RuntimeClaude = "claude"
+const RuntimeGemini = "gemini"
 
 func VigilanteSkillNames() []string {
 	return []string{
@@ -46,6 +47,11 @@ func EnsureInstalled(runtime string, home string) error {
 				return err
 			}
 		}
+		if strings.TrimSpace(runtime) == RuntimeGemini {
+			if err := installGeminiCommand(home, name); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }
@@ -59,9 +65,33 @@ func installTargets(runtime string, home string, name string) ([]string, error) 
 			filepath.Join(home, "skills", name),
 			filepath.Join(home, "commands", name),
 		}, nil
+	case RuntimeGemini:
+		return []string{
+			filepath.Join(home, "skills", name),
+		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported skill runtime %q", runtime)
 	}
+}
+
+func installGeminiCommand(home string, name string) error {
+	body, err := skillBody(name)
+	if err != nil {
+		return err
+	}
+	commandDir := filepath.Join(home, "commands")
+	if err := os.MkdirAll(commandDir, 0o755); err != nil {
+		return err
+	}
+	commandPath := filepath.Join(commandDir, name+".toml")
+	commandBody := strings.TrimSpace(fmt.Sprintf(`
+description = "Bundled Vigilante skill: %s"
+prompt = '''
+Follow these %q skill instructions directly for this task:
+%s
+'''
+`, name, "`"+name+"`", body)) + "\n"
+	return os.WriteFile(commandPath, []byte(commandBody), 0o644)
 }
 
 func skillBody(name string) (string, error) {
@@ -105,7 +135,7 @@ func BuildIssuePrompt(target state.WatchTarget, issue ghcli.Issue, session state
 
 func BuildIssuePromptForRuntime(runtime string, target state.WatchTarget, issue ghcli.Issue, session state.Session) string {
 	lines := []string{}
-	if strings.TrimSpace(runtime) == RuntimeClaude {
+	if runtimeUsesInlineSkillHeader(runtime) {
 		lines = append(lines, InlineSkillHeader(VigilanteIssueImplementation))
 	} else {
 		lines = append(lines, fmt.Sprintf("Use the `%s` skill for this task.", VigilanteIssueImplementation))
@@ -153,6 +183,8 @@ func displayProviderName(name string) string {
 		return "Claude Code"
 	case RuntimeCodex:
 		return "Codex"
+	case RuntimeGemini:
+		return "Gemini CLI"
 	}
 	parts := strings.FieldsFunc(name, func(r rune) bool {
 		return r == '-' || r == '_' || r == ' '
@@ -172,7 +204,7 @@ func BuildConflictResolutionPrompt(target state.WatchTarget, session state.Sessi
 
 func BuildConflictResolutionPromptForRuntime(runtime string, target state.WatchTarget, session state.Session, pr ghcli.PullRequest) string {
 	lines := []string{}
-	if strings.TrimSpace(runtime) == RuntimeClaude {
+	if runtimeUsesInlineSkillHeader(runtime) {
 		lines = append(lines, InlineSkillHeader(VigilanteConflictResolution))
 	} else {
 		lines = append(lines, fmt.Sprintf("Use the `%s` skill for this task.", VigilanteConflictResolution))
@@ -191,6 +223,15 @@ func BuildConflictResolutionPromptForRuntime(runtime string, target state.WatchT
 		"Keep the changes minimal and focused on getting the PR back to a merge-ready state.",
 	)
 	return strings.Join(lines, "\n")
+}
+
+func runtimeUsesInlineSkillHeader(runtime string) bool {
+	switch strings.TrimSpace(runtime) {
+	case RuntimeClaude, RuntimeGemini:
+		return true
+	default:
+		return false
+	}
 }
 
 func repoSkillPath(name string) string {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -203,12 +203,63 @@ func TestEnsureInstalledForClaudeCreatesCommandsAndSkills(t *testing.T) {
 	}
 }
 
+func TestEnsureInstalledForGeminiCreatesCommandsAndSkills(t *testing.T) {
+	dir := t.TempDir()
+	repoRoot := t.TempDir()
+	for _, name := range VigilanteSkillNames() {
+		skillSourceDir := filepath.Join(repoRoot, "skills", name)
+		if err := os.MkdirAll(skillSourceDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(skillSourceDir, "SKILL.md"), []byte("# repo skill\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.Chdir(wd)
+	}()
+
+	if err := EnsureInstalled(RuntimeGemini, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range VigilanteSkillNames() {
+		for _, path := range []string{
+			filepath.Join(dir, "skills", name, "SKILL.md"),
+			filepath.Join(dir, "commands", name+".toml"),
+		} {
+			if _, err := os.Stat(path); err != nil {
+				t.Fatalf("expected %s to exist: %v", path, err)
+			}
+		}
+	}
+}
+
 func TestBuildIssuePromptForClaudeInlinesSkillInstructions(t *testing.T) {
 	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
 	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
 	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "claude"}
 	prompt := BuildIssuePromptForRuntime(RuntimeClaude, target, issue, session)
 	for _, text := range []string{"Follow these `vigilante-issue-implementation` skill instructions directly", "Coding Agent Launched: Claude Code", "Issue: #12 - Fix bug"} {
+		if !strings.Contains(prompt, text) {
+			t.Fatalf("prompt missing %q: %s", text, prompt)
+		}
+	}
+}
+
+func TestBuildIssuePromptForGeminiInlinesSkillInstructions(t *testing.T) {
+	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
+	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
+	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "gemini"}
+	prompt := BuildIssuePromptForRuntime(RuntimeGemini, target, issue, session)
+	for _, text := range []string{"Follow these `vigilante-issue-implementation` skill instructions directly", "Coding Agent Launched: Gemini CLI", "Issue: #12 - Fix bug"} {
 		if !strings.Contains(prompt, text) {
 			t.Fatalf("prompt missing %q: %s", text, prompt)
 		}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -121,6 +121,17 @@ func (s *Store) ClaudeHome() string {
 	return filepath.Join(home, ".claude")
 }
 
+func (s *Store) GeminiHome() string {
+	if value := os.Getenv("GEMINI_HOME"); value != "" {
+		return value
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(s.root, ".gemini")
+	}
+	return filepath.Join(home, ".gemini")
+}
+
 func (s *Store) EnsureLayout() error {
 	for _, dir := range []string{s.root, s.LogsDir()} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {


### PR DESCRIPTION
## Summary
- add Gemini CLI as a registered provider with headless issue, preflight, conflict-resolution, and resume-diagnostic invocations
- install Gemini-compatible skill assets under `~/.gemini` and inline Vigilante skill instructions in Gemini prompts
- extend provider, app, runner, service, skill, and documentation coverage for Gemini flows

Closes #105.

## Testing
- go test ./...
