### PR TITLE
Fix Claude headless invocation compatibility

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1674,10 +1674,10 @@ func buildResumeFailureSummaryInvocation(selectedProvider provider.Provider, wor
 	switch selectedProvider.ID() {
 	case provider.ClaudeID:
 		return provider.Invocation{
+			Dir:  workdir,
 			Name: "claude",
 			Args: []string{
 				"--print",
-				"--cwd", workdir,
 				"--permission-mode", "acceptEdits",
 				prompt,
 			},

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2263,6 +2263,8 @@ func resumeDiagnosticSummaryCommand(worktreePath string, session state.Session, 
 
 func resumeDiagnosticSummaryCommandForProvider(worktreePath string, providerID string, session state.Session, previousStage string) string {
 	switch providerID {
+	case "claude":
+		return testutil.Key("claude", "--print", "--permission-mode", "acceptEdits", buildResumeFailureSummaryPrompt(session, previousStage))
 	case "gemini":
 		return testutil.Key("gemini", "--prompt", buildResumeFailureSummaryPrompt(session, previousStage), "--yolo")
 	default:

--- a/internal/provider/claude.go
+++ b/internal/provider/claude.go
@@ -25,10 +25,13 @@ func (claudeProvider) EnsureRuntimeInstalled(store *state.Store) error {
 
 func (claudeProvider) BuildIssuePreflightInvocation(task IssueTask) (Invocation, error) {
 	return Invocation{
+		// Use the process working directory instead of CLI-specific cwd flags so
+		// Vigilante stays compatible with Claude Code builds that do not expose
+		// a stable --cwd option in headless mode.
+		Dir:  task.Session.WorktreePath,
 		Name: "claude",
 		Args: []string{
 			"--print",
-			"--cwd", task.Session.WorktreePath,
 			"--permission-mode", "acceptEdits",
 			skill.BuildIssuePreflightPrompt(task.Target, task.Issue, task.Session),
 		},
@@ -37,10 +40,10 @@ func (claudeProvider) BuildIssuePreflightInvocation(task IssueTask) (Invocation,
 
 func (claudeProvider) BuildIssueInvocation(task IssueTask) (Invocation, error) {
 	return Invocation{
+		Dir:  task.Session.WorktreePath,
 		Name: "claude",
 		Args: []string{
 			"--print",
-			"--cwd", task.Session.WorktreePath,
 			"--permission-mode", "acceptEdits",
 			skill.BuildIssuePromptForRuntime(skill.RuntimeClaude, task.Target, task.Issue, task.Session),
 		},
@@ -49,10 +52,10 @@ func (claudeProvider) BuildIssueInvocation(task IssueTask) (Invocation, error) {
 
 func (claudeProvider) BuildConflictResolutionInvocation(task ConflictTask) (Invocation, error) {
 	return Invocation{
+		Dir:  task.Session.WorktreePath,
 		Name: "claude",
 		Args: []string{
 			"--print",
-			"--cwd", task.Session.WorktreePath,
 			"--permission-mode", "acceptEdits",
 			skill.BuildConflictResolutionPromptForRuntime(skill.RuntimeClaude, task.Target, task.Session, task.PR),
 		},

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
+	"github.com/nicobistolfi/vigilante/internal/skill"
 	"github.com/nicobistolfi/vigilante/internal/state"
 )
 
@@ -74,6 +75,48 @@ func TestResolveGeminiProvider(t *testing.T) {
 	}
 }
 
+func TestClaudeInvocationUsesWorktreeDirForHeadlessRuns(t *testing.T) {
+	selectedProvider, err := Resolve(ClaudeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
+	issue := ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}
+	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: ClaudeID}
+	pr := ghcli.PullRequest{Number: 11, URL: "https://github.com/owner/repo/pull/11"}
+
+	preflight, err := selectedProvider.BuildIssuePreflightInvocation(IssueTask{Target: target, Issue: issue, Session: session})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preflight.Dir != "/tmp/worktree" {
+		t.Fatalf("expected preflight dir to be worktree, got %#v", preflight)
+	}
+	wantPreflightArgs := []string{"--print", "--permission-mode", "acceptEdits", skill.BuildIssuePreflightPrompt(target, issue, session)}
+	assertInvocationArgs(t, preflight.Args, wantPreflightArgs)
+
+	issueInvocation, err := selectedProvider.BuildIssueInvocation(IssueTask{Target: target, Issue: issue, Session: session})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if issueInvocation.Dir != "/tmp/worktree" {
+		t.Fatalf("expected issue dir to be worktree, got %#v", issueInvocation)
+	}
+	wantIssueArgs := []string{"--print", "--permission-mode", "acceptEdits", skill.BuildIssuePromptForRuntime(skill.RuntimeClaude, target, issue, session)}
+	assertInvocationArgs(t, issueInvocation.Args, wantIssueArgs)
+
+	conflictInvocation, err := selectedProvider.BuildConflictResolutionInvocation(ConflictTask{Target: target, Session: session, PR: pr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conflictInvocation.Dir != "/tmp/worktree" {
+		t.Fatalf("expected conflict dir to be worktree, got %#v", conflictInvocation)
+	}
+	wantConflictArgs := []string{"--print", "--permission-mode", "acceptEdits", skill.BuildConflictResolutionPromptForRuntime(skill.RuntimeClaude, target, session, pr)}
+	assertInvocationArgs(t, conflictInvocation.Args, wantConflictArgs)
+}
+
 func TestResolveIssueLabelUsesRegisteredProviderIDs(t *testing.T) {
 	original := registry
 	registry = map[string]Provider{
@@ -109,6 +152,18 @@ func TestResolveIssueLabelRejectsConflictingProviderLabels(t *testing.T) {
 	}
 	if got := err.Error(); got != "multiple provider labels: codex, cursor" {
 		t.Fatalf("unexpected conflict error: %s", got)
+	}
+}
+
+func assertInvocationArgs(t *testing.T, got []string, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("unexpected arg count: got %#v want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected args: got %#v want %#v", got, want)
+		}
 	}
 }
 

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -170,12 +170,12 @@ func TestRunIssueSessionSuccessWithClaudeProvider(t *testing.T) {
 				},
 				Tagline: "Make it simple, but significant.",
 			}): "ok",
-			testutil.Key("claude", "--print", "--cwd", "/tmp/worktree", "--permission-mode", "acceptEdits", skill.BuildIssuePreflightPrompt(
+			testutil.Key("claude", "--print", "--permission-mode", "acceptEdits", skill.BuildIssuePreflightPrompt(
 				state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"},
 				ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"},
 				state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "claude"},
 			)): "baseline ok",
-			testutil.Key("claude", "--print", "--cwd", "/tmp/worktree", "--permission-mode", "acceptEdits", skill.BuildIssuePromptForRuntime(
+			testutil.Key("claude", "--print", "--permission-mode", "acceptEdits", skill.BuildIssuePromptForRuntime(
 				skill.RuntimeClaude,
 				state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"},
 				ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"},


### PR DESCRIPTION
## Summary
Fix Claude Code headless invocation compatibility so Claude-backed Vigilante sessions run from the assigned worktree directory instead of passing the unsupported `--cwd` flag.

Closes #124.

## What Changed
- updated the Claude provider to run preflight, implementation, and conflict-resolution commands from `Invocation.Dir`
- removed the Claude-specific `--cwd` flag from those invocations
- updated the Claude resume-diagnostic helper to use the same execution model
- added provider-level regression coverage for the exact Claude invocation contract
- updated session/app tests that previously encoded the wrong Claude flag shape

## Investigation
I verified the current Claude Code contract from two places:
- the installed local `claude --help` output on this machine
- Anthropic's official Claude Code CLI reference for headless mode

The installed Claude CLI here supports headless `--print` mode and `--permission-mode`, but it rejects `--cwd`, which is why the blocked Claude sessions were failing in baseline preflight.

## Validation
- `go test ./...`

## Prevention Plan
- keep provider-specific headless invocation details encapsulated in the provider layer
- add direct provider invocation tests for exact CLI flags/arguments instead of relying only on higher-level session tests
- verify provider runtime assumptions against installed CLI help / official docs before changing runtime flags
