### PR TITLE
Use main environment for release secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: main
     steps:
       - name: Check out repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
Run the release job in the `main` environment so environment-scoped `APP_ID` and `APP_PRIVATE_KEY` secrets are available to the Homebrew tap token step.

## Problem
The failing release job could not mint the GitHub App token for the Homebrew tap because `actions/create-github-app-token` received an empty `appId` value:
- `[@octokit/auth-app] appId option is required`

Those secrets live in the GitHub Actions environment `main`, but the release workflow job did not declare that environment, so the environment-scoped secrets were unavailable.

## Change
- add `environment: main` to the `release` job in `.github/workflows/release.yml`

## Validation
- workflow diff reviewed locally
- `git diff --stat origin/main...fix/release-main-environment`
