### PR TITLE
Validate provider CLI compatibility against build-supported ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Expected behavior:
 - creates `~/.vigilante/`
 - initializes `watchlist.json`
 - verifies `git`, `gh`, and the selected coding-agent provider CLI
+- verifies the selected provider CLI reports a compatible build-supported version range, currently `>=1.0.0, <2.0.0` for `codex`, `claude`, and `gemini`
 - installs the bundled coding-agent skills for regular runtime use, including any companion files under each skill directory
   - `vigilante-issue-implementation`
   - `vigilante-issue-implementation-on-monorepo`

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1828,6 +1828,9 @@ func (a *App) ensureTooling(ctx context.Context, selectedProvider provider.Provi
 			return fmt.Errorf("%s is required: %w", tool, err)
 		}
 	}
+	if err := provider.ValidateRuntimeCompatibility(ctx, a.env.Runner, selectedProvider); err != nil {
+		return err
+	}
 	if _, err := a.env.Runner.Run(ctx, "", "gh", "auth", "status"); err != nil {
 		return fmt.Errorf("gh authentication check failed: %w", err)
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -75,7 +75,8 @@ func TestSetupCreatesStateLayoutAndSkill(t *testing.T) {
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: map[string]string{
-			"gh auth status": "ok",
+			"codex --version": "codex 1.2.3",
+			"gh auth status":  "ok",
 		},
 	}
 
@@ -109,7 +110,8 @@ func TestSetupWithGeminiCreatesGeminiSkillAssets(t *testing.T) {
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "gemini": "/usr/bin/gemini"},
 		Outputs: map[string]string{
-			"gh auth status": "ok",
+			"gemini --version": "gemini 1.7.0",
+			"gh auth status":   "ok",
 		},
 	}
 
@@ -195,11 +197,13 @@ func TestWatchUpdatesExistingTarget(t *testing.T) {
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: map[string]string{
+			"codex --version":                   "codex 1.2.3",
 			"gh auth status":                    "ok",
 			`/bin/zsh -lic printf "%s" "$PATH"`: "/usr/bin:/bin:/Users/test/.local/bin",
 			`/bin/sh -lc PATH="/usr/bin:/bin:/Users/test/.local/bin" command -v 'git'`:   "/usr/bin/git\n",
 			`/bin/sh -lc PATH="/usr/bin:/bin:/Users/test/.local/bin" command -v 'gh'`:    "/usr/bin/gh\n",
 			`/bin/sh -lc PATH="/usr/bin:/bin:/Users/test/.local/bin" command -v 'codex'`: "/Users/test/.local/bin/codex\n",
+			`/bin/sh -lc PATH="/usr/bin:/bin:/Users/test/.local/bin" 'codex' --version`:  "codex 1.2.3\n",
 			testutil.Key("launchctl", "unload", launchAgentPath):                         "",
 			testutil.Key("launchctl", "load", launchAgentPath):                           "",
 			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                    "true\n",
@@ -254,10 +258,12 @@ func TestWatchWithProviderPersistsClaudeSelection(t *testing.T) {
 	app.stdout = testutil.IODiscard{}
 	app.stderr = testutil.IODiscard{}
 	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "claude": "/usr/bin/claude"},
 		Outputs: map[string]string{
 			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                  "true\n",
 			testutil.Key("git", "remote", "get-url", "origin"):                         "git@github.com:nicobistolfi/vigilante.git\n",
 			testutil.Key("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"): "origin/main\n",
+			"claude --version": "Claude Code 1.4.0",
 		},
 	}
 
@@ -290,10 +296,12 @@ func TestWatchPersistsRepoClassification(t *testing.T) {
 	app.stdout = testutil.IODiscard{}
 	app.stderr = testutil.IODiscard{}
 	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "gemini": "/usr/bin/gemini"},
 		Outputs: map[string]string{
 			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                  "true\n",
 			testutil.Key("git", "remote", "get-url", "origin"):                         "git@github.com:nicobistolfi/vigilante.git\n",
 			testutil.Key("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"): "origin/main\n",
+			"gemini --version": "gemini 1.7.0",
 		},
 	}
 
@@ -343,6 +351,28 @@ func TestWatchWithGeminiProviderPersistsSelection(t *testing.T) {
 	}
 	if len(targets) != 1 || targets[0].Provider != "gemini" {
 		t.Fatalf("expected gemini provider to persist: %#v", targets)
+	}
+}
+
+func TestSetupFailsWhenProviderVersionIsIncompatible(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"codex --version": "codex 2.0.0",
+		},
+	}
+
+	err := app.Setup(context.Background(), false)
+	if err == nil || !strings.Contains(err.Error(), "codex CLI version 2.0.0 is incompatible") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/provider/compatibility.go
+++ b/internal/provider/compatibility.go
@@ -1,0 +1,159 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/nicobistolfi/vigilante/internal/environment"
+)
+
+var versionPattern = regexp.MustCompile(`\b(v?\d+\.\d+\.\d+)\b`)
+
+type cliVersion struct {
+	major int
+	minor int
+	patch int
+}
+
+type compatibilityContract struct {
+	minInclusive string
+	maxExclusive string
+}
+
+var compatibilityContracts = map[string]compatibilityContract{
+	DefaultID: {minInclusive: "1.0.0", maxExclusive: "2.0.0"},
+	ClaudeID:  {minInclusive: "1.0.0", maxExclusive: "2.0.0"},
+	GeminiID:  {minInclusive: "1.0.0", maxExclusive: "2.0.0"},
+}
+
+func ValidateRuntimeCompatibility(ctx context.Context, runner environment.Runner, selectedProvider Provider) error {
+	tool := runtimeTool(selectedProvider)
+	output, err := runner.Run(ctx, "", tool, "--version")
+	if err != nil {
+		return fmt.Errorf("detect %s CLI version: %w", tool, err)
+	}
+	return ValidateVersionOutput(selectedProvider, output)
+}
+
+func ValidateVersionOutput(selectedProvider Provider, output string) error {
+	versionText, version, err := parseVersionOutput(selectedProvider.ID(), output)
+	if err != nil {
+		return err
+	}
+	contract, err := compatibilityFor(selectedProvider.ID())
+	if err != nil {
+		return err
+	}
+	min, err := parseVersion(contract.minInclusive)
+	if err != nil {
+		return err
+	}
+	max, err := parseVersion(contract.maxExclusive)
+	if err != nil {
+		return err
+	}
+	if compareVersions(version, min) < 0 || compareVersions(version, max) >= 0 {
+		return fmt.Errorf(
+			"%s CLI version %s is incompatible with this Vigilante build (supported: %s); install a compatible %s CLI version or use a matching Vigilante build",
+			runtimeTool(selectedProvider),
+			versionText,
+			describeCompatibility(selectedProvider.ID()),
+			runtimeTool(selectedProvider),
+		)
+	}
+	return nil
+}
+
+func describeCompatibility(providerID string) string {
+	contract, ok := compatibilityContracts[providerID]
+	if !ok {
+		return "unknown"
+	}
+	return fmt.Sprintf(">=%s, <%s", contract.minInclusive, contract.maxExclusive)
+}
+
+func parseVersionOutput(providerID string, output string) (string, cliVersion, error) {
+	matches := versionPattern.FindStringSubmatch(output)
+	if len(matches) < 2 {
+		return "", cliVersion{}, fmt.Errorf(
+			"could not parse %s CLI version from output %q (supported: %s); install a compatible %s CLI version or use a matching Vigilante build",
+			providerID,
+			strings.TrimSpace(output),
+			describeCompatibility(providerID),
+			providerID,
+		)
+	}
+	versionText := strings.TrimPrefix(matches[1], "v")
+	version, err := parseVersion(versionText)
+	if err != nil {
+		return "", cliVersion{}, fmt.Errorf(
+			"could not parse %s CLI version %q (supported: %s): %w",
+			providerID,
+			versionText,
+			describeCompatibility(providerID),
+			err,
+		)
+	}
+	return versionText, version, nil
+}
+
+func compatibilityFor(providerID string) (compatibilityContract, error) {
+	contract, ok := compatibilityContracts[providerID]
+	if !ok {
+		return compatibilityContract{}, fmt.Errorf("no compatibility contract defined for provider %q", providerID)
+	}
+	return contract, nil
+}
+
+func runtimeTool(selectedProvider Provider) string {
+	tools := selectedProvider.RequiredTools()
+	if len(tools) == 0 {
+		return selectedProvider.ID()
+	}
+	return strings.TrimSpace(tools[0])
+}
+
+func parseVersion(raw string) (cliVersion, error) {
+	parts := strings.Split(strings.TrimSpace(raw), ".")
+	if len(parts) != 3 {
+		return cliVersion{}, fmt.Errorf("expected major.minor.patch")
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return cliVersion{}, err
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return cliVersion{}, err
+	}
+	patch, err := strconv.Atoi(parts[2])
+	if err != nil {
+		return cliVersion{}, err
+	}
+	return cliVersion{major: major, minor: minor, patch: patch}, nil
+}
+
+func compareVersions(a cliVersion, b cliVersion) int {
+	switch {
+	case a.major != b.major:
+		return compareInt(a.major, b.major)
+	case a.minor != b.minor:
+		return compareInt(a.minor, b.minor)
+	default:
+		return compareInt(a.patch, b.patch)
+	}
+}
+
+func compareInt(a int, b int) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"strings"
 	"testing"
 
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
@@ -152,6 +153,79 @@ func TestResolveIssueLabelRejectsConflictingProviderLabels(t *testing.T) {
 	}
 	if got := err.Error(); got != "multiple provider labels: codex, cursor" {
 		t.Fatalf("unexpected conflict error: %s", got)
+	}
+}
+
+func TestValidateVersionOutputAcceptsSupportedVersions(t *testing.T) {
+	cases := []struct {
+		name     string
+		provider string
+		output   string
+	}{
+		{name: "codex", provider: DefaultID, output: "codex 1.2.3"},
+		{name: "claude", provider: ClaudeID, output: "Claude Code v1.4.0"},
+		{name: "gemini", provider: GeminiID, output: "gemini-cli 1.9.9"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			selectedProvider, err := Resolve(tc.provider)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := ValidateVersionOutput(selectedProvider, tc.output); err != nil {
+				t.Fatalf("expected version to be accepted, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateVersionOutputRejectsTooOldVersion(t *testing.T) {
+	selectedProvider, err := Resolve(DefaultID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ValidateVersionOutput(selectedProvider, "codex 0.9.9")
+	if err == nil {
+		t.Fatal("expected compatibility error")
+	}
+	for _, want := range []string{"codex CLI version 0.9.9 is incompatible", ">=1.0.0, <2.0.0"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %q", want, err.Error())
+		}
+	}
+}
+
+func TestValidateVersionOutputRejectsTooNewVersion(t *testing.T) {
+	selectedProvider, err := Resolve(ClaudeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ValidateVersionOutput(selectedProvider, "Claude Code 2.0.0")
+	if err == nil {
+		t.Fatal("expected compatibility error")
+	}
+	if !strings.Contains(err.Error(), "supported: >=1.0.0, <2.0.0") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateVersionOutputRejectsMalformedVersionOutput(t *testing.T) {
+	selectedProvider, err := Resolve(GeminiID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ValidateVersionOutput(selectedProvider, "gemini version unknown")
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	for _, want := range []string{"could not parse gemini CLI version", "supported: >=1.0.0, <2.0.0"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %q", want, err.Error())
+		}
 	}
 }
 

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -34,6 +34,14 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 	session.ProcessID = os.Getpid()
 	session.LastHeartbeatAt = time.Now().UTC().Format(time.RFC3339)
 	session.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	if err := provider.ValidateRuntimeCompatibility(ctx, env.Runner, selectedProvider); err != nil {
+		session.Status = state.SessionStatusFailed
+		session.LastError = err.Error()
+		session.EndedAt = time.Now().UTC().Format(time.RFC3339)
+		session.UpdatedAt = session.EndedAt
+		appendSessionLog(logPath, "session provider compatibility failed", session, err.Error())
+		return session
+	}
 	startBody := ghcli.FormatProgressComment(ghcli.ProgressComment{
 		Stage:      "Vigilante Session Start",
 		Emoji:      "🧢",
@@ -152,6 +160,10 @@ func RunConflictResolutionSession(ctx context.Context, env *environment.Environm
 	}
 	session.Provider = selectedProvider.ID()
 	appendSessionLog(logPath, "conflict resolution started", session, fmt.Sprintf("pr=%d url=%s", pr.Number, pr.URL))
+	if err := provider.ValidateRuntimeCompatibility(ctx, env.Runner, selectedProvider); err != nil {
+		appendSessionLog(logPath, "conflict resolution provider compatibility failed", session, err.Error())
+		return err
+	}
 
 	invocation, err := selectedProvider.BuildConflictResolutionInvocation(provider.ConflictTask{Target: target, Session: session, PR: pr})
 	if err != nil {

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -22,6 +22,7 @@ func TestRunIssueSessionSuccess(t *testing.T) {
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{
+			"codex --version": "codex 1.2.3",
 			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
 				Stage:      "Vigilante Session Start",
 				Emoji:      "🧢",
@@ -62,6 +63,7 @@ func TestRunIssueSessionFailureCommentsOnIssue(t *testing.T) {
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{
+			"codex --version": "codex 1.2.3",
 			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
 				Stage:      "Vigilante Session Start",
 				Emoji:      "🧢",
@@ -123,6 +125,7 @@ func TestRunConflictResolutionSessionFailureCommentsOnIssue(t *testing.T) {
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{
+			"codex --version": "codex 1.2.3",
 			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
 				Stage:      "Blocked",
 				Emoji:      "🧯",
@@ -164,6 +167,7 @@ func TestRunIssueSessionSuccessWithClaudeProvider(t *testing.T) {
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{
+			"claude --version": "Claude Code 1.4.0",
 			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
 				Stage:      "Vigilante Session Start",
 				Emoji:      "🧢",
@@ -206,6 +210,7 @@ func TestRunIssueSessionSuccessWithGeminiProvider(t *testing.T) {
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{
+			"gemini --version": "gemini 1.7.0",
 			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
 				Stage:      "Vigilante Session Start",
 				Emoji:      "🧢",
@@ -259,6 +264,7 @@ func TestRunIssueSessionUsesMonorepoSkillWhenClassified(t *testing.T) {
 	}
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{
+			"codex --version": "codex 1.2.3",
 			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
 				Stage:      "Vigilante Session Start",
 				Emoji:      "🧢",
@@ -290,6 +296,31 @@ func TestRunIssueSessionUsesMonorepoSkillWhenClassified(t *testing.T) {
 
 	if got.Status != state.SessionStatusSuccess {
 		t.Fatalf("unexpected status: %#v", got)
+	}
+}
+
+func TestRunIssueSessionFailsWhenProviderVersionIsIncompatible(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"codex --version": "codex 2.0.0",
+		},
+	}
+	env := &environment.Environment{OS: "darwin", Runner: runner}
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
+
+	got := RunIssueSession(context.Background(), env, store, state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+
+	if got.Status != state.SessionStatusFailed {
+		t.Fatalf("unexpected status: %#v", got)
+	}
+	if !strings.Contains(got.LastError, "codex CLI version 2.0.0 is incompatible") {
+		t.Fatalf("unexpected error: %#v", got)
 	}
 }
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -191,6 +191,9 @@ func validateDaemonTooling(ctx context.Context, runner environment.Runner, pathE
 		sort.Strings(missing)
 		return fmt.Errorf("daemon PATH does not resolve required tools: %s", strings.Join(missing, ", "))
 	}
+	if err := validateProviderVersionInPath(ctx, runner, pathEnv, selectedProvider); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -199,6 +202,24 @@ func validateToolInPath(ctx context.Context, runner environment.Runner, pathEnv 
 	command := fmt.Sprintf("PATH=%q command -v %s", pathEnv, shellQuote(tool))
 	_, err := runner.Run(ctx, "", shellPath, "-lc", command)
 	return err
+}
+
+func validateProviderVersionInPath(ctx context.Context, runner environment.Runner, pathEnv string, selectedProvider provider.Provider) error {
+	tool := shellQuote(runtimeTool(selectedProvider))
+	command := fmt.Sprintf("PATH=%q %s --version", pathEnv, tool)
+	output, err := runner.Run(ctx, "", "/bin/sh", "-lc", command)
+	if err != nil {
+		return fmt.Errorf("detect %s CLI version from daemon PATH: %w", runtimeTool(selectedProvider), err)
+	}
+	return provider.ValidateVersionOutput(selectedProvider, output)
+}
+
+func runtimeTool(selectedProvider provider.Provider) string {
+	tools := selectedProvider.RequiredTools()
+	if len(tools) == 0 {
+		return selectedProvider.ID()
+	}
+	return tools[0]
 }
 
 func shellQuote(value string) string {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -59,6 +59,7 @@ func TestBuildConfigUsesShellPath(t *testing.T) {
 				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'git'`:   "/opt/homebrew/bin/git\n",
 				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'gh'`:    "/opt/homebrew/bin/gh\n",
 				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'codex'`: "/Users/test/.local/bin/codex\n",
+				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" 'codex' --version`:  "codex 1.2.3\n",
 			},
 		},
 	}
@@ -122,6 +123,7 @@ func TestBuildConfigSupportsClaudeProvider(t *testing.T) {
 				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'git'`:    "/opt/homebrew/bin/git\n",
 				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'gh'`:     "/opt/homebrew/bin/gh\n",
 				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'claude'`: "/Users/test/.local/bin/claude\n",
+				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" 'claude' --version`:  "Claude Code 1.4.0\n",
 			},
 		},
 	}
@@ -152,6 +154,7 @@ func TestBuildConfigSupportsGeminiProvider(t *testing.T) {
 				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'git'`:    "/opt/homebrew/bin/git\n",
 				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'gh'`:     "/opt/homebrew/bin/gh\n",
 				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'gemini'`: "/Users/test/.local/bin/gemini\n",
+				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" 'gemini' --version`:  "gemini 1.7.0\n",
 			},
 		},
 	}
@@ -166,5 +169,32 @@ func TestBuildConfigSupportsGeminiProvider(t *testing.T) {
 	}
 	if cfg.PathEnv != "/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" {
 		t.Fatalf("unexpected PATH: %#v", cfg)
+	}
+}
+
+func TestBuildConfigFailsWhenProviderVersionIsIncompatible(t *testing.T) {
+	t.Setenv("HOME", "/Users/test")
+	t.Setenv("SHELL", "/bin/zsh")
+
+	env := &environment.Environment{
+		OS: "darwin",
+		Runner: testutil.FakeRunner{
+			Outputs: map[string]string{
+				`/bin/zsh -lic printf "%s" "$PATH"`: "/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin",
+				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'git'`:   "/opt/homebrew/bin/git\n",
+				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'gh'`:    "/opt/homebrew/bin/gh\n",
+				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'codex'`: "/Users/test/.local/bin/codex\n",
+				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" 'codex' --version`:  "codex 2.0.0\n",
+			},
+		},
+	}
+
+	selectedProvider, err := provider.Resolve(provider.DefaultID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = BuildConfig(context.Background(), env, selectedProvider)
+	if err == nil || !strings.Contains(err.Error(), "codex CLI version 2.0.0 is incompatible") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -22,6 +22,9 @@ func (f FakeRunner) Run(_ context.Context, _ string, name string, args ...string
 	if output, ok := f.Outputs[cmd]; ok {
 		return output, nil
 	}
+	if len(args) == 1 && args[0] == "--version" {
+		return name + " 1.0.0", nil
+	}
 	return "", fmt.Errorf("unexpected command: %s", cmd)
 }
 


### PR DESCRIPTION
## Summary
- add a shared provider CLI compatibility contract and version parsing for codex, claude, and gemini
- enforce compatibility checks during setup, daemon PATH validation, and session startup so incompatible CLIs fail early
- add parser and compatibility regression coverage plus document the supported range in the README

Closes #123

## Validation
- go test ./...
- go build ./...