### PR TITLE
Support Claude Code 2.x.x in Vigilante

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Expected behavior:
 - creates `~/.vigilante/`
 - initializes `watchlist.json`
 - verifies `git`, `gh`, and the selected coding-agent provider CLI
-- verifies the selected provider CLI reports a compatible build-supported version range, currently `>=0.114.0, <2.0.0` for `codex` and `>=1.0.0, <2.0.0` for `claude` and `gemini`
+- verifies the selected provider CLI reports a compatible build-supported version range, currently `>=0.114.0, <2.0.0` for `codex`, `>=2.0.0, <3.0.0` for `claude`, and `>=1.0.0, <2.0.0` for `gemini`
 - installs the bundled coding-agent skills for regular runtime use, including any companion files under each skill directory
   - `vigilante-issue-implementation`
   - `vigilante-issue-implementation-on-monorepo`

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -310,7 +310,7 @@ func TestWatchWithProviderPersistsClaudeSelection(t *testing.T) {
 			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                  "true\n",
 			testutil.Key("git", "remote", "get-url", "origin"):                         "git@github.com:nicobistolfi/vigilante.git\n",
 			testutil.Key("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"): "origin/main\n",
-			"claude --version": "Claude Code 1.4.0",
+			"claude --version": "Claude Code 2.1.3",
 		},
 	}
 

--- a/internal/provider/compatibility.go
+++ b/internal/provider/compatibility.go
@@ -25,7 +25,7 @@ type compatibilityContract struct {
 
 var compatibilityContracts = map[string]compatibilityContract{
 	DefaultID: {minInclusive: "0.114.0", maxExclusive: "2.0.0"},
-	ClaudeID:  {minInclusive: "1.0.0", maxExclusive: "2.0.0"},
+	ClaudeID:  {minInclusive: "2.0.0", maxExclusive: "3.0.0"},
 	GeminiID:  {minInclusive: "1.0.0", maxExclusive: "2.0.0"},
 }
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -164,7 +164,7 @@ func TestValidateVersionOutputAcceptsSupportedVersions(t *testing.T) {
 	}{
 		{name: "codex current supported 0.x", provider: DefaultID, output: "codex 0.114.0"},
 		{name: "codex", provider: DefaultID, output: "codex 1.2.3"},
-		{name: "claude", provider: ClaudeID, output: "Claude Code v1.4.0"},
+		{name: "claude 2.x", provider: ClaudeID, output: "Claude Code v2.1.3"},
 		{name: "gemini", provider: GeminiID, output: "gemini-cli 1.9.9"},
 	}
 
@@ -204,11 +204,26 @@ func TestValidateVersionOutputRejectsTooNewVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = ValidateVersionOutput(selectedProvider, "Claude Code 2.0.0")
+	err = ValidateVersionOutput(selectedProvider, "Claude Code 3.0.0")
 	if err == nil {
 		t.Fatal("expected compatibility error")
 	}
-	if !strings.Contains(err.Error(), "supported: >=1.0.0, <2.0.0") {
+	if !strings.Contains(err.Error(), "supported: >=2.0.0, <3.0.0") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateVersionOutputRejectsTooOldClaude2Contract(t *testing.T) {
+	selectedProvider, err := Resolve(ClaudeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ValidateVersionOutput(selectedProvider, "Claude Code 1.9.9")
+	if err == nil {
+		t.Fatal("expected compatibility error")
+	}
+	if !strings.Contains(err.Error(), "supported: >=2.0.0, <3.0.0") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -167,7 +167,7 @@ func TestRunIssueSessionSuccessWithClaudeProvider(t *testing.T) {
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{
-			"claude --version": "Claude Code 1.4.0",
+			"claude --version": "Claude Code 2.1.3",
 			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
 				Stage:      "Vigilante Session Start",
 				Emoji:      "🧢",

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -123,7 +123,7 @@ func TestBuildConfigSupportsClaudeProvider(t *testing.T) {
 				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'git'`:    "/opt/homebrew/bin/git\n",
 				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'gh'`:     "/opt/homebrew/bin/gh\n",
 				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" command -v 'claude'`: "/Users/test/.local/bin/claude\n",
-				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" 'claude' --version`:  "Claude Code 1.4.0\n",
+				`/bin/sh -lc PATH="/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin:/bin" 'claude' --version`:  "Claude Code 2.1.3\n",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- update the centralized Claude compatibility contract to explicitly support `>=2.0.0, <3.0.0`
- keep Claude invocation behavior unchanged where Vigilante already uses the compatible headless flags and working-directory handling
- refresh docs and tests so Claude `2.x` is accepted in provider validation, setup/watch flows, and Claude-backed session execution

Closes #146

## Validation
- `go test ./internal/provider ./internal/runner ./internal/service ./internal/app`
- `go test ./...`
