### PR TITLE
Add bundled skill for local service dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Expected behavior:
   - `vigilante-issue-implementation-on-monorepo`
   - `vigilante-conflict-resolution`
   - `vigilante-create-issue`
+  - `vigilante-local-service-dependencies`
 - installs or updates the daemon definition when requested
 
 ## Development Mode

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -19,6 +19,7 @@ const VigilanteIssueImplementation = "vigilante-issue-implementation"
 const VigilanteIssueImplementationOnMonorepo = "vigilante-issue-implementation-on-monorepo"
 const VigilanteConflictResolution = "vigilante-conflict-resolution"
 const VigilanteCreateIssue = "vigilante-create-issue"
+const VigilanteLocalServiceDependencies = "vigilante-local-service-dependencies"
 
 const RuntimeCodex = "codex"
 const RuntimeClaude = "claude"
@@ -30,6 +31,7 @@ func VigilanteSkillNames() []string {
 		VigilanteIssueImplementationOnMonorepo,
 		VigilanteConflictResolution,
 		VigilanteCreateIssue,
+		VigilanteLocalServiceDependencies,
 	}
 }
 

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -141,6 +141,19 @@ func TestBuildIssuePrompt(t *testing.T) {
 	}
 }
 
+func TestVigilanteSkillNamesIncludesLocalServiceDependencies(t *testing.T) {
+	found := false
+	for _, name := range VigilanteSkillNames() {
+		if name == VigilanteLocalServiceDependencies {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected %s to be bundled", VigilanteLocalServiceDependencies)
+	}
+}
+
 func TestBuildIssuePromptSelectsMonorepoSkill(t *testing.T) {
 	target := state.WatchTarget{
 		Path: "/tmp/repo",
@@ -339,6 +352,42 @@ func TestVigilanteCreateIssueSkillIncludesTypeSpecificDetailGuidance(t *testing.
 	} {
 		if !strings.Contains(text, snippet) {
 			t.Fatalf("skill missing %q", snippet)
+		}
+	}
+}
+
+func TestLocalServiceDependenciesSkillCoversStructuredOutputAndFailureModes(t *testing.T) {
+	body, err := os.ReadFile(repoSkillPath(VigilanteLocalServiceDependencies))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	text := string(body)
+	for _, snippet := range []string{
+		"Prefer repository-provided service startup mechanisms",
+		"repository-owned `docker compose` or `docker-compose` files before generating anything new",
+		"Docker Compose is an allowed fallback, not the defining abstraction.",
+		"`status`: `ready`, `not_needed`, or `failed`",
+		"`mechanism`: `repo_native`, `repo_compose`, `repo_script`, `repo_task_runner`, or `generated_fallback`",
+		"missing local tooling",
+		"unsupported repository setup",
+		"startup failure",
+		"readiness or connection failure",
+	} {
+		if !strings.Contains(text, snippet) {
+			t.Fatalf("skill missing %q", snippet)
+		}
+	}
+}
+
+func TestIssueImplementationSkillsReferenceLocalServiceDependencySkill(t *testing.T) {
+	for _, name := range []string{VigilanteIssueImplementation, VigilanteIssueImplementationOnMonorepo} {
+		body, err := os.ReadFile(repoSkillPath(name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(body), VigilanteLocalServiceDependencies) {
+			t.Fatalf("%s does not mention %s", name, VigilanteLocalServiceDependencies)
 		}
 	}
 }

--- a/skillassets.go
+++ b/skillassets.go
@@ -4,5 +4,5 @@ import "embed"
 
 // Skills contains built-in runtime skill files for installed binaries.
 //
-//go:embed skills/vigilante-issue-implementation skills/vigilante-issue-implementation-on-monorepo skills/vigilante-conflict-resolution skills/vigilante-create-issue
+//go:embed skills/vigilante-issue-implementation skills/vigilante-issue-implementation-on-monorepo skills/vigilante-conflict-resolution skills/vigilante-create-issue skills/vigilante-local-service-dependencies
 var Skills embed.FS

--- a/skills/vigilante-issue-implementation-on-monorepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-monorepo/SKILL.md
@@ -36,6 +36,7 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - Never edit the root checkout when a worktree was assigned.
 - Keep changes scoped to the issue.
 - Prefer native repository tooling and avoid unnecessary new dependencies.
+- If the affected workspace needs local services, call the bundled `vigilante-local-service-dependencies` skill and reuse its structured output before creating workspace-specific ad hoc service setup.
 
 5. Validate incrementally
 - Run the most relevant package/app/workspace checks first, then expand only if needed.

--- a/skills/vigilante-issue-implementation/SKILL.md
+++ b/skills/vigilante-issue-implementation/SKILL.md
@@ -43,6 +43,10 @@ Require these inputs from Vigilante:
 - Prefer native repository tooling and avoid unnecessary new dependencies.
 - Preserve existing coding patterns unless the issue requires a different approach.
 
+Service dependencies:
+- If app startup, migrations, or tests need local services, call the bundled `vigilante-local-service-dependencies` skill before inventing ad hoc setup steps.
+- Prefer the skill's repository-native path first, and use its structured output to decide which env vars, commands, or cleanup steps the rest of the implementation should use.
+
 5. Validate incrementally
 - Run relevant tests, builds, or linters for the changed area before concluding work.
 - Prefer targeted validation first, then broader validation when necessary.

--- a/skills/vigilante-local-service-dependencies/SKILL.md
+++ b/skills/vigilante-local-service-dependencies/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: vigilante-local-service-dependencies
+description: Prepare local service dependencies for an implementation worktree by preferring repository-native startup flows before falling back to compatible local mechanisms.
+---
+
+# Vigilante Local Service Dependencies
+
+## Overview
+Use this skill from an implementation workflow when the assigned repository needs local services before app startup, builds, migrations, or tests can run. Keep the core Vigilante scheduler ignorant of stack-specific orchestration details by doing service preparation here, inside the worktree, from repository context.
+
+## Inputs
+Require or infer these inputs before acting:
+
+- repository path
+- assigned worktree path
+- service intent or failing command context
+- repository docs or scripts that describe local setup
+- optional preferred service types such as `postgres`, `mysql`, `mariadb`, or `mongodb`
+
+## Goals
+- Prefer repository-provided service startup mechanisms when they are discoverable and usable.
+- Fall back to a local compatible mechanism only when the repository does not provide a workable path.
+- Return structured output that the parent implementation flow can use for later commands and cleanup.
+- Keep scope focused on local development dependencies, especially common database-backed environments.
+
+## Detection Order
+1. Search the repository for native service-management workflows first.
+- Check `README*`, `docs/`, `AGENTS.md`, `Taskfile*`, `Makefile*`, package scripts, and repo scripts for setup or startup commands.
+- Check for repository-owned `docker compose` or `docker-compose` files before generating anything new.
+- Prefer commands the repository already documents for development or test setup.
+
+2. Validate the native option before using it.
+- Confirm required tools exist, such as `docker`, `docker compose`, `make`, `task`, `npm`, `pnpm`, `yarn`, or project scripts.
+- If a documented path is incomplete or obviously stale, say so and continue to the next viable option.
+
+3. Fall back only when necessary.
+- If the repository has no usable local-service path, choose a compatible local mechanism with minimal new surface area.
+- Docker Compose is an allowed fallback, not the defining abstraction.
+- Namespace fallback artifacts, service names, ports, and temporary files to the worktree or issue session when possible.
+
+## Execution Rules
+- Work only inside the assigned worktree unless an existing repo-owned command clearly operates from the repository root.
+- Reuse repository environment files, scripts, and task runners when available.
+- Keep generated artifacts explicit and local to the session.
+- Surface the exact command used to start services.
+- Wait for readiness when practical; do not claim success immediately after spawning a process if the service is not yet accepting connections.
+
+## Structured Output Contract
+When you finish, return a concise structured summary that the parent workflow can reuse. Use this shape in plain text or JSON-like form:
+
+- `status`: `ready`, `not_needed`, or `failed`
+- `services`: started or detected services
+- `mechanism`: `repo_native`, `repo_compose`, `repo_script`, `repo_task_runner`, or `generated_fallback`
+- `commands`: startup and readiness commands that were used
+- `connection`: host, port, database, username, URL, or env hints when available
+- `cleanup`: expected stop or teardown command, or `none`
+- `artifacts`: files created or reused for this session
+- `notes`: concise caveats for the parent workflow
+
+## Failure Reporting
+When service preparation fails, explain which category applies:
+
+- missing local tooling
+- unsupported repository setup
+- startup failure
+- readiness or connection failure
+
+Include the failing command, the missing prerequisite or observed error, and the next most reasonable remediation step.
+
+## Practical Defaults
+- Prioritize common local databases first: Postgres, MySQL, MariaDB, and MongoDB.
+- If the repository already provides an application stack startup flow, use that instead of re-creating only the database layer unless the issue clearly needs the narrower setup.
+- If services are already running and usable, report `status: ready` with `mechanism: repo_native` or the closest truthful mechanism instead of restarting them.
+
+## Guardrails
+- Do not hard-code a single Docker Compose lifecycle into Vigilante core behavior.
+- Do not assume every repository uses containers.
+- Do not silently generate infrastructure when the repository already documents a supported path.
+- Do not hide cleanup expectations.

--- a/skills/vigilante-local-service-dependencies/agents/openai.yaml
+++ b/skills/vigilante-local-service-dependencies/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Vigilante Local Service Dependencies"
+  short_description: "Prepare local repo dependencies by preferring native startup workflows before falling back"
+  default_prompt: "Use $vigilante-local-service-dependencies to prepare local service dependencies for the assigned implementation worktree, prefer repository-native setup, and return structured service status and cleanup details."


### PR DESCRIPTION
## Summary
- add a bundled `vigilante-local-service-dependencies` skill for repo-native-first local service setup
- include the skill in embedded/installable bundled skills and document it in setup docs
- teach issue-implementation skills to call the new skill and cover the contract with tests

## Validation
- `go test ./internal/skill/...`
- `go test ./...`

Closes #102