### PR TITLE
Make default max-parallel unlimited

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Expected behavior:
 - validates the folder is a git repository
 - discovers the GitHub remote from git config
 - defaults the assignee filter to `me` unless overridden
-- defaults `--max-parallel` to `3` when not configured
+- defaults `--max-parallel` to `0` when not configured, where `0` means unlimited
 - defaults `--provider` to `codex` unless overridden
 - resolves `me` to the authenticated GitHub login at runtime before issue queries
 - stores the target in `~/.vigilante/watchlist.json`
@@ -101,6 +101,10 @@ vigilante watch --assignee nicobistolfi ~/hello-world-app
 
 ```sh
 vigilante watch --max-parallel 3 ~/hello-world-app
+```
+
+```sh
+vigilante watch --max-parallel 0 ~/hello-world-app
 ```
 
 ```sh
@@ -339,7 +343,7 @@ Suggested `watchlist.json` shape:
     "repo": "owner/hello-world-app",
     "branch": "main",
     "assignee": "me",
-    "max_parallel_sessions": 3,
+    "max_parallel_sessions": 0,
     "daemon_enabled": true,
     "last_scan_at": "2026-03-10T12:00:00Z"
   }
@@ -354,7 +358,8 @@ Initial rules:
 
 - only consider open issues
 - ignore pull requests
-- enforce `max_parallel_sessions` independently for each watched repository
+- enforce positive `max_parallel_sessions` independently for each watched repository
+- treat `max_parallel_sessions: 0` as unlimited parallel issue dispatch for that repository
 - count both running implementation sessions and open-PR maintenance sessions against that repository limit
 - avoid duplicate work across multiple daemon scans
 - allow an issue label that exactly matches a registered provider id, such as `codex`, `claude`, or `gemini`, to override the watch target provider for that issue only

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -31,6 +31,7 @@ import (
 const defaultScanInterval = 1 * time.Minute
 const defaultAssigneeFilter = "me"
 const defaultStalledSessionThreshold = 10 * time.Minute
+const unsetMaxParallel = -2147483648
 
 type App struct {
 	stdout io.Writer
@@ -111,7 +112,7 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 		var labels stringListFlag
 		fs.Var(&labels, "label", "allow only issues with this label; repeatable")
 		assignee := fs.String("assignee", "", "issue assignee filter (defaults to me)")
-		maxParallel := fs.Int("max-parallel", 0, "maximum concurrent issue sessions for this repository")
+		maxParallel := fs.Int("max-parallel", 0, "maximum concurrent issue sessions for this repository (0 = unlimited)")
 		selectedProvider := fs.String("provider", "", "coding agent provider")
 		if err := fs.Parse(args[1:]); err != nil {
 			return err
@@ -119,7 +120,13 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 		if fs.NArg() != 1 {
 			return errors.New("usage: vigilante watch [-d] [--label value] [--assignee value] [--max-parallel value] [--provider value] <path>")
 		}
-		return a.WatchWithProvider(ctx, fs.Arg(0), *daemon, labels, *assignee, *maxParallel, *selectedProvider)
+		parsedMaxParallel := unsetMaxParallel
+		fs.Visit(func(f *flag.Flag) {
+			if f.Name == "max-parallel" {
+				parsedMaxParallel = *maxParallel
+			}
+		})
+		return a.WatchWithProvider(ctx, fs.Arg(0), *daemon, labels, *assignee, parsedMaxParallel, *selectedProvider)
 	case "unwatch":
 		if len(args) != 2 {
 			return errors.New("usage: vigilante unwatch <path>")
@@ -251,8 +258,8 @@ func (a *App) WatchWithProvider(ctx context.Context, rawPath string, daemon bool
 	if err := a.state.EnsureLayout(); err != nil {
 		return err
 	}
-	if maxParallel < 0 {
-		return errors.New("max parallel must be at least 1")
+	if maxParallel < 0 && maxParallel != unsetMaxParallel {
+		return errors.New("max parallel must be at least 0")
 	}
 	if strings.TrimSpace(providerID) != "" {
 		resolvedProvider, err := provider.Resolve(providerID)
@@ -297,7 +304,7 @@ func (a *App) WatchWithProvider(ctx context.Context, rawPath string, daemon bool
 			} else if targets[i].Assignee == "" {
 				targets[i].Assignee = defaultAssigneeFilter
 			}
-			if maxParallel > 0 {
+			if maxParallel >= 0 {
 				targets[i].MaxParallel = maxParallel
 			}
 			targets[i].DaemonEnabled = daemon
@@ -503,9 +510,12 @@ func (a *App) ScanOnce(ctx context.Context) error {
 			a.state.AppendDaemonLog("scan repo issues repo=%s open_issues=%d", target.Repo, len(issues))
 
 			activeCount := ghcli.ActiveSessionCount(sessions, *target)
-			availableSlots := target.MaxParallel - activeCount
-			if availableSlots < 0 {
-				availableSlots = 0
+			availableSlots := len(issues)
+			if target.MaxParallel > 0 {
+				availableSlots = target.MaxParallel - activeCount
+				if availableSlots < 0 {
+					availableSlots = 0
+				}
 			}
 			nextIssues := ghcli.SelectIssues(issues, sessions, *target, availableSlots)
 			if len(nextIssues) == 0 {
@@ -2052,7 +2062,13 @@ func assigneeOrDefault(value string) string {
 }
 
 func configuredMaxParallel(value int) int {
-	if value <= 0 {
+	if value == unsetMaxParallel {
+		return state.DefaultMaxParallelSessions
+	}
+	if value < 0 {
+		return 1
+	}
+	if value == 0 {
 		return state.DefaultMaxParallelSessions
 	}
 	return value

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -169,7 +169,7 @@ func TestWatchListAndUnwatch(t *testing.T) {
 	if !strings.Contains(stdout.String(), "\"assignee\": \"me\"") {
 		t.Fatalf("expected default assignee in list output: %s", stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "\"max_parallel_sessions\": 3") {
+	if !strings.Contains(stdout.String(), "\"max_parallel_sessions\": 0") {
 		t.Fatalf("expected default max_parallel_sessions in list output: %s", stdout.String())
 	}
 
@@ -240,8 +240,55 @@ func TestWatchUpdatesExistingTarget(t *testing.T) {
 	if targets[0].Assignee != "nicobistolfi" {
 		t.Fatalf("expected assignee to be preserved: %#v", targets[0])
 	}
-	if targets[0].MaxParallel != 3 {
-		t.Fatalf("expected max_parallel_sessions to be preserved: %#v", targets[0])
+	if targets[0].MaxParallel != 0 {
+		t.Fatalf("expected explicit zero max_parallel_sessions to update target to unlimited: %#v", targets[0])
+	}
+}
+
+func TestWatchCommandWithoutMaxParallelPreservesExistingTargetValue(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                  "true\n",
+			testutil.Key("git", "remote", "get-url", "origin"):                         "git@github.com:nicobistolfi/vigilante.git\n",
+			testutil.Key("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"): "origin/main\n",
+		},
+	}
+
+	if err := app.Watch(context.Background(), repoPath, false, nil, "", 3); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.runCommand(context.Background(), []string{"watch", repoPath}); err != nil {
+		t.Fatal(err)
+	}
+
+	targets, err := app.state.LoadWatchTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 || targets[0].MaxParallel != 3 {
+		t.Fatalf("expected omitted max_parallel flag to preserve existing value: %#v", targets)
+	}
+}
+
+func TestWatchRejectsNegativeMaxParallel(t *testing.T) {
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+
+	err := app.runCommand(context.Background(), []string{"watch", "--max-parallel", "-1", "/tmp/repo"})
+	if err == nil || err.Error() != "max parallel must be at least 0" {
+		t.Fatalf("expected negative max_parallel rejection, got %v", err)
 	}
 }
 
@@ -2150,6 +2197,70 @@ func TestScanOnceWithMaxParallelOnePreservesSerialBehavior(t *testing.T) {
 	}
 	if len(sessions) != 1 || sessions[0].IssueNumber != 1 || sessions[0].Status != state.SessionStatusSuccess {
 		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+}
+
+func TestScanOnceWithUnlimitedMaxParallelStartsAllEligibleIssues(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	worktreePath1 := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	worktreePath2 := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-2")
+	worktreePath3 := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-3")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+
+	var stdout bytes.Buffer
+	app := New()
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]},{"number":2,"title":"second","createdAt":"2026-03-10T12:00:00Z","url":"https://github.com/owner/repo/issues/2","labels":[]},{"number":3,"title":"third","createdAt":"2026-03-11T12:00:00Z","url":"https://github.com/owner/repo/issues/3","labels":[]}]`,
+			"git worktree prune": "ok",
+			"git worktree add -b vigilante/issue-1-first " + worktreePath1 + " main":                                                                         "ok",
+			"git worktree add -b vigilante/issue-2-second " + worktreePath2 + " main":                                                                        "ok",
+			"git worktree add -b vigilante/issue-3-third " + worktreePath3 + " main":                                                                         "ok",
+			sessionStartCommentCommand("owner/repo", 1, worktreePath1, "vigilante/issue-1-first"):                                                            "ok",
+			sessionStartCommentCommand("owner/repo", 2, worktreePath2, "vigilante/issue-2-second"):                                                           "ok",
+			sessionStartCommentCommand("owner/repo", 3, worktreePath3, "vigilante/issue-3-third"):                                                            "ok",
+			preflightPromptCommand(worktreePath1, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1-first"):   "baseline ok",
+			preflightPromptCommand(worktreePath2, "owner/repo", repoPath, 2, "second", "https://github.com/owner/repo/issues/2", "vigilante/issue-2-second"): "baseline ok",
+			preflightPromptCommand(worktreePath3, "owner/repo", repoPath, 3, "third", "https://github.com/owner/repo/issues/3", "vigilante/issue-3-third"):   "baseline ok",
+			issuePromptCommand(worktreePath1, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1-first"):       "done",
+			issuePromptCommand(worktreePath2, "owner/repo", repoPath, 2, "second", "https://github.com/owner/repo/issues/2", "vigilante/issue-2-second"):     "done",
+			issuePromptCommand(worktreePath3, "owner/repo", repoPath, 3, "third", "https://github.com/owner/repo/issues/3", "vigilante/issue-3-third"):       "done",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: repoPath, Repo: "owner/repo", Branch: "main", Assignee: "me", MaxParallel: 0}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	app.waitForSessions()
+
+	got := stdout.String()
+	if !strings.Contains(got, "repo: owner/repo started issue #1 in "+worktreePath1) || !strings.Contains(got, "repo: owner/repo started issue #2 in "+worktreePath2) || !strings.Contains(got, "repo: owner/repo started issue #3 in "+worktreePath3) {
+		t.Fatalf("unexpected output: %s", got)
+	}
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 3 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	for _, session := range sessions {
+		if session.Status != state.SessionStatusSuccess {
+			t.Fatalf("expected successful sessions: %#v", sessions)
+		}
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -28,7 +28,7 @@ type WatchTarget struct {
 	AddedAt        string              `json:"added_at,omitempty"`
 }
 
-const DefaultMaxParallelSessions = 3
+const DefaultMaxParallelSessions = 0
 const DefaultBlockedSessionInactivityTimeout = 20 * time.Minute
 
 type ServiceConfig struct {
@@ -237,7 +237,10 @@ func (s *Store) SaveServiceConfig(config ServiceConfig) error {
 }
 
 func normalizeMaxParallelSessions(value int) int {
-	if value < 1 {
+	if value < 0 {
+		return 1
+	}
+	if value == 0 {
 		return DefaultMaxParallelSessions
 	}
 	return value

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -61,10 +61,10 @@ func TestAppendLogFileUsesLocalTimezone(t *testing.T) {
 
 func TestWatchTargetMaxParallelDefaultsToSharedValue(t *testing.T) {
 	if got := normalizeMaxParallelSessions(0); got != DefaultMaxParallelSessions {
-		t.Fatalf("expected zero max_parallel_sessions to normalize to default %d, got %d", DefaultMaxParallelSessions, got)
+		t.Fatalf("expected zero max_parallel_sessions to normalize to shared default %d, got %d", DefaultMaxParallelSessions, got)
 	}
-	if got := normalizeMaxParallelSessions(-1); got != DefaultMaxParallelSessions {
-		t.Fatalf("expected negative max_parallel_sessions to normalize to default %d, got %d", DefaultMaxParallelSessions, got)
+	if got := normalizeMaxParallelSessions(-1); got != 1 {
+		t.Fatalf("expected negative max_parallel_sessions to normalize conservatively to 1, got %d", got)
 	}
 	if got := normalizeMaxParallelSessions(1); got != 1 {
 		t.Fatalf("expected explicit max_parallel_sessions to be preserved, got %d", got)


### PR DESCRIPTION
## Summary
- change the shared `max_parallel_sessions` default to `0` and preserve `0` as unlimited
- distinguish omitted `--max-parallel` from explicit `--max-parallel 0` so existing watch targets can be preserved or reset intentionally
- handle unlimited dispatch in scan selection and update docs/tests for `0 = unlimited`

Closes #136

## Testing
- go test ./...
