### PR TITLE
Harden macOS setup -d against launchd code-signing failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ task setup-daemon
 
 On macOS, `task setup-daemon` now performs one explicit recovery attempt when an existing `com.vigilante.agent` launch agent is already present. If the first refresh fails, the task cleans up the existing launch agent, retries once, and prints a short manual `launchctl bootout ...` hint if recovery still fails.
 
+On macOS, `vigilante setup -d` also prepares the installed daemon binary before reloading the LaunchAgent by clearing an observed `com.apple.provenance` xattr, applying ad-hoc signing, and validating the binary with `spctl`. If macOS still rejects the binary, setup exits with a code-signing error instead of leaving the agent stuck in `OS_REASON_CODESIGNING`.
+
 Notes:
 
 - foreground runs are the quickest way to iterate on scheduler, worktree, and coding-agent execution behavior

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -193,6 +193,10 @@ func TestWatchUpdatesExistingTarget(t *testing.T) {
 	app.stdout = &stdout
 	app.stderr = testutil.IODiscard{}
 	app.env.OS = "darwin"
+	executablePath, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
 	launchAgentPath := filepath.Join(home, "Library", "LaunchAgents", "com.vigilante.agent.plist")
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
@@ -200,15 +204,18 @@ func TestWatchUpdatesExistingTarget(t *testing.T) {
 			"codex --version":                   "codex 0.114.0",
 			"gh auth status":                    "ok",
 			`/bin/zsh -lic printf "%s" "$PATH"`: "/usr/bin:/bin:/Users/test/.local/bin",
-			`/bin/sh -lc PATH="/usr/bin:/bin:/Users/test/.local/bin" command -v 'git'`:   "/usr/bin/git\n",
-			`/bin/sh -lc PATH="/usr/bin:/bin:/Users/test/.local/bin" command -v 'gh'`:    "/usr/bin/gh\n",
-			`/bin/sh -lc PATH="/usr/bin:/bin:/Users/test/.local/bin" command -v 'codex'`: "/Users/test/.local/bin/codex\n",
-			`/bin/sh -lc PATH="/usr/bin:/bin:/Users/test/.local/bin" 'codex' --version`:  "codex 0.114.0\n",
-			testutil.Key("launchctl", "unload", launchAgentPath):                         "",
-			testutil.Key("launchctl", "load", launchAgentPath):                           "",
-			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                    "true\n",
-			testutil.Key("git", "remote", "get-url", "origin"):                           "git@github.com:nicobistolfi/vigilante.git\n",
-			testutil.Key("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"):   "origin/main\n",
+			`/bin/sh -lc PATH="/usr/bin:/bin:/Users/test/.local/bin" command -v 'git'`:    "/usr/bin/git\n",
+			`/bin/sh -lc PATH="/usr/bin:/bin:/Users/test/.local/bin" command -v 'gh'`:     "/usr/bin/gh\n",
+			`/bin/sh -lc PATH="/usr/bin:/bin:/Users/test/.local/bin" command -v 'codex'`:  "/Users/test/.local/bin/codex\n",
+			`/bin/sh -lc PATH="/usr/bin:/bin:/Users/test/.local/bin" 'codex' --version`:   "codex 0.114.0\n",
+			testutil.Key("xattr", "-d", "com.apple.provenance", executablePath):           "",
+			testutil.Key("codesign", "--force", "--sign", "-", executablePath):            "",
+			testutil.Key("spctl", "--assess", "--type", "execute", "-vv", executablePath): "accepted\n",
+			testutil.Key("launchctl", "unload", launchAgentPath):                          "",
+			testutil.Key("launchctl", "load", launchAgentPath):                            "",
+			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                     "true\n",
+			testutil.Key("git", "remote", "get-url", "origin"):                            "git@github.com:nicobistolfi/vigilante.git\n",
+			testutil.Key("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"):    "origin/main\n",
 		},
 	}
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -45,10 +45,27 @@ func installLaunchdService(ctx context.Context, env *environment.Environment, st
 	if err := os.WriteFile(path, []byte(RenderLaunchdPlist(store, cfg)), 0o644); err != nil {
 		return err
 	}
+	if err := prepareLaunchdBinary(ctx, env, cfg.Executable); err != nil {
+		return err
+	}
 	_, _ = env.Runner.Run(ctx, "", "launchctl", "unload", path)
 	if _, err := env.Runner.Run(ctx, "", "launchctl", "load", path); err != nil {
 		return err
 	}
+	return nil
+}
+
+func prepareLaunchdBinary(ctx context.Context, env *environment.Environment, executable string) error {
+	_, _ = env.Runner.Run(ctx, "", "xattr", "-d", "com.apple.provenance", executable)
+
+	if output, err := env.Runner.Run(ctx, "", "codesign", "--force", "--sign", "-", executable); err != nil {
+		return fmt.Errorf("prepare macOS daemon binary %q for launchd: %s", executable, commandFailure("codesign", output, err))
+	}
+
+	if output, err := env.Runner.Run(ctx, "", "spctl", "--assess", "--type", "execute", "-vv", executable); err != nil {
+		return fmt.Errorf("macOS rejected daemon binary %q: %s", executable, commandFailure("spctl", output, err))
+	}
+
 	return nil
 }
 
@@ -224,4 +241,12 @@ func runtimeTool(selectedProvider provider.Provider) string {
 
 func shellQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
+}
+
+func commandFailure(command string, output string, err error) string {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return fmt.Sprintf("%s failed: %v", command, err)
+	}
+	return fmt.Sprintf("%s failed: %v (%s)", command, err, output)
 }

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -195,6 +196,67 @@ func TestBuildConfigFailsWhenProviderVersionIsIncompatible(t *testing.T) {
 	}
 	_, err = BuildConfig(context.Background(), env, selectedProvider)
 	if err == nil || !strings.Contains(err.Error(), "codex CLI version 2.0.0 is incompatible") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestInstallLaunchdServicePreparesBinaryBeforeReload(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	store := state.NewStore()
+	cfg := Config{
+		Executable: filepath.Join(home, ".local", "bin", "vigilante"),
+		PathEnv:    "/opt/homebrew/bin:/usr/bin:/bin",
+		HomeDir:    home,
+	}
+	launchAgentPath := filepath.Join(home, "Library", "LaunchAgents", "com.vigilante.agent.plist")
+	env := &environment.Environment{
+		OS: "darwin",
+		Runner: testutil.FakeRunner{
+			Outputs: map[string]string{
+				testutil.Key("xattr", "-d", "com.apple.provenance", cfg.Executable):           "",
+				testutil.Key("codesign", "--force", "--sign", "-", cfg.Executable):            "",
+				testutil.Key("spctl", "--assess", "--type", "execute", "-vv", cfg.Executable): "accepted\n",
+				testutil.Key("launchctl", "unload", launchAgentPath):                          "",
+				testutil.Key("launchctl", "load", launchAgentPath):                            "",
+			},
+		},
+	}
+
+	if err := installLaunchdService(context.Background(), env, store, cfg); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestInstallLaunchdServiceFailsWhenBinaryStillRejected(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	store := state.NewStore()
+	cfg := Config{
+		Executable: filepath.Join(home, ".local", "bin", "vigilante"),
+		PathEnv:    "/opt/homebrew/bin:/usr/bin:/bin",
+		HomeDir:    home,
+	}
+	env := &environment.Environment{
+		OS: "darwin",
+		Runner: testutil.FakeRunner{
+			Outputs: map[string]string{
+				testutil.Key("xattr", "-d", "com.apple.provenance", cfg.Executable): "",
+				testutil.Key("codesign", "--force", "--sign", "-", cfg.Executable):  "",
+			},
+			Errors: map[string]error{
+				testutil.Key("spctl", "--assess", "--type", "execute", "-vv", cfg.Executable): errors.New("exit status 3"),
+			},
+		},
+	}
+
+	err := installLaunchdService(context.Background(), env, store, cfg)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "macOS rejected daemon binary") || !strings.Contains(err.Error(), "spctl failed") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- prepare the installed macOS daemon binary before LaunchAgent reload by removing `com.apple.provenance` when present, ad-hoc signing it, and validating it with `spctl`
- stop `setup -d` before `launchctl load` when macOS still rejects the binary, surfacing summarized assessment output
- add service-level coverage for recovery and failure paths and update the existing app-level macOS setup test

Closes #134

## Validation
- `go test ./...`
- `go build ./...`
- `go vet ./...`
