### PR TITLE
Reduce daemon log noise from successful command output

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -70,8 +70,9 @@ func New() *App {
 		env: &environment.Environment{
 			OS: runtime.GOOS,
 			Runner: environment.LoggingRunner{
-				Base: environment.ExecRunner{},
-				Logf: store.AppendDaemonLog,
+				Base:             environment.ExecRunner{},
+				Logf:             store.AppendDaemonLog,
+				LogSuccessOutput: os.Getenv("VIGILANTE_DEBUG_COMMAND_OUTPUT") == "1",
 			},
 		},
 	}

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -17,8 +17,9 @@ type Runner interface {
 type ExecRunner struct{}
 
 type LoggingRunner struct {
-	Base Runner
-	Logf func(format string, args ...any)
+	Base             Runner
+	Logf             func(format string, args ...any)
+	LogSuccessOutput bool
 }
 
 func (ExecRunner) Run(ctx context.Context, dir string, name string, args ...string) (string, error) {
@@ -54,7 +55,11 @@ func (r LoggingRunner) Run(ctx context.Context, dir string, name string, args ..
 		if err != nil {
 			r.Logf("command failed cmd=%s err=%v output=%s", commandString(name, args...), err, trimForLog(output))
 		} else {
-			r.Logf("command ok cmd=%s output=%s", commandString(name, args...), trimForLog(output))
+			if r.LogSuccessOutput {
+				r.Logf("command ok cmd=%s output=%s", commandString(name, args...), trimForLog(output))
+			} else {
+				r.Logf("command ok cmd=%s", commandString(name, args...))
+			}
 		}
 	}
 	return output, err

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/nicobistolfi/vigilante/internal/testutil"
 )
 
-func TestLoggingRunnerLogsCommands(t *testing.T) {
+func TestLoggingRunnerLogsCommandsWithoutSuccessOutputByDefault(t *testing.T) {
 	var entries []string
 	runner := LoggingRunner{
 		Base: testutil.FakeRunner{
@@ -30,6 +30,31 @@ func TestLoggingRunnerLogsCommands(t *testing.T) {
 	}
 	if !strings.Contains(entries[0], `command start dir="/tmp/repo" cmd=gh issue list`) {
 		t.Fatalf("unexpected start log: %s", entries[0])
+	}
+	if entries[1] != "command ok cmd=gh issue list" {
+		t.Fatalf("unexpected success log: %s", entries[1])
+	}
+}
+
+func TestLoggingRunnerCanLogSuccessOutputWhenEnabled(t *testing.T) {
+	var entries []string
+	runner := LoggingRunner{
+		Base: testutil.FakeRunner{
+			Outputs: map[string]string{
+				"gh issue list": "[]",
+			},
+		},
+		Logf: func(format string, args ...any) {
+			entries = append(entries, sprintf(format, args...))
+		},
+		LogSuccessOutput: true,
+	}
+
+	if _, err := runner.Run(context.Background(), "/tmp/repo", "gh", "issue", "list"); err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("unexpected log entries: %#v", entries)
 	}
 	if !strings.Contains(entries[1], "command ok cmd=gh issue list output=[]") {
 		t.Fatalf("unexpected success log: %s", entries[1])


### PR DESCRIPTION
## Summary
- stop normal daemon logs from dumping raw output bodies for successful commands
- keep failure logs detailed and add an explicit opt-in for raw success-output tracing with `VIGILANTE_DEBUG_COMMAND_OUTPUT=1`
- cover the default and opt-in behaviors with focused `internal/environment` tests

Closes #117.

## Validation
- `go test ./internal/environment ./internal/app`
- `go test ./...`
