### PR TITLE
Add repo-aware issue skill selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Once a folder is registered, `vigilante` should:
 2. Poll or subscribe for open GitHub issues through `gh`.
 3. Select issues that are ready to work and not already being handled.
 4. Launch a headless coding agent session in YOLO mode against a dedicated git worktree.
-5. Use the issue implementation skill from the repo `skills/` folder as part of the execution prompt.
+5. Classify the watched repository and use the matching issue implementation skill from the repo `skills/` folder as part of the execution prompt.
 6. Post progress comments back to the GitHub issue, including session start and failures.
 7. Track watched repositories locally and optionally run as a daemon.
 
@@ -44,12 +44,13 @@ For each watched repository:
    - `git`
    - `gh`
    - the configured coding-agent provider CLI (`codex`, `claude`, or `gemini`)
-4. Ensure the coding-agent issue implementation skill from `skills/vigilante-issue-implementation/` is installed during setup, including its companion agent metadata.
+4. Ensure the bundled issue implementation skills from the repo `skills/` folder are installed during setup, including companion agent metadata.
 5. Query GitHub for open issues.
 6. Determine which issues are eligible for execution.
 7. Create a git worktree for the selected issue.
 8. Launch a supported coding agent headlessly in the worktree with a prompt that:
-   - uses the issue implementation skill
+   - uses the repo-aware issue implementation skill selected from repository classification
+   - passes the detected repo/process context into the prompt
    - instructs the agent to comment on the issue when work starts
    - instructs the agent to keep commenting as progress is made
    - instructs the agent to report errors back to the issue
@@ -172,6 +173,7 @@ Expected behavior:
 - verifies `git`, `gh`, and the selected coding-agent provider CLI
 - installs the bundled coding-agent skills for regular runtime use, including any companion files under each skill directory
   - `vigilante-issue-implementation`
+  - `vigilante-issue-implementation-on-monorepo`
   - `vigilante-conflict-resolution`
   - `vigilante-create-issue`
 - installs or updates the daemon definition when requested

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nicobistolfi/vigilante/internal/repo"
 	issuerunner "github.com/nicobistolfi/vigilante/internal/runner"
 	"github.com/nicobistolfi/vigilante/internal/service"
+	"github.com/nicobistolfi/vigilante/internal/skill"
 	"github.com/nicobistolfi/vigilante/internal/state"
 	"github.com/nicobistolfi/vigilante/internal/worktree"
 )
@@ -283,6 +284,7 @@ func (a *App) WatchWithProvider(ctx context.Context, rawPath string, daemon bool
 		if target.Path == info.Path {
 			targets[i].Repo = info.Repo
 			targets[i].Branch = info.Branch
+			targets[i].Classification = info.Classification
 			if strings.TrimSpace(targets[i].Provider) == "" {
 				targets[i].Provider = provider.DefaultID
 			}
@@ -306,15 +308,16 @@ func (a *App) WatchWithProvider(ctx context.Context, rawPath string, daemon bool
 
 	if !updated {
 		target := state.WatchTarget{
-			Path:          info.Path,
-			Repo:          info.Repo,
-			Branch:        info.Branch,
-			Provider:      provider.DefaultID,
-			Labels:        labels,
-			Assignee:      assigneeOrDefault(assignee),
-			MaxParallel:   configuredMaxParallel(maxParallel),
-			DaemonEnabled: daemon,
-			AddedAt:       a.clock().Format(time.RFC3339),
+			Path:           info.Path,
+			Repo:           info.Repo,
+			Branch:         info.Branch,
+			Classification: info.Classification,
+			Provider:       provider.DefaultID,
+			Labels:         labels,
+			Assignee:       assigneeOrDefault(assignee),
+			MaxParallel:    configuredMaxParallel(maxParallel),
+			DaemonEnabled:  daemon,
+			AddedAt:        a.clock().Format(time.RFC3339),
 		}
 		if providerID != "" {
 			target.Provider = providerID
@@ -483,6 +486,8 @@ func (a *App) ScanOnce(ctx context.Context) error {
 				target.Provider = provider.DefaultID
 			}
 			target.MaxParallel = configuredMaxParallel(target.MaxParallel)
+			target.Classification = repo.Classify(target.Path)
+			a.state.AppendDaemonLog("scan repo classified repo=%s shape=%s hints=%d/%d/%d", target.Repo, target.Classification.Shape, len(target.Classification.ProcessHints.WorkspaceConfigFiles), len(target.Classification.ProcessHints.WorkspaceManifestFiles), len(target.Classification.ProcessHints.MultiPackageRoots))
 			a.state.AppendDaemonLog("scan repo start repo=%s path=%s max_parallel=%d", target.Repo, target.Path, target.MaxParallel)
 			issues, err := ghcli.ListOpenIssues(ctx, a.env.Runner, target.Repo, target.Assignee)
 			target.LastScanAt = a.clock().Format(time.RFC3339)
@@ -516,6 +521,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 				if selectedProvider != target.Provider {
 					a.state.AppendDaemonLog("scan repo issue provider override repo=%s issue=%d provider=%s source=label", target.Repo, next.Number, selectedProvider)
 				}
+				a.state.AppendDaemonLog("scan repo issue skill repo=%s issue=%d skill=%s shape=%s", target.Repo, next.Number, skill.IssueImplementationSkill(*target), target.Classification.Shape)
 
 				wt, err := worktree.CreateIssueWorktree(ctx, a.env.Runner, *target, next.Number, next.Title)
 				if err != nil {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
+	"github.com/nicobistolfi/vigilante/internal/repo"
 	"github.com/nicobistolfi/vigilante/internal/skill"
 	"github.com/nicobistolfi/vigilante/internal/state"
 	"github.com/nicobistolfi/vigilante/internal/testutil"
@@ -86,6 +87,7 @@ func TestSetupCreatesStateLayoutAndSkill(t *testing.T) {
 		filepath.Join(app.state.Root(), "sessions.json"),
 		filepath.Join(app.state.Root(), "logs"),
 		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteIssueImplementation, "SKILL.md"),
+		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteIssueImplementationOnMonorepo, "SKILL.md"),
 		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteConflictResolution, "SKILL.md"),
 	} {
 		if _, err := os.Stat(path); err != nil {
@@ -268,6 +270,45 @@ func TestWatchWithProviderPersistsClaudeSelection(t *testing.T) {
 	}
 	if len(targets) != 1 || targets[0].Provider != "claude" {
 		t.Fatalf("expected claude provider to persist: %#v", targets)
+	}
+}
+
+func TestWatchPersistsRepoClassification(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(repoPath, "apps", "web"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoPath, "packages", "shared"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                  "true\n",
+			testutil.Key("git", "remote", "get-url", "origin"):                         "git@github.com:nicobistolfi/vigilante.git\n",
+			testutil.Key("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"): "origin/main\n",
+		},
+	}
+
+	if err := app.Watch(context.Background(), repoPath, false, nil, "", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	targets, err := app.state.LoadWatchTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("unexpected targets: %#v", targets)
+	}
+	if targets[0].Classification.Shape != repo.ShapeMonorepo {
+		t.Fatalf("expected monorepo classification to persist: %#v", targets[0])
 	}
 }
 

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -5,16 +5,37 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/nicobistolfi/vigilante/internal/environment"
 )
 
+type Shape string
+
+const (
+	ShapeTraditional Shape = "traditional"
+	ShapeMonorepo    Shape = "monorepo"
+)
+
+type ProcessHints struct {
+	WorkspaceConfigFiles   []string `json:"workspace_config_files,omitempty"`
+	WorkspaceManifestFiles []string `json:"workspace_manifest_files,omitempty"`
+	MultiPackageRoots      []string `json:"multi_package_roots,omitempty"`
+}
+
+type Classification struct {
+	Shape        Shape        `json:"shape"`
+	ProcessHints ProcessHints `json:"process_hints,omitempty"`
+}
+
 type Info struct {
-	Path   string
-	Repo   string
-	Branch string
+	Path           string
+	Repo           string
+	Branch         string
+	Classification Classification
 }
 
 func Discover(ctx context.Context, runner environment.Runner, path string) (Info, error) {
@@ -43,10 +64,45 @@ func Discover(ctx context.Context, runner environment.Runner, path string) (Info
 	}
 
 	return Info{
-		Path:   absPath,
-		Repo:   repo,
-		Branch: branch,
+		Path:           absPath,
+		Repo:           repo,
+		Branch:         branch,
+		Classification: Classify(absPath),
 	}, nil
+}
+
+func Classify(path string) Classification {
+	classification := Classification{Shape: ShapeTraditional}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		absPath = path
+	}
+
+	for _, name := range []string{"pnpm-workspace.yaml", "turbo.json", "nx.json", "lerna.json", "rush.json", "go.work"} {
+		if fileExists(filepath.Join(absPath, name)) {
+			classification.ProcessHints.WorkspaceConfigFiles = append(classification.ProcessHints.WorkspaceConfigFiles, name)
+		}
+	}
+	if packageJSONHasWorkspaces(filepath.Join(absPath, "package.json")) {
+		classification.ProcessHints.WorkspaceManifestFiles = append(classification.ProcessHints.WorkspaceManifestFiles, "package.json")
+	}
+	if cargoTomlHasWorkspace(filepath.Join(absPath, "Cargo.toml")) {
+		classification.ProcessHints.WorkspaceManifestFiles = append(classification.ProcessHints.WorkspaceManifestFiles, "Cargo.toml")
+	}
+	for _, root := range []string{"apps", "packages", "services", "libs", "modules"} {
+		if hasChildDirectories(filepath.Join(absPath, root)) {
+			classification.ProcessHints.MultiPackageRoots = append(classification.ProcessHints.MultiPackageRoots, root)
+		}
+	}
+	if len(classification.ProcessHints.WorkspaceConfigFiles) > 0 ||
+		len(classification.ProcessHints.WorkspaceManifestFiles) > 0 ||
+		len(classification.ProcessHints.MultiPackageRoots) >= 2 {
+		classification.Shape = ShapeMonorepo
+	}
+	slices.Sort(classification.ProcessHints.WorkspaceConfigFiles)
+	slices.Sort(classification.ProcessHints.WorkspaceManifestFiles)
+	slices.Sort(classification.ProcessHints.MultiPackageRoots)
+	return classification
 }
 
 func ParseGitHubRepo(remote string) (string, error) {
@@ -81,4 +137,38 @@ func normalizeGitHubPath(path string) (string, error) {
 		return "", fmt.Errorf("invalid GitHub repo path %q", path)
 	}
 	return parts[0] + "/" + parts[1], nil
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func hasChildDirectories(path string) bool {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return true
+		}
+	}
+	return false
+}
+
+func packageJSONHasWorkspaces(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), `"workspaces"`)
+}
+
+func cargoTomlHasWorkspace(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(data), "[workspace]")
 }

--- a/internal/repo/repo_test.go
+++ b/internal/repo/repo_test.go
@@ -2,6 +2,7 @@ package repo
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -41,6 +42,54 @@ func TestDiscoverRepositoryWithRealGit(t *testing.T) {
 	}
 	if info.Branch != "main" {
 		t.Fatalf("unexpected branch: %#v", info)
+	}
+	if info.Classification.Shape != ShapeTraditional {
+		t.Fatalf("unexpected classification: %#v", info.Classification)
+	}
+}
+
+func TestClassifyTraditionalRepo(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/demo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Classify(dir)
+
+	if got.Shape != ShapeTraditional {
+		t.Fatalf("expected traditional classification, got %#v", got)
+	}
+}
+
+func TestClassifyMonorepoFromWorkspaceSignals(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "pnpm-workspace.yaml"), []byte("packages:\n  - apps/*\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Classify(dir)
+
+	if got.Shape != ShapeMonorepo {
+		t.Fatalf("expected monorepo classification, got %#v", got)
+	}
+	if len(got.ProcessHints.WorkspaceConfigFiles) != 1 || got.ProcessHints.WorkspaceConfigFiles[0] != "pnpm-workspace.yaml" {
+		t.Fatalf("expected workspace config hint, got %#v", got.ProcessHints)
+	}
+}
+
+func TestClassifyFallsBackSafelyForAmbiguousRepo(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "apps", "web"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Classify(dir)
+
+	if got.Shape != ShapeTraditional {
+		t.Fatalf("expected safe fallback to traditional, got %#v", got)
+	}
+	if len(got.ProcessHints.MultiPackageRoots) != 1 || got.ProcessHints.MultiPackageRoots[0] != "apps" {
+		t.Fatalf("expected ambiguous multi-package hint to be preserved, got %#v", got.ProcessHints)
 	}
 }
 

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/nicobistolfi/vigilante/internal/environment"
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
+	"github.com/nicobistolfi/vigilante/internal/repo"
 	"github.com/nicobistolfi/vigilante/internal/skill"
 	"github.com/nicobistolfi/vigilante/internal/state"
 	"github.com/nicobistolfi/vigilante/internal/testutil"
@@ -232,6 +233,56 @@ func TestRunIssueSessionSuccessWithGeminiProvider(t *testing.T) {
 	}
 	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "gemini", Status: state.SessionStatusRunning}
 	got := RunIssueSession(context.Background(), env, store, state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+	if got.Status != state.SessionStatusSuccess {
+		t.Fatalf("unexpected status: %#v", got)
+	}
+}
+
+func TestRunIssueSessionUsesMonorepoSkillWhenClassified(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	target := state.WatchTarget{
+		Path: "/tmp/repo",
+		Repo: "owner/repo",
+		Classification: repo.Classification{
+			Shape: repo.ShapeMonorepo,
+			ProcessHints: repo.ProcessHints{
+				WorkspaceConfigFiles: []string{"pnpm-workspace.yaml"},
+				MultiPackageRoots:    []string{"apps", "packages"},
+			},
+		},
+	}
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Vigilante Session Start",
+				Emoji:      "🧢",
+				Percent:    20,
+				ETAMinutes: 25,
+				Items: []string{
+					"Vigilante launched this implementation session in `/tmp/worktree`.",
+					"Branch: `vigilante/issue-7`.",
+					"Current stage: handing the issue off to the configured coding agent (`Codex`) for investigation and implementation.",
+				},
+				Tagline: "Make it simple, but significant.",
+			}): "ok",
+			preflightPromptCommand("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", "vigilante/issue-7"): "baseline ok",
+			testutil.Key("codex", "exec", "--cd", "/tmp/worktree", "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePrompt(
+				target,
+				ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"},
+				state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "codex"},
+			)): "done",
+		},
+	}
+	env := &environment.Environment{OS: "darwin", Runner: runner}
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
+
+	got := RunIssueSession(context.Background(), env, store, target, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+
 	if got.Status != state.SessionStatusSuccess {
 		t.Fatalf("unexpected status: %#v", got)
 	}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -1,6 +1,7 @@
 package skill
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
@@ -10,10 +11,12 @@ import (
 
 	skillassets "github.com/nicobistolfi/vigilante"
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
+	"github.com/nicobistolfi/vigilante/internal/repo"
 	"github.com/nicobistolfi/vigilante/internal/state"
 )
 
 const VigilanteIssueImplementation = "vigilante-issue-implementation"
+const VigilanteIssueImplementationOnMonorepo = "vigilante-issue-implementation-on-monorepo"
 const VigilanteConflictResolution = "vigilante-conflict-resolution"
 const VigilanteCreateIssue = "vigilante-create-issue"
 
@@ -24,6 +27,7 @@ const RuntimeGemini = "gemini"
 func VigilanteSkillNames() []string {
 	return []string{
 		VigilanteIssueImplementation,
+		VigilanteIssueImplementationOnMonorepo,
 		VigilanteConflictResolution,
 		VigilanteCreateIssue,
 	}
@@ -134,15 +138,19 @@ func BuildIssuePrompt(target state.WatchTarget, issue ghcli.Issue, session state
 }
 
 func BuildIssuePromptForRuntime(runtime string, target state.WatchTarget, issue ghcli.Issue, session state.Session) string {
+	selectedSkill := IssueImplementationSkill(target)
 	lines := []string{}
 	if runtimeUsesInlineSkillHeader(runtime) {
-		lines = append(lines, InlineSkillHeader(VigilanteIssueImplementation))
+		lines = append(lines, InlineSkillHeader(selectedSkill))
 	} else {
-		lines = append(lines, fmt.Sprintf("Use the `%s` skill for this task.", VigilanteIssueImplementation))
+		lines = append(lines, fmt.Sprintf("Use the `%s` skill for this task.", selectedSkill))
 	}
 	lines = append(lines,
 		fmt.Sprintf("Repository: %s", target.Repo),
 		fmt.Sprintf("Local repository path: %s", target.Path),
+		fmt.Sprintf("Detected repo shape: %s", normalizedRepoShape(target)),
+		fmt.Sprintf("Selected issue implementation skill: %s", selectedSkill),
+		fmt.Sprintf("Repo process context JSON: %s", repoClassificationJSON(target)),
 		fmt.Sprintf("Issue: #%d - %s", issue.Number, issue.Title),
 		fmt.Sprintf("Issue URL: %s", issue.URL),
 		fmt.Sprintf("Worktree path: %s", session.WorktreePath),
@@ -153,6 +161,44 @@ func BuildIssuePromptForRuntime(runtime string, target state.WatchTarget, issue 
 		"Use the issue as the source of truth for the requested behavior and keep the implementation minimal.",
 	)
 	return strings.Join(lines, "\n")
+}
+
+func IssueImplementationSkill(target state.WatchTarget) string {
+	if normalizedRepoShape(target) == string(repo.ShapeMonorepo) {
+		return VigilanteIssueImplementationOnMonorepo
+	}
+	return VigilanteIssueImplementation
+}
+
+func normalizedRepoShape(target state.WatchTarget) string {
+	shape := strings.TrimSpace(string(target.Classification.Shape))
+	if shape == "" {
+		return string(repo.ShapeTraditional)
+	}
+	return shape
+}
+
+func repoClassificationJSON(target state.WatchTarget) string {
+	classification := target.Classification
+	if strings.TrimSpace(string(classification.Shape)) == "" {
+		classification.Shape = repo.ShapeTraditional
+	}
+	payload := struct {
+		Shape        repo.Shape         `json:"shape"`
+		ProcessHints *repo.ProcessHints `json:"process_hints,omitempty"`
+	}{
+		Shape: classification.Shape,
+	}
+	if len(classification.ProcessHints.WorkspaceConfigFiles) > 0 ||
+		len(classification.ProcessHints.WorkspaceManifestFiles) > 0 ||
+		len(classification.ProcessHints.MultiPackageRoots) > 0 {
+		payload.ProcessHints = &classification.ProcessHints
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return `{"shape":"traditional"}`
+	}
+	return string(data)
 }
 
 func BuildIssuePreflightPrompt(target state.WatchTarget, issue ghcli.Issue, session state.Session) string {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -9,6 +9,7 @@ import (
 
 	skillassets "github.com/nicobistolfi/vigilante"
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
+	"github.com/nicobistolfi/vigilante/internal/repo"
 	"github.com/nicobistolfi/vigilante/internal/state"
 )
 
@@ -133,7 +134,37 @@ func TestBuildIssuePrompt(t *testing.T) {
 	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
 	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
 	prompt := BuildIssuePrompt(target, issue, session)
-	for _, text := range []string{"Use the `vigilante-issue-implementation` skill", "Issue: #12 - Fix bug", "Worktree path: /tmp/worktree", "gh issue comment", "implementation plan", "open a pull request", "Coding Agent Launched: Codex", "10-cell progress bar", "ETA: ~N minutes"} {
+	for _, text := range []string{"Use the `vigilante-issue-implementation` skill", "Detected repo shape: traditional", `Repo process context JSON: {"shape":"traditional"}`, "Selected issue implementation skill: vigilante-issue-implementation", "Issue: #12 - Fix bug", "Worktree path: /tmp/worktree", "gh issue comment", "implementation plan", "open a pull request", "Coding Agent Launched: Codex", "10-cell progress bar", "ETA: ~N minutes"} {
+		if !strings.Contains(prompt, text) {
+			t.Fatalf("prompt missing %q: %s", text, prompt)
+		}
+	}
+}
+
+func TestBuildIssuePromptSelectsMonorepoSkill(t *testing.T) {
+	target := state.WatchTarget{
+		Path: "/tmp/repo",
+		Repo: "owner/repo",
+		Classification: repo.Classification{
+			Shape: repo.ShapeMonorepo,
+			ProcessHints: repo.ProcessHints{
+				WorkspaceConfigFiles: []string{"pnpm-workspace.yaml"},
+				MultiPackageRoots:    []string{"apps", "packages"},
+			},
+		},
+	}
+	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
+	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
+
+	prompt := BuildIssuePrompt(target, issue, session)
+
+	for _, text := range []string{
+		"Use the `vigilante-issue-implementation-on-monorepo` skill",
+		"Detected repo shape: monorepo",
+		"Selected issue implementation skill: vigilante-issue-implementation-on-monorepo",
+		`"workspace_config_files":["pnpm-workspace.yaml"]`,
+		`"multi_package_roots":["apps","packages"]`,
+	} {
 		if !strings.Contains(prompt, text) {
 			t.Fatalf("prompt missing %q: %s", text, prompt)
 		}
@@ -263,6 +294,12 @@ func TestBuildIssuePromptForGeminiInlinesSkillInstructions(t *testing.T) {
 		if !strings.Contains(prompt, text) {
 			t.Fatalf("prompt missing %q: %s", text, prompt)
 		}
+	}
+}
+
+func TestIssueImplementationSkillDefaultsToTraditional(t *testing.T) {
+	if got := IssueImplementationSkill(state.WatchTarget{}); got != VigilanteIssueImplementation {
+		t.Fatalf("unexpected default issue skill: %s", got)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -11,19 +11,21 @@ import (
 	"time"
 
 	"github.com/nicobistolfi/vigilante/internal/logtime"
+	"github.com/nicobistolfi/vigilante/internal/repo"
 )
 
 type WatchTarget struct {
-	Path          string   `json:"path"`
-	Repo          string   `json:"repo"`
-	Branch        string   `json:"branch"`
-	Provider      string   `json:"provider,omitempty"`
-	Labels        []string `json:"labels,omitempty"`
-	Assignee      string   `json:"assignee,omitempty"`
-	MaxParallel   int      `json:"max_parallel_sessions"`
-	DaemonEnabled bool     `json:"daemon_enabled"`
-	LastScanAt    string   `json:"last_scan_at,omitempty"`
-	AddedAt       string   `json:"added_at,omitempty"`
+	Path           string              `json:"path"`
+	Repo           string              `json:"repo"`
+	Branch         string              `json:"branch"`
+	Classification repo.Classification `json:"classification,omitempty"`
+	Provider       string              `json:"provider,omitempty"`
+	Labels         []string            `json:"labels,omitempty"`
+	Assignee       string              `json:"assignee,omitempty"`
+	MaxParallel    int                 `json:"max_parallel_sessions"`
+	DaemonEnabled  bool                `json:"daemon_enabled"`
+	LastScanAt     string              `json:"last_scan_at,omitempty"`
+	AddedAt        string              `json:"added_at,omitempty"`
 }
 
 const DefaultMaxParallelSessions = 3

--- a/skillassets.go
+++ b/skillassets.go
@@ -4,5 +4,5 @@ import "embed"
 
 // Skills contains built-in runtime skill files for installed binaries.
 //
-//go:embed skills/vigilante-issue-implementation skills/vigilante-conflict-resolution skills/vigilante-create-issue
+//go:embed skills/vigilante-issue-implementation skills/vigilante-issue-implementation-on-monorepo skills/vigilante-conflict-resolution skills/vigilante-create-issue
 var Skills embed.FS

--- a/skills/vigilante-issue-implementation-on-monorepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-monorepo/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: vigilante-issue-implementation-on-monorepo
+description: Implement a GitHub issue end-to-end when Vigilante dispatches work for a watched monorepo. Use the provided worktree, respect repository instructions, comment on the issue as work progresses, and report failures back to GitHub.
+---
+
+# Vigilante Monorepo Issue Implementation
+
+## Overview
+Implement one GitHub issue from Vigilante dispatch through validated code changes, a pushed branch, and an opened pull request from the provided worktree. Always work inside the assigned worktree, respect repository instructions, and keep the GitHub issue updated with start, plan, progress, PR, and failure comments.
+
+## Monorepo Focus
+- Read the repo/process context supplied in the prompt before changing code.
+- Limit edits to the packages, apps, or shared modules required for the issue.
+- Prefer targeted validation for the touched workspace scope before broader monorepo validation.
+- Avoid unrelated cross-package refactors unless they are required to complete the issue safely.
+
+## Workflow
+1. Inspect issue and repository constraints
+- Read the issue details supplied by Vigilante and confirm the issue scope before coding.
+- Read development constraints from repository markdown files before making changes:
+  - `AGENTS.md` when present
+  - `README.md`
+  - other root or area-specific docs that affect touched files
+- If repository instructions conflict, follow the more specific instruction.
+
+2. Announce session start on GitHub
+- Post a comment on the issue as soon as work begins using `gh issue comment`.
+- Include that Vigilante launched the session, the working branch, and that implementation is in progress.
+
+3. Post an implementation plan early
+- After inspecting the issue and repository constraints, post a concise implementation plan to the issue using `gh issue comment`.
+- The plan comment should describe the intended development steps before substantial coding work begins.
+
+4. Implement inside the assigned worktree only
+- Use only the provided worktree path.
+- Never edit the root checkout when a worktree was assigned.
+- Keep changes scoped to the issue.
+- Prefer native repository tooling and avoid unnecessary new dependencies.
+
+5. Validate incrementally
+- Run the most relevant package/app/workspace checks first, then expand only if needed.
+- If validation fails, determine whether the problem is in the code, test setup, or environment before retrying.
+
+6. Commit, push, and open a pull request
+- Commit only issue-relevant changes in the assigned branch.
+- Push the assigned branch to the remote.
+- Open a pull request targeting the repository default branch unless repository instructions say otherwise.
+
+7. Report progress and failures clearly
+- Use `gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
+- Keep comments concise, factual, and tied to real progress.

--- a/skills/vigilante-issue-implementation-on-monorepo/agents/openai.yaml
+++ b/skills/vigilante-issue-implementation-on-monorepo/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Vigilante Monorepo Issue Implementation"
+  short_description: "Implement a Vigilante-dispatched GitHub issue in a monorepo with issue comments, pushed changes, and a PR"
+  default_prompt: "Use $vigilante-issue-implementation-on-monorepo to implement the assigned monorepo issue in the provided worktree, push the branch, open a PR, comment on the issue as progress is made, and report failures clearly."


### PR DESCRIPTION
## Summary
- add conservative repo classification with structured process hints
- route issue dispatch between traditional and monorepo implementation skills
- install/embed the new monorepo skill and update docs/tests

Closes #109

## Validation
- go test ./...
- go build ./...