### PR TITLE
Support Codex CLI 0.114.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Expected behavior:
 - creates `~/.vigilante/`
 - initializes `watchlist.json`
 - verifies `git`, `gh`, and the selected coding-agent provider CLI
-- verifies the selected provider CLI reports a compatible build-supported version range, currently `>=1.0.0, <2.0.0` for `codex`, `claude`, and `gemini`
+- verifies the selected provider CLI reports a compatible build-supported version range, currently `>=0.114.0, <2.0.0` for `codex` and `>=1.0.0, <2.0.0` for `claude` and `gemini`
 - installs the bundled coding-agent skills for regular runtime use, including any companion files under each skill directory
   - `vigilante-issue-implementation`
   - `vigilante-issue-implementation-on-monorepo`

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -75,7 +75,7 @@ func TestSetupCreatesStateLayoutAndSkill(t *testing.T) {
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: map[string]string{
-			"codex --version": "codex 1.2.3",
+			"codex --version": "codex 0.114.0",
 			"gh auth status":  "ok",
 		},
 	}
@@ -197,13 +197,13 @@ func TestWatchUpdatesExistingTarget(t *testing.T) {
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: map[string]string{
-			"codex --version":                   "codex 1.2.3",
+			"codex --version":                   "codex 0.114.0",
 			"gh auth status":                    "ok",
 			`/bin/zsh -lic printf "%s" "$PATH"`: "/usr/bin:/bin:/Users/test/.local/bin",
 			`/bin/sh -lc PATH="/usr/bin:/bin:/Users/test/.local/bin" command -v 'git'`:   "/usr/bin/git\n",
 			`/bin/sh -lc PATH="/usr/bin:/bin:/Users/test/.local/bin" command -v 'gh'`:    "/usr/bin/gh\n",
 			`/bin/sh -lc PATH="/usr/bin:/bin:/Users/test/.local/bin" command -v 'codex'`: "/Users/test/.local/bin/codex\n",
-			`/bin/sh -lc PATH="/usr/bin:/bin:/Users/test/.local/bin" 'codex' --version`:  "codex 1.2.3\n",
+			`/bin/sh -lc PATH="/usr/bin:/bin:/Users/test/.local/bin" 'codex' --version`:  "codex 0.114.0\n",
 			testutil.Key("launchctl", "unload", launchAgentPath):                         "",
 			testutil.Key("launchctl", "load", launchAgentPath):                           "",
 			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                    "true\n",

--- a/internal/provider/compatibility.go
+++ b/internal/provider/compatibility.go
@@ -24,7 +24,7 @@ type compatibilityContract struct {
 }
 
 var compatibilityContracts = map[string]compatibilityContract{
-	DefaultID: {minInclusive: "1.0.0", maxExclusive: "2.0.0"},
+	DefaultID: {minInclusive: "0.114.0", maxExclusive: "2.0.0"},
 	ClaudeID:  {minInclusive: "1.0.0", maxExclusive: "2.0.0"},
 	GeminiID:  {minInclusive: "1.0.0", maxExclusive: "2.0.0"},
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -162,6 +162,7 @@ func TestValidateVersionOutputAcceptsSupportedVersions(t *testing.T) {
 		provider string
 		output   string
 	}{
+		{name: "codex current supported 0.x", provider: DefaultID, output: "codex 0.114.0"},
 		{name: "codex", provider: DefaultID, output: "codex 1.2.3"},
 		{name: "claude", provider: ClaudeID, output: "Claude Code v1.4.0"},
 		{name: "gemini", provider: GeminiID, output: "gemini-cli 1.9.9"},
@@ -186,11 +187,11 @@ func TestValidateVersionOutputRejectsTooOldVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ValidateVersionOutput(selectedProvider, "codex 0.9.9")
+	err = ValidateVersionOutput(selectedProvider, "codex 0.113.9")
 	if err == nil {
 		t.Fatal("expected compatibility error")
 	}
-	for _, want := range []string{"codex CLI version 0.9.9 is incompatible", ">=1.0.0, <2.0.0"} {
+	for _, want := range []string{"codex CLI version 0.113.9 is incompatible", ">=0.114.0, <2.0.0"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("expected error to contain %q, got %q", want, err.Error())
 		}

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -22,7 +22,7 @@ func TestRunIssueSessionSuccess(t *testing.T) {
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{
-			"codex --version": "codex 1.2.3",
+			"codex --version": "codex 0.114.0",
 			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
 				Stage:      "Vigilante Session Start",
 				Emoji:      "🧢",
@@ -63,7 +63,7 @@ func TestRunIssueSessionFailureCommentsOnIssue(t *testing.T) {
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{
-			"codex --version": "codex 1.2.3",
+			"codex --version": "codex 0.114.0",
 			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
 				Stage:      "Vigilante Session Start",
 				Emoji:      "🧢",
@@ -125,7 +125,7 @@ func TestRunConflictResolutionSessionFailureCommentsOnIssue(t *testing.T) {
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{
-			"codex --version": "codex 1.2.3",
+			"codex --version": "codex 0.114.0",
 			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
 				Stage:      "Blocked",
 				Emoji:      "🧯",
@@ -264,7 +264,7 @@ func TestRunIssueSessionUsesMonorepoSkillWhenClassified(t *testing.T) {
 	}
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{
-			"codex --version": "codex 1.2.3",
+			"codex --version": "codex 0.114.0",
 			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
 				Stage:      "Vigilante Session Start",
 				Emoji:      "🧢",

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -59,7 +59,7 @@ func TestBuildConfigUsesShellPath(t *testing.T) {
 				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'git'`:   "/opt/homebrew/bin/git\n",
 				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'gh'`:    "/opt/homebrew/bin/gh\n",
 				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'codex'`: "/Users/test/.local/bin/codex\n",
-				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" 'codex' --version`:  "codex 1.2.3\n",
+				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" 'codex' --version`:  "codex 0.114.0\n",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- accept Codex CLI `0.114.0` in the provider compatibility contract
- update focused provider/service/app/runner tests to cover the supported 0.x case
- refresh README compatibility wording for Codex versus Claude/Gemini

## Validation
- go test ./internal/provider ./internal/service ./internal/runner ./internal/app

Closes #142