### PR TITLE
Make task setup-daemon resilient to stuck launchd refreshes

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Primary tasks:
 - `task install` copies the built binary to `~/.local/bin/vigilante`
 - `task setup` runs `./vigilante setup`
 - `task install-setup` runs `~/.local/bin/vigilante setup`
-- `task setup-daemon` runs `~/.local/bin/vigilante setup -d`
+- `task setup-daemon` runs a small wrapper around `~/.local/bin/vigilante setup -d` that retries once on macOS after cleaning up an existing `launchd` agent
 
 Recommended loop:
 
@@ -233,6 +233,8 @@ task install-setup
 ```sh
 task setup-daemon
 ```
+
+On macOS, `task setup-daemon` now performs one explicit recovery attempt when an existing `com.vigilante.agent` launch agent is already present. If the first refresh fails, the task cleans up the existing launch agent, retries once, and prints a short manual `launchctl bootout ...` hint if recovery still fails.
 
 Notes:
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,4 +38,4 @@ tasks:
     desc: Refresh the installed daemon or service definition
     deps: [install]
     cmds:
-      - '{{.INSTALL_PATH}} setup -d'
+      - ./scripts/setup-daemon.sh

--- a/scripts/setup-daemon.sh
+++ b/scripts/setup-daemon.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+
+set -u
+
+INSTALL_PATH="${VIGILANTE_INSTALL_PATH:-$HOME/.local/bin/vigilante}"
+DAEMON_LABEL="${VIGILANTE_DAEMON_LABEL:-com.vigilante.agent}"
+DAEMON_PLIST="${VIGILANTE_DAEMON_PLIST:-$HOME/Library/LaunchAgents/${DAEMON_LABEL}.plist}"
+
+current_os() {
+  if [ -n "${VIGILANTE_SETUP_DAEMON_OS:-}" ]; then
+    printf '%s\n' "$VIGILANTE_SETUP_DAEMON_OS"
+    return
+  fi
+
+  uname -s | tr '[:upper:]' '[:lower:]'
+}
+
+run_setup() {
+  "$INSTALL_PATH" setup -d
+}
+
+print_interrupted_hint() {
+  status="$1"
+  if [ "$status" -eq 137 ]; then
+    printf '%s\n' "setup-daemon: the refresh process was interrupted or killed during launchd reload."
+  fi
+}
+
+cleanup_launchd() {
+  uid="$(id -u)"
+  launchctl bootout "gui/$uid" "$DAEMON_PLIST" >/dev/null 2>&1 || \
+    launchctl unload "$DAEMON_PLIST" >/dev/null 2>&1 || true
+  launchctl remove "$DAEMON_LABEL" >/dev/null 2>&1 || true
+}
+
+main() {
+  os_name="$(current_os)"
+  if [ "$os_name" != "darwin" ]; then
+    exec "$INSTALL_PATH" setup -d
+  fi
+
+  run_setup
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    exit 0
+  fi
+
+  if [ ! -f "$DAEMON_PLIST" ]; then
+    print_interrupted_hint "$status"
+    exit "$status"
+  fi
+
+  printf '%s\n' "setup-daemon: detected an existing launch agent, attempting cleanup and one retry..."
+  cleanup_launchd
+
+  run_setup
+  retry_status=$?
+  if [ "$retry_status" -eq 0 ]; then
+    printf '%s\n' "setup-daemon: recovered after cleaning up the existing launch agent."
+    exit 0
+  fi
+
+  print_interrupted_hint "$retry_status"
+  uid="$(id -u)"
+  printf '%s\n' "setup-daemon: automatic recovery failed."
+  printf '%s\n' "Next step: run 'launchctl bootout gui/$uid $DAEMON_PLIST' and retry 'task setup-daemon'."
+  exit "$retry_status"
+}
+
+main "$@"

--- a/scripts/setup_daemon_test.go
+++ b/scripts/setup_daemon_test.go
@@ -1,0 +1,213 @@
+package scripts
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSetupDaemonPassesThroughOnLinux(t *testing.T) {
+	t.Parallel()
+
+	fixture := newSetupDaemonFixture(t)
+	fixture.writeVigilanteScript(t, `#!/bin/sh
+printf '%s\n' "$*" >"$TEST_LOG"
+exit 0
+`)
+
+	result := fixture.run(t, "linux")
+	if result.exitCode != 0 {
+		t.Fatalf("expected success, got %d with output %s", result.exitCode, result.output)
+	}
+	if !strings.Contains(result.log, "setup -d") {
+		t.Fatalf("expected direct setup invocation, log=%q", result.log)
+	}
+	if strings.Contains(result.log, "launchctl") {
+		t.Fatalf("expected no launchctl cleanup, log=%q", result.log)
+	}
+}
+
+func TestSetupDaemonRetriesAfterLaunchdCleanup(t *testing.T) {
+	t.Parallel()
+
+	fixture := newSetupDaemonFixture(t)
+	fixture.touchPlist(t)
+	fixture.writeVigilanteScript(t, `#!/bin/sh
+count_file="$TMPDIR_BASE/vigilante-count"
+count=0
+if [ -f "$count_file" ]; then
+  count=$(cat "$count_file")
+fi
+count=$((count + 1))
+printf '%s' "$count" >"$count_file"
+printf 'vigilante %s %s\n' "$count" "$*" >>"$TEST_LOG"
+if [ "$count" -eq 1 ]; then
+  exit 137
+fi
+exit 0
+`)
+	fixture.writeLaunchctlScript(t, `#!/bin/sh
+printf 'launchctl %s\n' "$*" >>"$TEST_LOG"
+exit 0
+`)
+
+	result := fixture.run(t, "darwin")
+	if result.exitCode != 0 {
+		t.Fatalf("expected success, got %d with output %s", result.exitCode, result.output)
+	}
+	if strings.Count(result.log, "vigilante ") != 2 {
+		t.Fatalf("expected two setup attempts, log=%q", result.log)
+	}
+	if !strings.Contains(result.log, "launchctl bootout") || !strings.Contains(result.log, "launchctl remove") {
+		t.Fatalf("expected launchctl cleanup, log=%q", result.log)
+	}
+	if !strings.Contains(result.output, "detected an existing launch agent") || !strings.Contains(result.output, "recovered after cleaning up") {
+		t.Fatalf("expected recovery messaging, output=%q", result.output)
+	}
+}
+
+func TestSetupDaemonFailsWithActionableHintAfterRetry(t *testing.T) {
+	t.Parallel()
+
+	fixture := newSetupDaemonFixture(t)
+	fixture.touchPlist(t)
+	fixture.writeVigilanteScript(t, `#!/bin/sh
+printf 'vigilante %s\n' "$*" >>"$TEST_LOG"
+exit 137
+`)
+	fixture.writeLaunchctlScript(t, `#!/bin/sh
+printf 'launchctl %s\n' "$*" >>"$TEST_LOG"
+exit 0
+`)
+
+	result := fixture.run(t, "darwin")
+	if result.exitCode != 137 {
+		t.Fatalf("expected exit 137, got %d with output %s", result.exitCode, result.output)
+	}
+	if !strings.Contains(result.output, "automatic recovery failed") {
+		t.Fatalf("expected failure summary, output=%q", result.output)
+	}
+	if !strings.Contains(result.output, "launchctl bootout gui/") || !strings.Contains(result.output, "task setup-daemon") {
+		t.Fatalf("expected actionable next step, output=%q", result.output)
+	}
+	if !strings.Contains(result.output, "refresh process was interrupted or killed") {
+		t.Fatalf("expected interrupted hint, output=%q", result.output)
+	}
+}
+
+type setupDaemonFixture struct {
+	root        string
+	home        string
+	binDir      string
+	logPath     string
+	installPath string
+	plistPath   string
+}
+
+type setupDaemonResult struct {
+	exitCode int
+	output   string
+	log      string
+}
+
+func newSetupDaemonFixture(t *testing.T) setupDaemonFixture {
+	t.Helper()
+
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	return setupDaemonFixture{
+		root:        root,
+		home:        home,
+		binDir:      binDir,
+		logPath:     filepath.Join(root, "calls.log"),
+		installPath: filepath.Join(binDir, "vigilante"),
+		plistPath:   filepath.Join(home, "Library", "LaunchAgents", "com.vigilante.agent.plist"),
+	}
+}
+
+func (f setupDaemonFixture) touchPlist(t *testing.T) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(f.plistPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(f.plistPath, []byte("plist"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (f setupDaemonFixture) writeVigilanteScript(t *testing.T, contents string) {
+	t.Helper()
+	writeExecutable(t, f.installPath, contents)
+}
+
+func (f setupDaemonFixture) writeLaunchctlScript(t *testing.T, contents string) {
+	t.Helper()
+	writeExecutable(t, filepath.Join(f.binDir, "launchctl"), contents)
+}
+
+func (f setupDaemonFixture) run(t *testing.T, osName string) setupDaemonResult {
+	t.Helper()
+
+	cmd := exec.Command("/bin/sh", "./scripts/setup-daemon.sh")
+	cmd.Dir = repoRoot(t)
+	cmd.Env = append(os.Environ(),
+		"HOME="+f.home,
+		"PATH="+f.binDir+":"+os.Getenv("PATH"),
+		"TMPDIR_BASE="+f.root,
+		"TEST_LOG="+f.logPath,
+		"VIGILANTE_INSTALL_PATH="+f.installPath,
+		"VIGILANTE_DAEMON_PLIST="+f.plistPath,
+		"VIGILANTE_SETUP_DAEMON_OS="+osName,
+	)
+	output, err := cmd.CombinedOutput()
+
+	exitCode := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if ok := errors.As(err, &exitErr); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			t.Fatalf("run script: %v", err)
+		}
+	}
+
+	logData, readErr := os.ReadFile(f.logPath)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		t.Fatal(readErr)
+	}
+
+	return setupDaemonResult{
+		exitCode: exitCode,
+		output:   string(output),
+		log:      string(logData),
+	}
+}
+
+func writeExecutable(t *testing.T, path string, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Dir(dir)
+}


### PR DESCRIPTION
## Summary
- wrap `task setup-daemon` in a small helper script instead of calling `vigilante setup -d` directly
- on macOS, retry once after cleaning up an existing `com.vigilante.agent` launch agent and emit a manual recovery hint if the retry still fails
- document the new behavior and add focused script tests for Linux pass-through plus macOS recovery/failure scenarios

## Testing
- go test ./scripts
- go test ./internal/service ./internal/app
- go test ./...

Closes #110.
