### PR TITLE
Require v-prefixed release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - '*.*.*'
+      - 'v*.*.*'
 
 permissions:
   contents: write
@@ -33,8 +33,8 @@ jobs:
         env:
           TAG_NAME: ${{ github.ref_name }}
         run: |
-          if ! printf '%s\n' "$TAG_NAME" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "Release tags must use the format {x}.{y}.{z}."
+          if ! printf '%s\n' "$TAG_NAME" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Release tags must use the format v{x}.{y}.{z}."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- trigger the release workflow only for v-prefixed semantic version tags
- update the tag policy validation step to require v{x}.{y}.{z}
- keep the main ancestry check unchanged

## Testing
- not run (workflow-only change)