### PR TITLE
Report local issue actions on GitHub

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1122,6 +1122,7 @@ func (a *App) CleanupSession(ctx context.Context, repo string, issue int, source
 	}
 
 	found := false
+	var cleanedSession *state.Session
 	for i := range sessions {
 		if sessions[i].Status != state.SessionStatusRunning || sessions[i].Repo != repo || sessions[i].IssueNumber != issue {
 			continue
@@ -1130,13 +1131,20 @@ func (a *App) CleanupSession(ctx context.Context, repo string, issue int, source
 			return err
 		}
 		found = true
+		cleanedSession = &sessions[i]
 		break
 	}
 	if !found {
+		if source == "cli" {
+			a.commentOnIssueBestEffort(ctx, repo, issue, localCleanupNoopComment(), "local cleanup no-op")
+		}
 		return fmt.Errorf("running session not found for %s issue #%d", repo, issue)
 	}
 	if err := a.state.SaveSessions(sessions); err != nil {
 		return err
+	}
+	if source == "cli" && cleanedSession != nil {
+		a.commentOnIssueBestEffort(ctx, repo, issue, localCleanupResultComment(*cleanedSession), "local cleanup result")
 	}
 	fmt.Fprintf(a.stdout, "cleaned up running session for %s issue #%d\n", repo, issue)
 	return nil
@@ -1157,6 +1165,9 @@ func (a *App) ResumeSession(ctx context.Context, repo string, issue int, source 
 		}
 		found = true
 		if sessions[i].Status != state.SessionStatusBlocked {
+			if source == "cli" {
+				a.commentOnIssueBestEffort(ctx, repo, issue, localResumeNoopComment(), "local resume no-op")
+			}
 			return fmt.Errorf("issue #%d in %s is not blocked", issue, repo)
 		}
 		if err := a.resumeBlockedSession(ctx, &sessions[i], source); err != nil {
@@ -1165,6 +1176,9 @@ func (a *App) ResumeSession(ctx context.Context, repo string, issue int, source 
 		break
 	}
 	if !found {
+		if source == "cli" {
+			a.commentOnIssueBestEffort(ctx, repo, issue, localResumeNoopComment(), "local resume no-op")
+		}
 		return fmt.Errorf("blocked session not found for %s issue #%d", repo, issue)
 	}
 	if err := a.state.SaveSessions(sessions); err != nil {
@@ -1254,6 +1268,10 @@ func (a *App) resumeBlockedSession(ctx context.Context, session *state.Session, 
 		blocked := classifyBlockedReason(session.BlockedStage, session.BlockedReason.Operation, err)
 		markSessionBlocked(session, fallbackText(session.BlockedStage, "pr_maintenance"), blocked, a.clock())
 		session.LastError = err.Error()
+		if source == "cli" {
+			a.commentOnIssueBestEffort(ctx, session.Repo, session.IssueNumber, localResumeFailureComment(*session, previousStage), "local resume failure")
+			return err
+		}
 		return a.commentResumeFailure(ctx, session, previousStage)
 	}
 
@@ -1270,11 +1288,19 @@ func (a *App) resumeBlockedSession(ctx context.Context, session *state.Session, 
 		blocked := classifyBlockedReason(session.BlockedStage, session.BlockedReason.Operation, err)
 		markSessionBlocked(session, fallbackText(session.BlockedStage, "pr_maintenance"), blocked, a.clock())
 		session.LastError = err.Error()
+		if source == "cli" {
+			a.commentOnIssueBestEffort(ctx, session.Repo, session.IssueNumber, localResumeFailureComment(*session, previousStage), "local resume failure")
+			return err
+		}
 		return a.commentResumeFailure(ctx, session, previousStage)
 	}
 
 	previousKind := session.BlockedReason.Kind
 	clearBlockedState(session, a.clock(), source)
+	if source == "cli" {
+		a.commentOnIssueBestEffort(ctx, session.Repo, session.IssueNumber, localResumeSuccessComment(*session, previousStage, previousKind), "local resume result")
+		return nil
+	}
 	body := ghcli.FormatProgressComment(ghcli.ProgressComment{
 		Stage:      "Recovered",
 		Emoji:      "🫡",
@@ -1768,6 +1794,101 @@ func inactiveBlockedCleanupComment(session state.Session, timeout time.Duration,
 	})
 }
 
+func localCleanupResultComment(session state.Session) string {
+	if session.CleanupError == "" {
+		return ghcli.FormatProgressComment(ghcli.ProgressComment{
+			Stage:      "Local Cleanup Completed",
+			Emoji:      "🧹",
+			Percent:    100,
+			ETAMinutes: 1,
+			Items: []string{
+				"A local operator ran `vigilante cleanup` for this issue.",
+				fmt.Sprintf("Result: succeeded. Removed the running Vigilante session for `%s`.", session.Branch),
+				fmt.Sprintf("Local worktree artifacts were cleaned up at `%s` when present.", session.WorktreePath),
+			},
+			Tagline: "Operator action recorded.",
+		})
+	}
+	return ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Local Cleanup Attempted",
+		Emoji:      "🛠️",
+		Percent:    100,
+		ETAMinutes: 1,
+		Items: []string{
+			"A local operator ran `vigilante cleanup` for this issue.",
+			fmt.Sprintf("Result: attempted. Removed the running-session blockage for `%s`.", session.Branch),
+			fmt.Sprintf("Local artifact cleanup still needs attention: `%s`.", summarizeMaintenanceError(errors.New(fallbackText(session.CleanupError, "unknown cleanup error")))),
+		},
+		Tagline: "Operator action recorded.",
+	})
+}
+
+func localCleanupNoopComment() string {
+	return ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Local Cleanup Checked",
+		Emoji:      "🧭",
+		Percent:    100,
+		ETAMinutes: 1,
+		Items: []string{
+			"A local operator ran `vigilante cleanup` for this issue.",
+			"Result: no-op. No running Vigilante session matched the request.",
+			"Next step: run `vigilante list --running` locally if dispatch still looks blocked.",
+		},
+		Tagline: "Operator action recorded.",
+	})
+}
+
+func localResumeSuccessComment(session state.Session, previousStage string, previousKind string) string {
+	return ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Local Resume Completed",
+		Emoji:      "🫡",
+		Percent:    92,
+		ETAMinutes: 5,
+		Items: []string{
+			"A local operator ran `vigilante resume` for this issue.",
+			fmt.Sprintf("Result: succeeded. The previous `%s` block was cleared for `%s`.", fallbackText(previousKind, "unknown_operator_action_required"), session.Branch),
+			fmt.Sprintf("Next step: Vigilante resumed `%s` successfully.", fallbackText(previousStage, "issue_execution")),
+		},
+		Tagline: "Operator action recorded.",
+	})
+}
+
+func localResumeFailureComment(session state.Session, previousStage string) string {
+	diagnostic := deterministicResumeFailureDiagnostic(session, previousStage)
+	return ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Local Resume Failed",
+		Emoji:      "🧱",
+		Percent:    100,
+		ETAMinutes: 1,
+		Items: []string{
+			"A local operator ran `vigilante resume` for this issue.",
+			fmt.Sprintf("Result: failed. %s", diagnostic.Step),
+			fmt.Sprintf("Failure type: `%s` (`%s`). %s", diagnostic.Classification, fallbackText(session.BlockedReason.Kind, "unknown_operator_action_required"), diagnostic.NextStep),
+		},
+		Tagline: "Operator action recorded.",
+	})
+}
+
+func localResumeNoopComment() string {
+	return ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Local Resume Checked",
+		Emoji:      "🧭",
+		Percent:    100,
+		ETAMinutes: 1,
+		Items: []string{
+			"A local operator ran `vigilante resume` for this issue.",
+			"Result: no-op. No blocked Vigilante session matched the request.",
+			"Next step: run `vigilante list` locally to inspect the latest session state.",
+		},
+		Tagline: "Operator action recorded.",
+	})
+}
+
+func (a *App) commentOnIssueBestEffort(ctx context.Context, repo string, issue int, body string, purpose string) {
+	if err := ghcli.CommentOnIssue(ctx, a.env.Runner, repo, issue, body); err != nil {
+		a.state.AppendDaemonLog("%s comment failed repo=%s issue=%d err=%v", purpose, repo, issue, err)
+	}
+}
 func fallbackText(value string, fallback string) string {
 	if strings.TrimSpace(value) == "" {
 		return fallback

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -597,6 +597,10 @@ func TestCleanupSessionByIssue(t *testing.T) {
 			"git worktree list --porcelain":                               "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
 			"git show-ref --verify --quiet refs/heads/vigilante/issue-44": "ok",
 			"git branch -D vigilante/issue-44":                            "Deleted branch vigilante/issue-44\n",
+			localCleanupCommentCommand("owner/repo", 44, state.Session{
+				Branch:       "vigilante/issue-44",
+				WorktreePath: worktreePath,
+			}): "ok",
 		},
 	}
 	if err := app.state.EnsureLayout(); err != nil {
@@ -632,6 +636,88 @@ func TestCleanupSessionByIssue(t *testing.T) {
 	}
 	if got := stdout.String(); !strings.Contains(got, "cleaned up running session for owner/repo issue #44") {
 		t.Fatalf("unexpected output: %s", got)
+	}
+}
+
+func TestCleanupSessionCommentsNoopForLocalCLIRequest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			localCleanupNoopCommentCommand("owner/repo", 44): "ok",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions(nil); err != nil {
+		t.Fatal(err)
+	}
+
+	err := app.CleanupSession(context.Background(), "owner/repo", 44, "cli")
+	if err == nil || !strings.Contains(err.Error(), "running session not found") {
+		t.Fatalf("expected not found error, got: %v", err)
+	}
+}
+
+func TestCleanupSessionIgnoresLocalCommentFailure(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-44")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"git worktree prune":                                          "ok",
+			"git worktree remove --force " + worktreePath:                 "ok",
+			"git worktree list --porcelain":                               "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-44": "ok",
+			"git branch -D vigilante/issue-44":                            "Deleted branch vigilante/issue-44\n",
+		},
+		Errors: map[string]error{
+			localCleanupCommentCommand("owner/repo", 44, state.Session{
+				Branch:       "vigilante/issue-44",
+				WorktreePath: worktreePath,
+			}): errors.New("comment failed"),
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:     repoPath,
+		Repo:         "owner/repo",
+		IssueNumber:  44,
+		Status:       state.SessionStatusRunning,
+		Branch:       "vigilante/issue-44",
+		WorktreePath: worktreePath,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.CleanupSession(context.Background(), "owner/repo", 44, "cli"); err != nil {
+		t.Fatal(err)
+	}
+
+	logData, err := os.ReadFile(app.state.DaemonLogPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(logData), "local cleanup result comment failed repo=owner/repo issue=44 err=comment failed") {
+		t.Fatalf("expected cleanup comment failure log, got: %s", logData)
 	}
 }
 
@@ -833,6 +919,201 @@ func TestScanOnceProcessesGitHubCommentResumeRequest(t *testing.T) {
 	}
 	if sessions[0].RecoveredAt == "" {
 		t.Fatalf("expected recovery timestamp to be recorded: %#v", sessions[0])
+	}
+}
+
+func TestResumeSessionCommentsSuccessForLocalCLIRequest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"codex --version": "codex 1.0.0",
+			issuePromptCommand(worktreePath, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1"): "done",
+			localResumeSuccessCommentCommand("owner/repo", 1, state.Session{Branch: "vigilante/issue-1"}, "issue_execution", "provider_auth"):   "ok",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:        repoPath,
+		Repo:            "owner/repo",
+		IssueNumber:     1,
+		IssueTitle:      "first",
+		IssueURL:        "https://github.com/owner/repo/issues/1",
+		Branch:          "vigilante/issue-1",
+		WorktreePath:    worktreePath,
+		Status:          state.SessionStatusBlocked,
+		BlockedAt:       "2026-03-11T13:19:12Z",
+		BlockedStage:    "issue_execution",
+		BlockedReason:   state.BlockedReason{Kind: "provider_auth", Operation: "codex exec", Summary: "session expired", Detail: "session expired"},
+		RetryPolicy:     "paused",
+		ResumeRequired:  true,
+		ResumeHint:      "vigilante resume --repo owner/repo --issue 1",
+		UpdatedAt:       "2026-03-11T13:19:12Z",
+		LastHeartbeatAt: "2026-03-11T13:19:12Z",
+		Provider:        "codex",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ResumeSession(context.Background(), "owner/repo", 1, "cli"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResumeSessionCommentsNoopForLocalCLIRequest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			localResumeNoopCommentCommand("owner/repo", 44): "ok",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions(nil); err != nil {
+		t.Fatal(err)
+	}
+
+	err := app.ResumeSession(context.Background(), "owner/repo", 44, "cli")
+	if err == nil || !strings.Contains(err.Error(), "blocked session not found") {
+		t.Fatalf("expected not found error, got: %v", err)
+	}
+}
+
+func TestResumeSessionCommentsFailureForLocalCLIRequest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	session := state.Session{
+		RepoPath:        repoPath,
+		Repo:            "owner/repo",
+		IssueNumber:     1,
+		IssueTitle:      "first",
+		IssueURL:        "https://github.com/owner/repo/issues/1",
+		Branch:          "vigilante/issue-1",
+		WorktreePath:    worktreePath,
+		Status:          state.SessionStatusBlocked,
+		BlockedAt:       "2026-03-11T13:19:12Z",
+		BlockedStage:    "issue_execution",
+		BlockedReason:   state.BlockedReason{Kind: "provider_auth", Operation: "codex exec", Summary: "session expired", Detail: "session expired"},
+		RetryPolicy:     "paused",
+		ResumeRequired:  true,
+		ResumeHint:      "vigilante resume --repo owner/repo --issue 1",
+		UpdatedAt:       "2026-03-11T13:19:12Z",
+		LastHeartbeatAt: "2026-03-11T13:19:12Z",
+		Provider:        "codex",
+	}
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"codex --version": "codex 1.0.0",
+			localResumeFailureCommentCommand("owner/repo", 1, failedResumeSession(session), "issue_execution"): "ok",
+		},
+		Errors: map[string]error{
+			issuePromptCommand(worktreePath, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1"): errors.New("resume run failed"),
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{session}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := app.ResumeSession(context.Background(), "owner/repo", 1, "cli")
+	if err == nil || !strings.Contains(err.Error(), "resume run failed") {
+		t.Fatalf("expected resume failure, got: %v", err)
+	}
+}
+
+func TestResumeSessionIgnoresLocalCommentFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"codex --version": "codex 1.0.0",
+			issuePromptCommand(worktreePath, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1"): "done",
+		},
+		Errors: map[string]error{
+			localResumeSuccessCommentCommand("owner/repo", 1, state.Session{Branch: "vigilante/issue-1"}, "issue_execution", "provider_auth"): errors.New("comment failed"),
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:        repoPath,
+		Repo:            "owner/repo",
+		IssueNumber:     1,
+		IssueTitle:      "first",
+		IssueURL:        "https://github.com/owner/repo/issues/1",
+		Branch:          "vigilante/issue-1",
+		WorktreePath:    worktreePath,
+		Status:          state.SessionStatusBlocked,
+		BlockedAt:       "2026-03-11T13:19:12Z",
+		BlockedStage:    "issue_execution",
+		BlockedReason:   state.BlockedReason{Kind: "provider_auth", Operation: "codex exec", Summary: "session expired", Detail: "session expired"},
+		RetryPolicy:     "paused",
+		ResumeRequired:  true,
+		ResumeHint:      "vigilante resume --repo owner/repo --issue 1",
+		UpdatedAt:       "2026-03-11T13:19:12Z",
+		LastHeartbeatAt: "2026-03-11T13:19:12Z",
+		Provider:        "codex",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ResumeSession(context.Background(), "owner/repo", 1, "cli"); err != nil {
+		t.Fatal(err)
+	}
+
+	logData, err := os.ReadFile(app.state.DaemonLogPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(logData), "local resume result comment failed repo=owner/repo issue=1 err=comment failed") {
+		t.Fatalf("expected resume comment failure log, got: %s", logData)
 	}
 }
 
@@ -3005,6 +3286,33 @@ func sessionStartCommentCommand(repo string, issueNumber int, worktreePath strin
 		},
 		Tagline: "Make it simple, but significant.",
 	})
+}
+
+func localCleanupCommentCommand(repo string, issueNumber int, session state.Session) string {
+	return "gh issue comment --repo " + repo + " " + fmt.Sprintf("%d", issueNumber) + " --body " + localCleanupResultComment(session)
+}
+
+func localCleanupNoopCommentCommand(repo string, issueNumber int) string {
+	return "gh issue comment --repo " + repo + " " + fmt.Sprintf("%d", issueNumber) + " --body " + localCleanupNoopComment()
+}
+
+func localResumeSuccessCommentCommand(repo string, issueNumber int, session state.Session, previousStage string, previousKind string) string {
+	return "gh issue comment --repo " + repo + " " + fmt.Sprintf("%d", issueNumber) + " --body " + localResumeSuccessComment(session, previousStage, previousKind)
+}
+
+func localResumeFailureCommentCommand(repo string, issueNumber int, session state.Session, previousStage string) string {
+	return "gh issue comment --repo " + repo + " " + fmt.Sprintf("%d", issueNumber) + " --body " + localResumeFailureComment(session, previousStage)
+}
+
+func localResumeNoopCommentCommand(repo string, issueNumber int) string {
+	return "gh issue comment --repo " + repo + " " + fmt.Sprintf("%d", issueNumber) + " --body " + localResumeNoopComment()
+}
+
+func failedResumeSession(session state.Session) state.Session {
+	session.Status = state.SessionStatusBlocked
+	session.LastResumeSource = "cli"
+	session.LastError = "resume run failed"
+	return session
 }
 
 func issuePromptCommand(worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, branch string) string {


### PR DESCRIPTION
## Summary
- report issue-scoped local `vigilante cleanup` and `vigilante resume` actions back to the related GitHub issue
- keep GitHub-comment-triggered wording unchanged while making local CLI comment posting best-effort
- add focused tests for local success, no-op, failure, and comment-post failure cases

Closes #113.

## Validation
- `go test ./...`
