### PR TITLE
Add blocked-session inactivity cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,9 +308,25 @@ You can also confirm the Homebrew cask will target the published release archive
 
 Initial files:
 
+- `config.json`: service-level daemon configuration
 - `watchlist.json`: configured repositories being monitored
 - `sessions.json`: active or recent issue execution sessions
 - `logs/`: daemon and run logs
+
+Suggested `config.json` shape:
+
+```json
+{
+  "blocked_session_inactivity_timeout": "20m"
+}
+```
+
+Notes:
+
+- `blocked_session_inactivity_timeout` is a service-level setting shared across all watched repositories.
+- The default is `20m`.
+- A blocked session is eligible for automatic local cleanup only after there have been no qualifying user comments on the issue, no session updates, and no worktree updates for longer than the configured timeout.
+- This inactivity cleanup is conservative: it clears local blocked-session artifacts so the issue can be redispatched later, but it does not delete remote pull requests or remote branches automatically.
 
 Suggested `watchlist.json` shape:
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -470,6 +470,10 @@ func (a *App) ScanOnce(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		sessions, err = a.cleanupInactiveBlockedSessions(ctx, sessions)
+		if err != nil {
+			return err
+		}
 		sessions, err = a.maintainPullRequests(ctx, sessions)
 		if err != nil {
 			return err
@@ -1389,6 +1393,99 @@ func (a *App) resumeBlockedConflictResolution(ctx context.Context, session *stat
 	return nil
 }
 
+func (a *App) cleanupInactiveBlockedSessions(ctx context.Context, sessions []state.Session) ([]state.Session, error) {
+	config, err := a.state.LoadServiceConfig()
+	if err != nil {
+		return nil, err
+	}
+	timeout := state.DefaultBlockedSessionInactivityTimeout
+	if parsed, err := time.ParseDuration(config.BlockedSessionInactivityTimeout); err == nil && parsed > 0 {
+		timeout = parsed
+	}
+
+	for i := range sessions {
+		session := &sessions[i]
+		if session.Status != state.SessionStatusBlocked {
+			continue
+		}
+
+		inactive, err := a.blockedSessionExceededInactivityTimeout(ctx, *session, timeout)
+		if err != nil {
+			session.LastError = err.Error()
+			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			a.state.AppendDaemonLog("blocked session inactivity evaluation failed repo=%s issue=%d branch=%s err=%v", session.Repo, session.IssueNumber, session.Branch, err)
+			continue
+		}
+		if !inactive {
+			continue
+		}
+
+		a.state.AppendDaemonLog("blocked session inactivity timeout reached repo=%s issue=%d branch=%s timeout=%s", session.Repo, session.IssueNumber, session.Branch, timeout)
+		cleanupErr := a.cleanupBlockedSessionForInactivity(ctx, session, timeout)
+		body := inactiveBlockedCleanupComment(*session, timeout, cleanupErr)
+		if err := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); err != nil {
+			session.LastError = err.Error()
+			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			a.state.AppendDaemonLog("blocked session inactivity comment failed repo=%s issue=%d branch=%s err=%v", session.Repo, session.IssueNumber, session.Branch, err)
+		}
+	}
+
+	return sessions, nil
+}
+
+func (a *App) blockedSessionExceededInactivityTimeout(ctx context.Context, session state.Session, timeout time.Duration) (bool, error) {
+	comments, err := ghcli.ListIssueCommentsForPolling(ctx, a.env.Runner, session.Repo, session.IssueNumber, "blocked-inactivity", a.state.AppendDaemonLog)
+	if err != nil {
+		return false, err
+	}
+
+	latestWorktreeActivity, err := latestWorktreeActivity(session.WorktreePath)
+	if err != nil {
+		return false, err
+	}
+
+	threshold := a.clock().Add(-timeout)
+	for _, activity := range []time.Time{
+		ghcli.LatestUserCommentTime(comments),
+		sessionActivityTime(session),
+		latestWorktreeActivity,
+	} {
+		if !activity.IsZero() && activity.After(threshold) {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (a *App) cleanupBlockedSessionForInactivity(ctx context.Context, session *state.Session, timeout time.Duration) error {
+	now := a.clock().Format(time.RFC3339)
+	session.LastCleanupSource = "blocked_inactivity_timeout"
+	if err := worktree.CleanupIssueArtifacts(ctx, a.env.Runner, session.RepoPath, session.WorktreePath, session.Branch); err != nil {
+		session.CleanupError = err.Error()
+		session.LastError = fmt.Sprintf("blocked session exceeded inactivity timeout (%s) but cleanup failed: %s", timeout, err)
+		session.UpdatedAt = now
+		a.state.AppendDaemonLog("blocked session inactivity cleanup failed repo=%s issue=%d branch=%s timeout=%s err=%v", session.Repo, session.IssueNumber, session.Branch, timeout, err)
+		return err
+	}
+
+	session.Status = state.SessionStatusFailed
+	session.ProcessID = 0
+	session.BlockedAt = ""
+	session.BlockedStage = ""
+	session.BlockedReason = state.BlockedReason{}
+	session.RetryPolicy = ""
+	session.ResumeRequired = false
+	session.ResumeHint = ""
+	session.LastHeartbeatAt = ""
+	session.CleanupCompletedAt = now
+	session.CleanupError = ""
+	session.EndedAt = now
+	session.UpdatedAt = now
+	session.LastError = fmt.Sprintf("blocked session cleaned up after %s of inactivity", timeout)
+	a.state.AppendDaemonLog("blocked session inactivity cleanup complete repo=%s issue=%d branch=%s timeout=%s", session.Repo, session.IssueNumber, session.Branch, timeout)
+	return nil
+}
+
 func stalledSessionThreshold() time.Duration {
 	raw := strings.TrimSpace(os.Getenv("VIGILANTE_STALLED_SESSION_THRESHOLD"))
 	if raw == "" {
@@ -1432,6 +1529,37 @@ func sessionActivityTime(session state.Session) time.Time {
 		}
 	}
 	return time.Time{}
+}
+
+func latestWorktreeActivity(path string) (time.Time, error) {
+	if strings.TrimSpace(path) == "" {
+		return time.Time{}, nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return time.Time{}, nil
+		}
+		return time.Time{}, err
+	}
+
+	latest := info.ModTime().UTC()
+	err = filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		if info.ModTime().After(latest) {
+			latest = info.ModTime().UTC()
+		}
+		return nil
+	})
+	if err != nil {
+		return time.Time{}, err
+	}
+	return latest, nil
 }
 
 func sessionProcessAlive(pid int) bool {
@@ -1598,6 +1726,35 @@ func cleanupResultComment(session state.Session, cleanupErr error) string {
 			fmt.Sprintf("Local artifact cleanup still needs attention: `%s`.", summarizeMaintenanceError(errors.New(fallbackText(session.CleanupError, "unknown cleanup error")))),
 		},
 		Tagline: "Progress over paralysis.",
+	})
+}
+
+func inactiveBlockedCleanupComment(session state.Session, timeout time.Duration, cleanupErr error) string {
+	if cleanupErr == nil && session.CleanupError == "" {
+		return ghcli.FormatProgressComment(ghcli.ProgressComment{
+			Stage:      "Inactive Blocked Session Cleaned Up",
+			Emoji:      "🧹",
+			Percent:    100,
+			ETAMinutes: 1,
+			Items: []string{
+				fmt.Sprintf("No qualifying user comments, session updates, or worktree changes were detected for `%s` longer than `%s`.", session.Branch, timeout),
+				"Vigilante cleaned up the local blocked-session artifacts conservatively.",
+				"Next step: the issue is ready for a future redispatch in a fresh worktree.",
+			},
+			Tagline: "What is left idle grows loud.",
+		})
+	}
+	return ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Blocked",
+		Emoji:      "🛠️",
+		Percent:    85,
+		ETAMinutes: 10,
+		Items: []string{
+			fmt.Sprintf("The blocked session on `%s` exceeded the inactivity timeout of `%s`.", session.Branch, timeout),
+			fmt.Sprintf("Automatic local cleanup failed: `%s`.", summarizeMaintenanceError(errors.New(fallbackText(session.CleanupError, "unknown cleanup error")))),
+			"Next step: fix the local cleanup problem before redispatching the issue.",
+		},
+		Tagline: "A knot is patient until you pull it.",
 	})
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1454,6 +1454,368 @@ func TestScanOnceReportsNoMatchingRunningSessionForGitHubCleanupRequest(t *testi
 	}
 }
 
+func TestBlockedSessionExceededInactivityTimeoutTreatsUserCommentAsActivity(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 3, 12, 18, 0, 0, 0, time.UTC)
+	old := now.Add(-1 * time.Hour)
+	if err := os.Chtimes(worktreePath, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.clock = func() time.Time { return now }
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1/comments": `[{"id":101,"body":"Still blocked on my side.","created_at":"2026-03-12T17:50:00Z","user":{"login":"nicobistolfi"}}]`,
+		},
+	}
+
+	inactive, err := app.blockedSessionExceededInactivityTimeout(context.Background(), state.Session{
+		Repo:         "owner/repo",
+		IssueNumber:  1,
+		Branch:       "vigilante/issue-1",
+		WorktreePath: worktreePath,
+		Status:       state.SessionStatusBlocked,
+		UpdatedAt:    old.Format(time.RFC3339),
+	}, 20*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inactive {
+		t.Fatal("expected recent user comment to prevent inactivity cleanup")
+	}
+}
+
+func TestBlockedSessionExceededInactivityTimeoutTreatsRecentSessionUpdateAsActivity(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 3, 12, 18, 0, 0, 0, time.UTC)
+	old := now.Add(-1 * time.Hour)
+	if err := os.Chtimes(worktreePath, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.clock = func() time.Time { return now }
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1/comments": "[]",
+		},
+	}
+
+	inactive, err := app.blockedSessionExceededInactivityTimeout(context.Background(), state.Session{
+		Repo:         "owner/repo",
+		IssueNumber:  1,
+		Branch:       "vigilante/issue-1",
+		WorktreePath: worktreePath,
+		Status:       state.SessionStatusBlocked,
+		UpdatedAt:    now.Add(-10 * time.Minute).Format(time.RFC3339),
+	}, 20*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inactive {
+		t.Fatal("expected recent session update to prevent inactivity cleanup")
+	}
+}
+
+func TestBlockedSessionExceededInactivityTimeoutTreatsRecentWorktreeChangeAsActivity(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 3, 12, 18, 0, 0, 0, time.UTC)
+	old := now.Add(-1 * time.Hour)
+	recent := now.Add(-5 * time.Minute)
+	if err := os.Chtimes(worktreePath, old, old); err != nil {
+		t.Fatal(err)
+	}
+	worktreeFile := filepath.Join(worktreePath, "note.txt")
+	if err := os.WriteFile(worktreeFile, []byte("recent"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(worktreeFile, recent, recent); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.clock = func() time.Time { return now }
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1/comments": "[]",
+		},
+	}
+
+	inactive, err := app.blockedSessionExceededInactivityTimeout(context.Background(), state.Session{
+		Repo:         "owner/repo",
+		IssueNumber:  1,
+		Branch:       "vigilante/issue-1",
+		WorktreePath: worktreePath,
+		Status:       state.SessionStatusBlocked,
+		UpdatedAt:    old.Format(time.RFC3339),
+	}, 20*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inactive {
+		t.Fatal("expected recent worktree change to prevent inactivity cleanup")
+	}
+}
+
+func TestScanOnceCleansUpBlockedSessionAfterDefaultInactivityTimeout(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 3, 12, 18, 0, 0, 0, time.UTC)
+	old := now.Add(-45 * time.Minute)
+	if err := os.Chtimes(worktreePath, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.clock = func() time.Time { return now }
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1/comments":                  "[]",
+			"gh api repos/owner/repo/issues/1":                           "{}",
+			"git worktree prune":                                         "ok",
+			"git worktree remove --force " + worktreePath:                "ok",
+			"git worktree list --porcelain":                              "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": "ok",
+			"git branch -D vigilante/issue-1":                            "Deleted branch vigilante/issue-1\n",
+			"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Inactive Blocked Session Cleaned Up",
+				Emoji:      "🧹",
+				Percent:    100,
+				ETAMinutes: 1,
+				Items: []string{
+					"No qualifying user comments, session updates, or worktree changes were detected for `vigilante/issue-1` longer than `20m0s`.",
+					"Vigilante cleaned up the local blocked-session artifacts conservatively.",
+					"Next step: the issue is ready for a future redispatch in a fresh worktree.",
+				},
+				Tagline: "What is left idle grows loud.",
+			}): "ok",
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: repoPath, Repo: "owner/repo", Branch: "main", Assignee: "me"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:     repoPath,
+		Repo:         "owner/repo",
+		IssueNumber:  1,
+		IssueTitle:   "first",
+		IssueURL:     "https://github.com/owner/repo/issues/1",
+		Branch:       "vigilante/issue-1",
+		WorktreePath: worktreePath,
+		Status:       state.SessionStatusBlocked,
+		BlockedAt:    old.Format(time.RFC3339),
+		BlockedStage: "issue_execution",
+		BlockedReason: state.BlockedReason{
+			Kind:      "provider_auth",
+			Operation: "codex exec",
+			Summary:   "session expired",
+			Detail:    "session expired",
+		},
+		UpdatedAt: old.Format(time.RFC3339),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if sessions[0].Status != state.SessionStatusFailed || sessions[0].CleanupCompletedAt == "" || sessions[0].LastCleanupSource != "blocked_inactivity_timeout" {
+		t.Fatalf("expected blocked session cleanup to complete: %#v", sessions[0])
+	}
+	if sessions[0].BlockedStage != "" || sessions[0].ResumeRequired {
+		t.Fatalf("expected blocked state to be cleared after inactivity cleanup: %#v", sessions[0])
+	}
+}
+
+func TestScanOnceUsesOverriddenBlockedSessionInactivityTimeout(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 3, 12, 18, 0, 0, 0, time.UTC)
+	old := now.Add(-30 * time.Minute)
+	if err := os.Chtimes(worktreePath, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.clock = func() time.Time { return now }
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1/comments": "[]",
+			"gh api repos/owner/repo/issues/1":          "{}",
+			"gh api user --jq .login":                   "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveServiceConfig(state.ServiceConfig{BlockedSessionInactivityTimeout: "45m"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: repoPath, Repo: "owner/repo", Branch: "main", Assignee: "me"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:     repoPath,
+		Repo:         "owner/repo",
+		IssueNumber:  1,
+		IssueTitle:   "first",
+		IssueURL:     "https://github.com/owner/repo/issues/1",
+		Branch:       "vigilante/issue-1",
+		WorktreePath: worktreePath,
+		Status:       state.SessionStatusBlocked,
+		BlockedAt:    old.Format(time.RFC3339),
+		BlockedStage: "issue_execution",
+		UpdatedAt:    old.Format(time.RFC3339),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions[0].Status != state.SessionStatusBlocked || sessions[0].CleanupCompletedAt != "" {
+		t.Fatalf("expected overridden timeout to keep session blocked: %#v", sessions[0])
+	}
+}
+
+func TestScanOnceLeavesBlockedSessionVisibleWhenInactivityCleanupFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 3, 12, 18, 0, 0, 0, time.UTC)
+	old := now.Add(-45 * time.Minute)
+	if err := os.Chtimes(worktreePath, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.clock = func() time.Time { return now }
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1/comments": "[]",
+			"gh api repos/owner/repo/issues/1":          "{}",
+			"git worktree prune":                        "ok",
+			"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Blocked",
+				Emoji:      "🛠️",
+				Percent:    85,
+				ETAMinutes: 10,
+				Items: []string{
+					"The blocked session on `vigilante/issue-1` exceeded the inactivity timeout of `20m0s`.",
+					"Automatic local cleanup failed: `exit status 1`.",
+					"Next step: fix the local cleanup problem before redispatching the issue.",
+				},
+				Tagline: "A knot is patient until you pull it.",
+			}): "ok",
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+		},
+		Errors: map[string]error{
+			"git worktree remove --force " + worktreePath: errors.New("exit status 1"),
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: repoPath, Repo: "owner/repo", Branch: "main", Assignee: "me"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:     repoPath,
+		Repo:         "owner/repo",
+		IssueNumber:  1,
+		IssueTitle:   "first",
+		IssueURL:     "https://github.com/owner/repo/issues/1",
+		Branch:       "vigilante/issue-1",
+		WorktreePath: worktreePath,
+		Status:       state.SessionStatusBlocked,
+		BlockedAt:    old.Format(time.RFC3339),
+		BlockedStage: "issue_execution",
+		UpdatedAt:    old.Format(time.RFC3339),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions[0].Status != state.SessionStatusBlocked || sessions[0].CleanupError == "" || sessions[0].LastCleanupSource != "blocked_inactivity_timeout" {
+		t.Fatalf("expected failed inactivity cleanup to leave a visible blocked state: %#v", sessions[0])
+	}
+}
+
 func TestScanOnceSelectsEligibleIssueAndPersistsSession(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -256,6 +256,26 @@ func FindCleanupComment(comments []IssueComment, claimedCommentID int64) *IssueC
 	return findCommandComment(comments, "@vigilanteai cleanup", claimedCommentID)
 }
 
+func LatestUserCommentTime(comments []IssueComment) time.Time {
+	for i := len(comments) - 1; i >= 0; i-- {
+		if IsUserComment(comments[i]) {
+			return comments[i].CreatedAt.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+func IsUserComment(comment IssueComment) bool {
+	body := strings.TrimSpace(comment.Body)
+	if body == "" {
+		return false
+	}
+	if strings.HasPrefix(body, "@vigilanteai ") {
+		return true
+	}
+	return !isAutomationComment(body)
+}
+
 func findCommandComment(comments []IssueComment, command string, claimedCommentID int64) *IssueComment {
 	for i := len(comments) - 1; i >= 0; i-- {
 		body := strings.TrimSpace(comments[i].Body)
@@ -323,4 +343,17 @@ func summarizeForLog(text string) string {
 		return text
 	}
 	return text[:limit] + "...(truncated)"
+}
+
+func isAutomationComment(body string) bool {
+	if !strings.HasPrefix(body, "## ") {
+		return false
+	}
+	if strings.Contains(body, "\nProgress: [") && strings.Contains(body, "\n`ETA: ~") {
+		return true
+	}
+	if strings.Contains(body, "\nWorking branch: `") || strings.Contains(body, "\nETA: ~") {
+		return true
+	}
+	return false
 }

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -220,3 +220,18 @@ func TestFindCleanupComment(t *testing.T) {
 		t.Fatalf("expected claimed cleanup comment to be ignored, got: %#v", comment)
 	}
 }
+
+func TestLatestUserCommentTimeIgnoresAutomationComments(t *testing.T) {
+	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	comments := []IssueComment{
+		{ID: 10, Body: FormatProgressComment(ProgressComment{Stage: "Blocked", Emoji: "🧱", Percent: 80, ETAMinutes: 5, Items: []string{"Agent update."}}), CreatedAt: now.Add(-3 * time.Minute)},
+		{ID: 11, Body: "Can you pick this back up tomorrow?", CreatedAt: now.Add(-2 * time.Minute)},
+		{ID: 12, Body: "## 🕹️ Coding Agent Launched: Codex\n\nWorking branch: `vigilante/issue-129`\n\nImplementation is in progress.", CreatedAt: now.Add(-1 * time.Minute)},
+	}
+
+	got := LatestUserCommentTime(comments)
+	want := now.Add(-2 * time.Minute)
+	if !got.Equal(want) {
+		t.Fatalf("expected latest user comment at %s, got %s", want, got)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -29,6 +29,11 @@ type WatchTarget struct {
 }
 
 const DefaultMaxParallelSessions = 3
+const DefaultBlockedSessionInactivityTimeout = 20 * time.Minute
+
+type ServiceConfig struct {
+	BlockedSessionInactivityTimeout string `json:"blocked_session_inactivity_timeout,omitempty"`
+}
 
 type SessionStatus string
 
@@ -145,6 +150,9 @@ func (s *Store) EnsureLayout() error {
 			return err
 		}
 	}
+	if err := ensureJSONFile(s.serviceConfigPath(), defaultServiceConfig()); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -166,6 +174,10 @@ func (s *Store) watchlistPath() string {
 
 func (s *Store) sessionsPath() string {
 	return filepath.Join(s.root, "sessions.json")
+}
+
+func (s *Store) serviceConfigPath() string {
+	return filepath.Join(s.root, "config.json")
 }
 
 func (s *Store) scanLockPath() string {
@@ -210,11 +222,43 @@ func (s *Store) SaveSessions(sessions []Session) error {
 	return writeJSONFile(s.sessionsPath(), sessions)
 }
 
+func (s *Store) LoadServiceConfig() (ServiceConfig, error) {
+	config := defaultServiceConfig()
+	if err := readJSONFile(s.serviceConfigPath(), &config); err != nil {
+		return ServiceConfig{}, err
+	}
+	config.BlockedSessionInactivityTimeout = normalizeBlockedSessionInactivityTimeout(config.BlockedSessionInactivityTimeout)
+	return config, nil
+}
+
+func (s *Store) SaveServiceConfig(config ServiceConfig) error {
+	config.BlockedSessionInactivityTimeout = normalizeBlockedSessionInactivityTimeout(config.BlockedSessionInactivityTimeout)
+	return writeJSONFile(s.serviceConfigPath(), config)
+}
+
 func normalizeMaxParallelSessions(value int) int {
 	if value < 1 {
 		return DefaultMaxParallelSessions
 	}
 	return value
+}
+
+func normalizeBlockedSessionInactivityTimeout(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return DefaultBlockedSessionInactivityTimeout.String()
+	}
+	parsed, err := time.ParseDuration(raw)
+	if err != nil || parsed <= 0 {
+		return DefaultBlockedSessionInactivityTimeout.String()
+	}
+	return parsed.String()
+}
+
+func defaultServiceConfig() ServiceConfig {
+	return ServiceConfig{
+		BlockedSessionInactivityTimeout: DefaultBlockedSessionInactivityTimeout.String(),
+	}
 }
 
 func discoverStateRoot() string {
@@ -235,6 +279,15 @@ func ensureJSONArrayFile(path string) error {
 		return err
 	}
 	return os.WriteFile(path, []byte("[]\n"), 0o644)
+}
+
+func ensureJSONFile(path string, value any) error {
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return writeJSONFile(path, value)
 }
 
 func readJSONFile(path string, dst any) error {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -70,3 +70,42 @@ func TestWatchTargetMaxParallelDefaultsToSharedValue(t *testing.T) {
 		t.Fatalf("expected explicit max_parallel_sessions to be preserved, got %d", got)
 	}
 }
+
+func TestEnsureLayoutCreatesDefaultServiceConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	store := NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := store.LoadServiceConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := config.BlockedSessionInactivityTimeout; got != DefaultBlockedSessionInactivityTimeout.String() {
+		t.Fatalf("expected default blocked-session timeout %q, got %q", DefaultBlockedSessionInactivityTimeout.String(), got)
+	}
+}
+
+func TestSaveServiceConfigNormalizesInvalidBlockedSessionTimeout(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	store := NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveServiceConfig(ServiceConfig{BlockedSessionInactivityTimeout: "not-a-duration"}); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := store.LoadServiceConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := config.BlockedSessionInactivityTimeout; got != DefaultBlockedSessionInactivityTimeout.String() {
+		t.Fatalf("expected invalid timeout to normalize to %q, got %q", DefaultBlockedSessionInactivityTimeout.String(), got)
+	}
+}


### PR DESCRIPTION
## Summary
- add a service-level `config.json` setting for blocked-session inactivity with a default of `20m`
- clean up blocked sessions automatically when user comments, session updates, and worktree updates have all been quiet longer than the configured timeout
- document the config and cover the inactivity logic with focused tests

Closes #129

## Validation
- `go test ./...`
