### PR TITLE
Include diagnostic details in validation_failed blocked comments

### DIFF
--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -89,12 +89,8 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 			Emoji:      "🧱",
 			Percent:    25,
 			ETAMinutes: 15,
-			Items: []string{
-				blockedPreflightMessage(blocked, selectedProvider.ID()),
-				blocking.CauseLine(blocked),
-				fmt.Sprintf("Next step: restore the repository baseline, then run `%s` or request resume from GitHub.", session.ResumeHint),
-			},
-			Tagline: "Strong foundations make calm debugging sessions.",
+			Items:      blockedPreflightItems(blocked, selectedProvider.ID(), preflightOutput, session.ResumeHint),
+			Tagline:    "Strong foundations make calm debugging sessions.",
 		})
 		_ = ghcli.CommentOnIssue(ctx, env.Runner, target.Repo, issue.Number, body)
 		return session
@@ -221,6 +217,23 @@ func blockedPreflightMessage(blocked state.BlockedReason, providerID string) str
 	return "Repository baseline validation failed before issue implementation began."
 }
 
+func blockedPreflightItems(blocked state.BlockedReason, providerID string, preflightOutput string, resumeHint string) []string {
+	items := []string{
+		blockedPreflightMessage(blocked, providerID),
+		blocking.CauseLine(blocked),
+	}
+	if blocked.Kind == "validation_failed" {
+		if detail := blockedValidationDetail(blocked); detail != "" {
+			items = append(items, fmt.Sprintf("Failed validation: %s.", detail))
+		}
+		if output := summarizePreflightOutput(preflightOutput); output != "" {
+			items = append(items, fmt.Sprintf("Relevant preflight output: %s.", output))
+		}
+	}
+	items = append(items, fmt.Sprintf("Next step: restore the repository baseline, then run `%s` or request resume from GitHub.", resumeHint))
+	return items
+}
+
 func blockedExecutionMessage(blocked state.BlockedReason, providerID string) string {
 	if blocked.Kind == "provider_quota" {
 		return fmt.Sprintf("The `%s` provider hit a usage or subscription limit before the issue implementation completed.", providerID)
@@ -233,6 +246,39 @@ func blockedConflictMessage(blocked state.BlockedReason, prNumber int, branch st
 		return fmt.Sprintf("Conflict resolution for PR #%d on `%s` stopped because provider `%s` hit a usage or subscription limit.", prNumber, branch, providerID)
 	}
 	return fmt.Sprintf("Conflict resolution for PR #%d on `%s` through provider `%s` did not complete.", prNumber, branch, providerID)
+}
+
+func blockedValidationDetail(blocked state.BlockedReason) string {
+	for _, candidate := range []string{blocked.Summary, blocked.Detail} {
+		if text := sanitizeDiagnosticText(candidate, 220); text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func summarizePreflightOutput(output string) string {
+	return sanitizeDiagnosticText(output, 280)
+}
+
+func sanitizeDiagnosticText(text string, limit int) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	fields := strings.Fields(text)
+	if len(fields) == 0 {
+		return ""
+	}
+	text = strings.Join(fields, " ")
+	text = strings.TrimSpace(strings.TrimRight(text, ".!?"))
+	if len(text) > limit {
+		if limit <= 3 {
+			return text[:limit]
+		}
+		return strings.TrimSpace(text[:limit-3]) + "..."
+	}
+	return text
 }
 
 func appendSessionLog(path string, event string, session state.Session, details string) {

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -79,11 +79,16 @@ func TestRunIssueSessionFailureCommentsOnIssue(t *testing.T) {
 				Emoji:      "🧱",
 				Percent:    25,
 				ETAMinutes: 15,
-				Items: []string{
-					"Repository baseline validation failed before issue implementation began.",
-					"Cause class: `validation_failed`.",
-					"Next step: restore the repository baseline, then run `vigilante resume --repo owner/repo --issue 7` or request resume from GitHub.",
-				},
+				Items: blockedPreflightItems(
+					state.BlockedReason{
+						Kind:    "validation_failed",
+						Summary: "baseline validation failed: go test ./... exit status 1",
+						Detail:  "baseline validation failed: go test ./... exit status 1",
+					},
+					"codex",
+					"",
+					"vigilante resume --repo owner/repo --issue 7",
+				),
 				Tagline: "Strong foundations make calm debugging sessions.",
 			}): "ok",
 		},
@@ -312,6 +317,82 @@ func TestClassifyBlockedFailureDetectsProviderQuota(t *testing.T) {
 	}
 }
 
+func TestBlockedPreflightItemsIncludeSummarizedOutputForValidationFailures(t *testing.T) {
+	items := blockedPreflightItems(
+		state.BlockedReason{
+			Kind:    "validation_failed",
+			Summary: "baseline validation failed: go test ./... exit status 1",
+			Detail:  "line one\nline two",
+		},
+		"codex",
+		"--- FAIL: TestCLIWatch\nwatch command failed\nFAIL\tgithub.com/nicobistolfi/vigilante/internal/app\t0.421s",
+		"vigilante resume --repo owner/repo --issue 7",
+	)
+
+	for _, want := range []string{
+		"Repository baseline validation failed before issue implementation began.",
+		"Cause class: `validation_failed`.",
+		"Failed validation: baseline validation failed: go test ./... exit status 1.",
+		"Relevant preflight output: --- FAIL: TestCLIWatch watch command failed FAIL github.com/nicobistolfi/vigilante/internal/app 0.421s.",
+	} {
+		if !containsLine(items, want) {
+			t.Fatalf("expected items to contain %q, got %#v", want, items)
+		}
+	}
+}
+
+func TestBlockedPreflightItemsBoundLongOutput(t *testing.T) {
+	output := strings.Repeat("noisy log line ", 40)
+
+	items := blockedPreflightItems(
+		state.BlockedReason{
+			Kind:    "validation_failed",
+			Summary: "baseline validation failed: npm test exit status 1",
+		},
+		"codex",
+		output,
+		"vigilante resume --repo owner/repo --issue 7",
+	)
+
+	var relevant string
+	for _, item := range items {
+		if strings.HasPrefix(item, "Relevant preflight output: ") {
+			relevant = item
+			break
+		}
+	}
+	if relevant == "" {
+		t.Fatalf("expected relevant preflight output item, got %#v", items)
+	}
+	if len(relevant) > 320 {
+		t.Fatalf("expected bounded output item, got length %d: %q", len(relevant), relevant)
+	}
+	if !strings.Contains(relevant, "...") {
+		t.Fatalf("expected truncated output marker, got %q", relevant)
+	}
+}
+
+func TestBlockedPreflightItemsSkipOutputWhenEmpty(t *testing.T) {
+	items := blockedPreflightItems(
+		state.BlockedReason{
+			Kind:    "validation_failed",
+			Summary: "baseline validation failed: go test ./... exit status 1",
+		},
+		"codex",
+		"",
+		"vigilante resume --repo owner/repo --issue 7",
+	)
+
+	if !containsLine(items, "Failed validation: baseline validation failed: go test ./... exit status 1.") {
+		t.Fatalf("expected failed validation item, got %#v", items)
+	}
+	for _, item := range items {
+		if strings.HasPrefix(item, "Relevant preflight output: ") {
+			t.Fatalf("did not expect output item for empty preflight output, got %#v", items)
+		}
+	}
+}
+
 func TestAppendSessionLogUsesLocalTimezone(t *testing.T) {
 	originalLocal := time.Local
 	time.Local = time.FixedZone("TEST", -8*60*60)
@@ -358,4 +439,13 @@ func issuePromptCommand(worktreePath string, repo string, repoPath string, issue
 		ghcli.Issue{Number: issueNumber, Title: title, URL: issueURL},
 		state.Session{WorktreePath: worktreePath, Branch: branch, Provider: "codex"},
 	))
+}
+
+func containsLine(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- include bounded validation diagnostics in baseline preflight blocked comments for `validation_failed`
- include summarized preflight output when available without dumping unbounded logs
- add runner coverage for rich comment content, truncation, and empty-output fallback

Closes #120

## Validation
- `go test ./internal/runner`
- `go test ./...`
