### PR TITLE
Reuse existing remote issue branches during dispatch

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -548,22 +548,46 @@ func (a *App) ScanOnce(ctx context.Context) error {
 					fmt.Fprintf(a.stdout, "repo: %s blocked issue #%d: %s\n", target.Repo, next.Number, summarizeText(err.Error()))
 					continue
 				}
-				a.state.AppendDaemonLog("scan repo worktree ready repo=%s issue=%d path=%s branch=%s", target.Repo, next.Number, wt.Path, wt.Branch)
+				a.state.AppendDaemonLog("scan repo worktree ready repo=%s issue=%d path=%s branch=%s reused_remote=%t", target.Repo, next.Number, wt.Path, wt.Branch, wt.ReusedRemoteBranch != "")
+
+				diffSummary := ""
+				if strings.TrimSpace(wt.ReusedRemoteBranch) != "" {
+					diffSummary, err = summarizeIssueBranchDiff(ctx, a.env.Runner, target.Path, target.Branch, wt.Branch)
+					if err != nil {
+						_ = worktree.CleanupIssueArtifacts(ctx, a.env.Runner, target.Path, wt.Path, wt.Branch)
+						session := blockedIssueSessionForDispatchFailure(*target, next, selectedProvider, fmt.Errorf("analyze reused remote issue branch %q against %q: %w", wt.Branch, target.Branch, err), a.clock())
+						session.Branch = wt.Branch
+						session.BaseBranch = target.Branch
+						session.WorktreePath = wt.Path
+						session.ReusedRemoteBranch = wt.ReusedRemoteBranch
+						a.state.AppendDaemonLog("scan repo dispatch blocked repo=%s issue=%d branch=%s err=%v", target.Repo, next.Number, wt.Branch, err)
+						sessions = upsertSession(sessions, session)
+						if err := a.state.SaveSessions(sessions); err != nil {
+							return err
+						}
+						fmt.Fprintf(a.stdout, "repo: %s blocked issue #%d: %s\n", target.Repo, next.Number, summarizeText(session.LastError))
+						continue
+					}
+					a.state.AppendDaemonLog("scan repo reused remote issue branch repo=%s issue=%d branch=%s base=%s diff=%s", target.Repo, next.Number, wt.Branch, target.Branch, summarizeText(diffSummary))
+				}
 
 				session := state.Session{
-					RepoPath:        target.Path,
-					Repo:            target.Repo,
-					Provider:        selectedProvider,
-					IssueNumber:     next.Number,
-					IssueTitle:      next.Title,
-					IssueURL:        next.URL,
-					Branch:          wt.Branch,
-					WorktreePath:    wt.Path,
-					Status:          state.SessionStatusRunning,
-					ProcessID:       os.Getpid(),
-					StartedAt:       a.clock().Format(time.RFC3339),
-					LastHeartbeatAt: a.clock().Format(time.RFC3339),
-					UpdatedAt:       a.clock().Format(time.RFC3339),
+					RepoPath:           target.Path,
+					Repo:               target.Repo,
+					Provider:           selectedProvider,
+					IssueNumber:        next.Number,
+					IssueTitle:         next.Title,
+					IssueURL:           next.URL,
+					BaseBranch:         target.Branch,
+					Branch:             wt.Branch,
+					WorktreePath:       wt.Path,
+					ReusedRemoteBranch: wt.ReusedRemoteBranch,
+					BranchDiffSummary:  diffSummary,
+					Status:             state.SessionStatusRunning,
+					ProcessID:          os.Getpid(),
+					StartedAt:          a.clock().Format(time.RFC3339),
+					LastHeartbeatAt:    a.clock().Format(time.RFC3339),
+					UpdatedAt:          a.clock().Format(time.RFC3339),
 				}
 				sessions = upsertSession(sessions, session)
 				if err := a.state.SaveSessions(sessions); err != nil {
@@ -1889,6 +1913,19 @@ func (a *App) commentOnIssueBestEffort(ctx context.Context, repo string, issue i
 		a.state.AppendDaemonLog("%s comment failed repo=%s issue=%d err=%v", purpose, repo, issue, err)
 	}
 }
+
+func summarizeIssueBranchDiff(ctx context.Context, runner environment.Runner, repoPath string, baseBranch string, issueBranch string) (string, error) {
+	output, err := runner.Run(ctx, repoPath, "git", "diff", "--stat", baseBranch+"..."+issueBranch)
+	if err != nil {
+		return "", err
+	}
+	summary := strings.TrimSpace(output)
+	if summary == "" {
+		return fmt.Sprintf("No diff detected between `%s` and `%s`.", baseBranch, issueBranch), nil
+	}
+	return summarizeText(summary), nil
+}
+
 func fallbackText(value string, fallback string) string {
 	if strings.TrimSpace(value) == "" {
 		return fallback

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2235,6 +2235,116 @@ func TestScanOnceSelectsEligibleIssueAndPersistsSession(t *testing.T) {
 	}
 }
 
+func TestScanOnceReusesExistingRemoteIssueBranchAndPersistsDiffContext(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	worktreePath := filepath.Join("/tmp/repo", ".worktrees", "vigilante", "issue-1")
+	branch := "vigilante/issue-1-first"
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh auth status":          "ok",
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[{"name":"to-do"}]}]`,
+			"git worktree prune":                              "ok",
+			"git fetch origin " + branch + ":" + branch:       "ok",
+			"git worktree add " + worktreePath + " " + branch: "ok",
+			"git diff --stat main..." + branch:                "README.md | 2 ++\n 1 file changed, 2 insertions(+)\n",
+			sessionStartCommentCommand("owner/repo", 1, worktreePath, state.Session{Branch: branch, BaseBranch: "main", ReusedRemoteBranch: branch, BranchDiffSummary: "README.md | 2 ++\n 1 file changed, 2 insertions(+)"}):                                                                                                                  "ok",
+			preflightPromptCommandForSession(worktreePath, "owner/repo", "/tmp/repo", 1, "first", "https://github.com/owner/repo/issues/1", state.Session{WorktreePath: worktreePath, Branch: branch, BaseBranch: "main", ReusedRemoteBranch: branch}):                                                                                         "baseline ok",
+			issuePromptCommandForSession(worktreePath, "owner/repo", "/tmp/repo", 1, "first", "https://github.com/owner/repo/issues/1", state.Session{WorktreePath: worktreePath, Branch: branch, BaseBranch: "main", ReusedRemoteBranch: branch, BranchDiffSummary: "README.md | 2 ++\n 1 file changed, 2 insertions(+)", Provider: "codex"}): "done",
+		},
+		Errors: map[string]error{
+			"git ls-remote --exit-code --heads origin " + branch:         nil,
+			"git ls-remote --exit-code --heads origin vigilante/issue-1": errors.New("exit status 2"),
+			"git show-ref --verify --quiet refs/heads/" + branch:         errors.New("exit status 1"),
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": errors.New("exit status 1"),
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main", Assignee: "me", Labels: []string{"to-do"}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	app.waitForSessions()
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if sessions[0].ReusedRemoteBranch != branch || sessions[0].BaseBranch != "main" {
+		t.Fatalf("expected reused remote branch context to persist: %#v", sessions[0])
+	}
+	if !strings.Contains(sessions[0].BranchDiffSummary, "README.md | 2 ++") {
+		t.Fatalf("expected branch diff summary to persist: %#v", sessions[0])
+	}
+}
+
+func TestScanOnceBlocksIssueWhenReusedRemoteBranchDiffAnalysisFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	worktreePath := filepath.Join("/tmp/repo", ".worktrees", "vigilante", "issue-1")
+	branch := "vigilante/issue-1-first"
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh auth status":          "ok",
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[{"name":"to-do"}]}]`,
+			"git worktree prune":                              "ok",
+			"git fetch origin " + branch + ":" + branch:       "ok",
+			"git worktree add " + worktreePath + " " + branch: "ok",
+			"git worktree list --porcelain":                   "worktree /tmp/repo\nHEAD abcdef\nbranch refs/heads/main\n",
+			"git branch -D " + branch:                         "Deleted branch " + branch,
+		},
+		Errors: map[string]error{
+			"git ls-remote --exit-code --heads origin " + branch:         nil,
+			"git ls-remote --exit-code --heads origin vigilante/issue-1": errors.New("exit status 2"),
+			"git diff --stat main..." + branch:                           errors.New("diff failed"),
+			"git show-ref --verify --quiet refs/heads/" + branch:         nil,
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main", Assignee: "me", Labels: []string{"to-do"}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 || sessions[0].Status != state.SessionStatusBlocked {
+		t.Fatalf("expected blocked session after diff analysis failure: %#v", sessions)
+	}
+	if !strings.Contains(sessions[0].LastError, "analyze reused remote issue branch") {
+		t.Fatalf("expected diff analysis failure to be recorded: %#v", sessions[0])
+	}
+}
+
 func TestScanOnceUsesProviderLabelOverrideForSession(t *testing.T) {
 	home := t.TempDir()
 	repoPath := filepath.Join(home, "repo")
@@ -2254,7 +2364,7 @@ func TestScanOnceUsesProviderLabelOverrideForSession(t *testing.T) {
 			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[{"name":"codex"}]}]`,
 			"git worktree prune": "ok",
 			"git worktree add -b " + branch + " " + worktreePath + " main":                                                         "ok",
-			sessionStartCommentCommand("owner/repo", 1, worktreePath, branch):                                                      "ok",
+			sessionStartCommentCommand("owner/repo", 1, worktreePath, state.Session{Branch: branch}):                               "ok",
 			issuePromptCommand(worktreePath, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", branch): "done",
 		},
 		Errors: map[string]error{
@@ -2452,7 +2562,7 @@ func TestScanOnceWithMaxParallelOnePreservesSerialBehavior(t *testing.T) {
 			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]},{"number":2,"title":"second","createdAt":"2026-03-10T12:00:00Z","url":"https://github.com/owner/repo/issues/2","labels":[]}]`,
 			"git worktree prune": "ok",
 			"git worktree add -b vigilante/issue-1-first " + worktreePath1 + " main":                                                                       "ok",
-			sessionStartCommentCommand("owner/repo", 1, worktreePath1, "vigilante/issue-1-first"):                                                          "ok",
+			sessionStartCommentCommand("owner/repo", 1, worktreePath1, state.Session{Branch: "vigilante/issue-1-first"}):                                   "ok",
 			preflightPromptCommand(worktreePath1, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1-first"): "baseline ok",
 			issuePromptCommand(worktreePath1, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1-first"):     "done",
 		},
@@ -2504,9 +2614,9 @@ func TestScanOnceWithUnlimitedMaxParallelStartsAllEligibleIssues(t *testing.T) {
 			"git worktree add -b vigilante/issue-1-first " + worktreePath1 + " main":                                                                         "ok",
 			"git worktree add -b vigilante/issue-2-second " + worktreePath2 + " main":                                                                        "ok",
 			"git worktree add -b vigilante/issue-3-third " + worktreePath3 + " main":                                                                         "ok",
-			sessionStartCommentCommand("owner/repo", 1, worktreePath1, "vigilante/issue-1-first"):                                                            "ok",
-			sessionStartCommentCommand("owner/repo", 2, worktreePath2, "vigilante/issue-2-second"):                                                           "ok",
-			sessionStartCommentCommand("owner/repo", 3, worktreePath3, "vigilante/issue-3-third"):                                                            "ok",
+			sessionStartCommentCommand("owner/repo", 1, worktreePath1, state.Session{Branch: "vigilante/issue-1-first"}):                                     "ok",
+			sessionStartCommentCommand("owner/repo", 2, worktreePath2, state.Session{Branch: "vigilante/issue-2-second"}):                                    "ok",
+			sessionStartCommentCommand("owner/repo", 3, worktreePath3, state.Session{Branch: "vigilante/issue-3-third"}):                                     "ok",
 			preflightPromptCommand(worktreePath1, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1-first"):   "baseline ok",
 			preflightPromptCommand(worktreePath2, "owner/repo", repoPath, 2, "second", "https://github.com/owner/repo/issues/2", "vigilante/issue-2-second"): "baseline ok",
 			preflightPromptCommand(worktreePath3, "owner/repo", repoPath, 3, "third", "https://github.com/owner/repo/issues/3", "vigilante/issue-3-third"):   "baseline ok",
@@ -2566,8 +2676,8 @@ func TestScanOnceStartsMultipleIssuesUpToConfiguredLimit(t *testing.T) {
 			"git worktree prune": "ok",
 			"git worktree add -b vigilante/issue-1-first " + worktreePath1 + " main":                                                                         "ok",
 			"git worktree add -b vigilante/issue-2-second " + worktreePath2 + " main":                                                                        "ok",
-			sessionStartCommentCommand("owner/repo", 1, worktreePath1, "vigilante/issue-1-first"):                                                            "ok",
-			sessionStartCommentCommand("owner/repo", 2, worktreePath2, "vigilante/issue-2-second"):                                                           "ok",
+			sessionStartCommentCommand("owner/repo", 1, worktreePath1, state.Session{Branch: "vigilante/issue-1-first"}):                                     "ok",
+			sessionStartCommentCommand("owner/repo", 2, worktreePath2, state.Session{Branch: "vigilante/issue-2-second"}):                                    "ok",
 			preflightPromptCommand(worktreePath1, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1-first"):   "baseline ok",
 			preflightPromptCommand(worktreePath2, "owner/repo", repoPath, 2, "second", "https://github.com/owner/repo/issues/2", "vigilante/issue-2-second"): "baseline ok",
 			issuePromptCommand(worktreePath1, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1-first"):       "done",
@@ -2623,7 +2733,7 @@ func TestScanOnceDoesNotExceedConfiguredLimit(t *testing.T) {
 			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]},{"number":2,"title":"second","createdAt":"2026-03-10T12:00:00Z","url":"https://github.com/owner/repo/issues/2","labels":[]},{"number":3,"title":"third","createdAt":"2026-03-11T12:00:00Z","url":"https://github.com/owner/repo/issues/3","labels":[]}]`,
 			"git worktree prune": "ok",
 			"git worktree add -b vigilante/issue-2-second " + worktreePath2 + " main":                                                                    "ok",
-			sessionStartCommentCommand("owner/repo", 2, worktreePath2, "vigilante/issue-2-second"):                                                       "ok",
+			sessionStartCommentCommand("owner/repo", 2, worktreePath2, state.Session{Branch: "vigilante/issue-2-second"}):                                "ok",
 			issuePromptCommand(worktreePath2, "owner/repo", repoPath, 2, "second", "https://github.com/owner/repo/issues/2", "vigilante/issue-2-second"): "done",
 		},
 	}
@@ -2687,7 +2797,7 @@ func TestScanOnceBlocksFailedIssueDispatchAndContinuesToNextIssue(t *testing.T) 
 			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]},{"number":2,"title":"second","createdAt":"2026-03-10T12:00:00Z","url":"https://github.com/owner/repo/issues/2","labels":[]}]`,
 			"git worktree prune": "ok",
 			"git worktree add -b " + branch2 + " " + worktreePath2 + " main":                                                              "ok",
-			sessionStartCommentCommand("owner/repo", 2, worktreePath2, branch2):                                                           "ok",
+			sessionStartCommentCommand("owner/repo", 2, worktreePath2, state.Session{Branch: branch2}):                                    "ok",
 			preflightPromptCommand(worktreePath2, "owner/repo", repoPath, 2, "second", "https://github.com/owner/repo/issues/2", branch2): "baseline ok",
 			issuePromptCommand(worktreePath2, "owner/repo", repoPath, 2, "second", "https://github.com/owner/repo/issues/2", branch2):     "done",
 		},
@@ -2755,9 +2865,9 @@ func TestScanOnceEnforcesLimitsIndependentlyAcrossRepositories(t *testing.T) {
 			"git worktree add -b vigilante/issue-1-first-a " + worktreeA1 + " main":                                                                                  "ok",
 			"git worktree add -b vigilante/issue-2-second-a " + worktreeA2 + " main":                                                                                 "ok",
 			"git worktree add -b vigilante/issue-10-first-b " + worktreeB10 + " main":                                                                                "ok",
-			sessionStartCommentCommand("owner/repo-a", 1, worktreeA1, "vigilante/issue-1-first-a"):                                                                   "ok",
-			sessionStartCommentCommand("owner/repo-a", 2, worktreeA2, "vigilante/issue-2-second-a"):                                                                  "ok",
-			sessionStartCommentCommand("owner/repo-b", 10, worktreeB10, "vigilante/issue-10-first-b"):                                                                "ok",
+			sessionStartCommentCommand("owner/repo-a", 1, worktreeA1, state.Session{Branch: "vigilante/issue-1-first-a"}):                                            "ok",
+			sessionStartCommentCommand("owner/repo-a", 2, worktreeA2, state.Session{Branch: "vigilante/issue-2-second-a"}):                                           "ok",
+			sessionStartCommentCommand("owner/repo-b", 10, worktreeB10, state.Session{Branch: "vigilante/issue-10-first-b"}):                                         "ok",
 			preflightPromptCommand(worktreeA1, "owner/repo-a", repoPathA, 1, "first-a", "https://github.com/owner/repo-a/issues/1", "vigilante/issue-1-first-a"):     "baseline ok",
 			preflightPromptCommand(worktreeA2, "owner/repo-a", repoPathA, 2, "second-a", "https://github.com/owner/repo-a/issues/2", "vigilante/issue-2-second-a"):   "baseline ok",
 			preflightPromptCommand(worktreeB10, "owner/repo-b", repoPathB, 10, "first-b", "https://github.com/owner/repo-b/issues/10", "vigilante/issue-10-first-b"): "baseline ok",
@@ -2815,7 +2925,7 @@ func TestScanOnceContinuesWhenOneRepositoryScanFails(t *testing.T) {
 			"gh issue list --repo owner/repo-b --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":10,"title":"first-b","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo-b/issues/10","labels":[]}]`,
 			"git worktree prune": "ok",
 			"git worktree add -b " + branchB10 + " " + worktreeB10 + " main":                                                                      "ok",
-			sessionStartCommentCommand("owner/repo-b", 10, worktreeB10, branchB10):                                                                "ok",
+			sessionStartCommentCommand("owner/repo-b", 10, worktreeB10, state.Session{Branch: branchB10}):                                         "ok",
 			preflightPromptCommand(worktreeB10, "owner/repo-b", repoPathB, 10, "first-b", "https://github.com/owner/repo-b/issues/10", branchB10): "baseline ok",
 			issuePromptCommand(worktreeB10, "owner/repo-b", repoPathB, 10, "first-b", "https://github.com/owner/repo-b/issues/10", branchB10):     "done",
 		},
@@ -3273,18 +3383,30 @@ func TestScanOnceRecoversStalledSessionIntoPRMaintenance(t *testing.T) {
 	}
 }
 
-func sessionStartCommentCommand(repo string, issueNumber int, worktreePath string, branch string) string {
+func sessionStartCommentCommand(repo string, issueNumber int, worktreePath string, session state.Session) string {
+	items := []string{
+		"Vigilante launched this implementation session in `" + worktreePath + "`.",
+		"Branch: `" + session.Branch + "`.",
+		"Current stage: handing the issue off to the configured coding agent (`Codex`) for investigation and implementation.",
+	}
+	if session.ReusedRemoteBranch != "" {
+		base := session.BaseBranch
+		if base == "" {
+			base = "main"
+		}
+		items = []string{
+			"Vigilante launched this implementation session in `" + worktreePath + "` from existing remote branch `origin/" + session.ReusedRemoteBranch + "`.",
+			"Diff summary against `" + base + "`: " + session.BranchDiffSummary,
+			"Current stage: handing the issue off to the configured coding agent (`Codex`) to continue the existing implementation.",
+		}
+	}
 	return "gh issue comment --repo " + repo + " " + fmt.Sprintf("%d", issueNumber) + " --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
 		Stage:      "Vigilante Session Start",
 		Emoji:      "🧢",
 		Percent:    20,
 		ETAMinutes: 25,
-		Items: []string{
-			"Vigilante launched this implementation session in `" + worktreePath + "`.",
-			"Branch: `" + branch + "`.",
-			"Current stage: handing the issue off to the configured coding agent (`Codex`) for investigation and implementation.",
-		},
-		Tagline: "Make it simple, but significant.",
+		Items:      items,
+		Tagline:    "Make it simple, but significant.",
 	})
 }
 
@@ -3338,10 +3460,22 @@ func issuePromptCommandForProvider(providerID string, worktreePath string, repo 
 }
 
 func preflightPromptCommand(worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, branch string) string {
+	return preflightPromptCommandForSession(worktreePath, repo, repoPath, issueNumber, title, issueURL, state.Session{WorktreePath: worktreePath, Branch: branch})
+}
+
+func preflightPromptCommandForSession(worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, session state.Session) string {
 	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePreflightPrompt(
 		state.WatchTarget{Path: repoPath, Repo: repo},
 		ghcli.Issue{Number: issueNumber, Title: title, URL: issueURL},
-		state.Session{WorktreePath: worktreePath, Branch: branch},
+		session,
+	))
+}
+
+func issuePromptCommandForSession(worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, session state.Session) string {
+	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePrompt(
+		state.WatchTarget{Path: repoPath, Repo: repo},
+		ghcli.Issue{Number: issueNumber, Title: title, URL: issueURL},
+		session,
 	))
 }
 

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -42,17 +42,29 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 		appendSessionLog(logPath, "session provider compatibility failed", session, err.Error())
 		return session
 	}
+	startItems := []string{
+		fmt.Sprintf("Vigilante launched this implementation session in `%s`.", session.WorktreePath),
+		fmt.Sprintf("Branch: `%s`.", session.Branch),
+		fmt.Sprintf("Current stage: handing the issue off to the configured coding agent (`%s`) for investigation and implementation.", selectedProvider.DisplayName()),
+	}
+	if strings.TrimSpace(session.ReusedRemoteBranch) != "" {
+		baseBranch := strings.TrimSpace(session.BaseBranch)
+		if baseBranch == "" {
+			baseBranch = "main"
+		}
+		startItems = []string{
+			fmt.Sprintf("Vigilante launched this implementation session in `%s` from existing remote branch `origin/%s`.", session.WorktreePath, session.ReusedRemoteBranch),
+			fmt.Sprintf("Diff summary against `%s`: %s", baseBranch, fallbackSessionText(session.BranchDiffSummary, "diff summary unavailable")),
+			fmt.Sprintf("Current stage: handing the issue off to the configured coding agent (`%s`) to continue the existing implementation.", selectedProvider.DisplayName()),
+		}
+	}
 	startBody := ghcli.FormatProgressComment(ghcli.ProgressComment{
 		Stage:      "Vigilante Session Start",
 		Emoji:      "🧢",
 		Percent:    20,
 		ETAMinutes: 25,
-		Items: []string{
-			fmt.Sprintf("Vigilante launched this implementation session in `%s`.", session.WorktreePath),
-			fmt.Sprintf("Branch: `%s`.", session.Branch),
-			fmt.Sprintf("Current stage: handing the issue off to the configured coding agent (`%s`) for investigation and implementation.", selectedProvider.DisplayName()),
-		},
-		Tagline: "Make it simple, but significant.",
+		Items:      startItems,
+		Tagline:    "Make it simple, but significant.",
 	})
 	appendSessionLog(logPath, "session started", session, "")
 	if err := ghcli.CommentOnIssue(ctx, env.Runner, target.Repo, issue.Number, startBody); err != nil {
@@ -149,6 +161,13 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 	session.Status = state.SessionStatusSuccess
 	appendSessionLog(logPath, "session succeeded", session, output)
 	return session
+}
+
+func fallbackSessionText(value string, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
 }
 
 func RunConflictResolutionSession(ctx context.Context, env *environment.Environment, store *state.Store, target state.WatchTarget, session state.Session, pr ghcli.PullRequest) error {

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -58,6 +58,49 @@ func TestRunIssueSessionSuccess(t *testing.T) {
 	}
 }
 
+func TestRunIssueSessionStartCommentIncludesReusedRemoteBranchContext(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"codex --version": "codex 0.114.0",
+			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Vigilante Session Start",
+				Emoji:      "🧢",
+				Percent:    20,
+				ETAMinutes: 25,
+				Items: []string{
+					"Vigilante launched this implementation session in `/tmp/worktree` from existing remote branch `origin/vigilante/issue-7-demo`.",
+					"Diff summary against `main`: README.md | 2 ++",
+					"Current stage: handing the issue off to the configured coding agent (`Codex`) to continue the existing implementation.",
+				},
+				Tagline: "Make it simple, but significant.",
+			}): "ok",
+			preflightPromptCommandForSession("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7-demo", BaseBranch: "main", ReusedRemoteBranch: "vigilante/issue-7-demo"}):                                                       "baseline ok",
+			issuePromptCommandForSession("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7-demo", BaseBranch: "main", ReusedRemoteBranch: "vigilante/issue-7-demo", BranchDiffSummary: "README.md | 2 ++", Provider: "codex"}): "done",
+		},
+	}
+	env := &environment.Environment{OS: "darwin", Runner: runner}
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	session := state.Session{
+		RepoPath:           "/tmp/repo",
+		IssueNumber:        7,
+		WorktreePath:       "/tmp/worktree",
+		Branch:             "vigilante/issue-7-demo",
+		BaseBranch:         "main",
+		ReusedRemoteBranch: "vigilante/issue-7-demo",
+		BranchDiffSummary:  "README.md | 2 ++",
+		Status:             state.SessionStatusRunning,
+	}
+	got := RunIssueSession(context.Background(), env, store, state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+	if got.Status != state.SessionStatusSuccess {
+		t.Fatalf("unexpected status: %#v", got)
+	}
+}
+
 func TestRunIssueSessionFailureCommentsOnIssue(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
@@ -457,18 +500,26 @@ func TestAppendSessionLogUsesLocalTimezone(t *testing.T) {
 }
 
 func preflightPromptCommand(worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, branch string) string {
+	return preflightPromptCommandForSession(worktreePath, repo, repoPath, issueNumber, title, issueURL, state.Session{WorktreePath: worktreePath, Branch: branch})
+}
+
+func preflightPromptCommandForSession(worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, session state.Session) string {
 	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePreflightPrompt(
 		state.WatchTarget{Path: repoPath, Repo: repo},
 		ghcli.Issue{Number: issueNumber, Title: title, URL: issueURL},
-		state.Session{WorktreePath: worktreePath, Branch: branch},
+		session,
 	))
 }
 
 func issuePromptCommand(worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, branch string) string {
+	return issuePromptCommandForSession(worktreePath, repo, repoPath, issueNumber, title, issueURL, state.Session{WorktreePath: worktreePath, Branch: branch, Provider: "codex"})
+}
+
+func issuePromptCommandForSession(worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, session state.Session) string {
 	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePrompt(
 		state.WatchTarget{Path: repoPath, Repo: repo},
 		ghcli.Issue{Number: issueNumber, Title: title, URL: issueURL},
-		state.Session{WorktreePath: worktreePath, Branch: branch, Provider: "codex"},
+		session,
 	))
 }
 

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -162,6 +162,18 @@ func BuildIssuePromptForRuntime(runtime string, target state.WatchTarget, issue 
 		"Use the same GitHub comment structure for every non-terminal milestone comment: a short header with the current stage and optional emoji, a 10-cell progress bar with percentage, an `ETA: ~N minutes` line, 1-3 concise bullets covering what just happened and what is next, and an optional short playful quote or tagline.",
 		"Use the issue as the source of truth for the requested behavior and keep the implementation minimal.",
 	)
+	if strings.TrimSpace(session.ReusedRemoteBranch) != "" {
+		baseBranch := strings.TrimSpace(session.BaseBranch)
+		if baseBranch == "" {
+			baseBranch = "main"
+		}
+		lines = append(lines,
+			fmt.Sprintf("Existing remote issue branch detected: origin/%s", session.ReusedRemoteBranch),
+			fmt.Sprintf("Default branch for comparison: %s", baseBranch),
+			fmt.Sprintf("Diff summary against `%s`: %s", baseBranch, fallbackPromptText(session.BranchDiffSummary, "Diff analysis was requested but no summary was recorded.")),
+			"Continue from the reused branch state and build on top of the existing diff instead of restarting from scratch.",
+		)
+	}
 	return strings.Join(lines, "\n")
 }
 
@@ -204,6 +216,14 @@ func repoClassificationJSON(target state.WatchTarget) string {
 }
 
 func BuildIssuePreflightPrompt(target state.WatchTarget, issue ghcli.Issue, session state.Session) string {
+	baselineLine := fmt.Sprintf("Before implementing issue #%d, validate the repository baseline from the current `main`-derived worktree without making any file changes.", issue.Number)
+	if strings.TrimSpace(session.ReusedRemoteBranch) != "" {
+		baseBranch := strings.TrimSpace(session.BaseBranch)
+		if baseBranch == "" {
+			baseBranch = "main"
+		}
+		baselineLine = fmt.Sprintf("Before implementing issue #%d, validate the repository baseline from the current reused issue-branch worktree without making any file changes. This branch is being continued from `origin/%s` and compared against `%s`.", issue.Number, session.ReusedRemoteBranch, baseBranch)
+	}
 	lines := []string{
 		fmt.Sprintf("Repository: %s", target.Repo),
 		fmt.Sprintf("Local repository path: %s", target.Path),
@@ -211,7 +231,7 @@ func BuildIssuePreflightPrompt(target state.WatchTarget, issue ghcli.Issue, sess
 		fmt.Sprintf("Issue URL: %s", issue.URL),
 		fmt.Sprintf("Worktree path: %s", session.WorktreePath),
 		fmt.Sprintf("Branch: %s", session.Branch),
-		fmt.Sprintf("Before implementing issue #%d, validate the repository baseline from the current `main`-derived worktree without making any file changes.", issue.Number),
+		baselineLine,
 		"Detect and run the appropriate build or equivalent verification command for this repository.",
 		"Detect and run the existing test suite when tests are present; if no tests exist, state that clearly and continue.",
 		"If the baseline build or tests fail, exit with a non-zero status and summarize the failing validation in the final output.",
@@ -219,6 +239,13 @@ func BuildIssuePreflightPrompt(target state.WatchTarget, issue ghcli.Issue, sess
 		"Do not implement the issue, do not modify files, do not commit, and do not comment on GitHub during this preflight.",
 	}
 	return strings.Join(lines, "\n")
+}
+
+func fallbackPromptText(value string, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
 }
 
 func displayProviderName(name string) string {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -141,6 +141,30 @@ func TestBuildIssuePrompt(t *testing.T) {
 	}
 }
 
+func TestBuildIssuePromptIncludesReusedRemoteBranchContext(t *testing.T) {
+	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"}
+	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
+	session := state.Session{
+		WorktreePath:       "/tmp/worktree",
+		Branch:             "vigilante/issue-12-fix-bug",
+		BaseBranch:         "main",
+		ReusedRemoteBranch: "vigilante/issue-12-fix-bug",
+		BranchDiffSummary:  "README.md | 2 ++",
+		Provider:           "Codex",
+	}
+	prompt := BuildIssuePrompt(target, issue, session)
+	for _, text := range []string{
+		"Existing remote issue branch detected: origin/vigilante/issue-12-fix-bug",
+		"Default branch for comparison: main",
+		"Diff summary against `main`: README.md | 2 ++",
+		"Continue from the reused branch state",
+	} {
+		if !strings.Contains(prompt, text) {
+			t.Fatalf("prompt missing %q: %s", text, prompt)
+		}
+	}
+}
+
 func TestVigilanteSkillNamesIncludesLocalServiceDependencies(t *testing.T) {
 	found := false
 	for _, name := range VigilanteSkillNames() {
@@ -190,6 +214,27 @@ func TestBuildIssuePreflightPrompt(t *testing.T) {
 	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
 	prompt := BuildIssuePreflightPrompt(target, issue, session)
 	for _, text := range []string{"Repository: owner/repo", "Issue: #12 - Fix bug", "`main`-derived worktree", "build or equivalent verification command", "existing test suite", "Do not implement the issue", "do not comment on GitHub"} {
+		if !strings.Contains(prompt, text) {
+			t.Fatalf("prompt missing %q: %s", text, prompt)
+		}
+	}
+}
+
+func TestBuildIssuePreflightPromptForReusedRemoteBranch(t *testing.T) {
+	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
+	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
+	session := state.Session{
+		WorktreePath:       "/tmp/worktree",
+		Branch:             "vigilante/issue-12-fix-bug",
+		BaseBranch:         "main",
+		ReusedRemoteBranch: "vigilante/issue-12-fix-bug",
+	}
+	prompt := BuildIssuePreflightPrompt(target, issue, session)
+	for _, text := range []string{
+		"reused issue-branch worktree",
+		"origin/vigilante/issue-12-fix-bug",
+		"compared against `main`",
+	} {
 		if !strings.Contains(prompt, text) {
 			t.Fatalf("prompt missing %q: %s", text, prompt)
 		}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -59,8 +59,11 @@ type Session struct {
 	IssueNumber                  int           `json:"issue_number"`
 	IssueTitle                   string        `json:"issue_title,omitempty"`
 	IssueURL                     string        `json:"issue_url,omitempty"`
+	BaseBranch                   string        `json:"base_branch,omitempty"`
 	Branch                       string        `json:"branch"`
 	WorktreePath                 string        `json:"worktree_path"`
+	ReusedRemoteBranch           string        `json:"reused_remote_branch,omitempty"`
+	BranchDiffSummary            string        `json:"branch_diff_summary,omitempty"`
 	Status                       SessionStatus `json:"status"`
 	PullRequestNumber            int           `json:"pull_request_number,omitempty"`
 	PullRequestURL               string        `json:"pull_request_url,omitempty"`

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -22,6 +22,9 @@ func (f FakeRunner) Run(_ context.Context, _ string, name string, args ...string
 	if output, ok := f.Outputs[cmd]; ok {
 		return output, nil
 	}
+	if name == "git" && len(args) == 5 && args[0] == "ls-remote" && args[1] == "--exit-code" && args[2] == "--heads" && args[3] == "origin" {
+		return "", errors.New("exit status 2")
+	}
 	if len(args) == 1 && args[0] == "--version" {
 		return name + " 1.0.0", nil
 	}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -14,8 +14,9 @@ import (
 )
 
 type Worktree struct {
-	Path   string
-	Branch string
+	Path               string
+	Branch             string
+	ReusedRemoteBranch string
 }
 
 var nonAlnumPattern = regexp.MustCompile(`[^a-z0-9]+`)
@@ -34,16 +35,34 @@ func CreateIssueWorktree(ctx context.Context, runner environment.Runner, target 
 		return Worktree{}, err
 	}
 
-	args := []string{"worktree", "add", "-b", branch, path, target.Branch}
+	for _, candidate := range IssueBranchCandidates(issueNumber, issueTitle) {
+		exists, err := remoteBranchExistsWithError(ctx, runner, target.Path, candidate)
+		if err != nil {
+			return Worktree{}, err
+		}
+		if !exists {
+			continue
+		}
+		if _, err := runner.Run(ctx, target.Path, "git", "fetch", "origin", candidate+":"+candidate); err != nil {
+			return Worktree{}, fmt.Errorf("prepare remote issue branch %q: %w", candidate, err)
+		}
+		if _, err := runner.Run(ctx, target.Path, "git", "worktree", "add", path, candidate); err != nil {
+			return Worktree{}, fmt.Errorf("checkout remote issue branch %q into worktree: %w", candidate, err)
+		}
+		return Worktree{Path: path, Branch: candidate, ReusedRemoteBranch: candidate}, nil
+	}
+
 	for _, candidate := range IssueBranchCandidates(issueNumber, issueTitle) {
 		if branchExists(ctx, runner, target.Path, candidate) {
 			branch = candidate
-			args = []string{"worktree", "add", path, branch}
-			break
+			if _, err := runner.Run(ctx, target.Path, "git", "worktree", "add", path, branch); err != nil {
+				return Worktree{}, err
+			}
+			return Worktree{Path: path, Branch: branch}, nil
 		}
 	}
 
-	if _, err := runner.Run(ctx, target.Path, "git", args...); err != nil {
+	if _, err := runner.Run(ctx, target.Path, "git", "worktree", "add", "-b", branch, path, target.Branch); err != nil {
 		return Worktree{}, err
 	}
 	return Worktree{Path: path, Branch: branch}, nil
@@ -138,6 +157,17 @@ func branchExistsWithError(ctx context.Context, runner environment.Runner, repoP
 		return true, nil
 	}
 	if strings.Contains(err.Error(), "exit status 1") {
+		return false, nil
+	}
+	return false, err
+}
+
+func remoteBranchExistsWithError(ctx context.Context, runner environment.Runner, repoPath string, branch string) (bool, error) {
+	_, err := runner.Run(ctx, repoPath, "git", "ls-remote", "--exit-code", "--heads", "origin", branch)
+	if err == nil {
+		return true, nil
+	}
+	if strings.Contains(err.Error(), "exit status 1") || strings.Contains(err.Error(), "exit status 2") {
 		return false, nil
 	}
 	return false, err

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -81,6 +81,118 @@ func TestCreateIssueWorktreeReusesExistingLegacyBranch(t *testing.T) {
 	}
 }
 
+func TestCreateIssueWorktreeReusesExistingRemoteBranch(t *testing.T) {
+	home := t.TempDir()
+	repo := filepath.Join(home, "repo")
+	remote := filepath.Join(home, "remote.git")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(remote, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := environment.ExecRunner{}
+	ctx := context.Background()
+	mustRun(t, runner, ctx, remote, "git", "init", "--bare")
+	mustRun(t, runner, ctx, repo, "git", "init", "--initial-branch=main")
+	mustRun(t, runner, ctx, repo, "git", "config", "user.email", "test@example.com")
+	mustRun(t, runner, ctx, repo, "git", "config", "user.name", "Test User")
+	mustRun(t, runner, ctx, repo, "git", "remote", "add", "origin", remote)
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRun(t, runner, ctx, repo, "git", "add", "README.md")
+	mustRun(t, runner, ctx, repo, "git", "commit", "-m", "init")
+	mustRun(t, runner, ctx, repo, "git", "push", "-u", "origin", "main")
+	mustRun(t, runner, ctx, repo, "git", "checkout", "-b", "vigilante/issue-9-add-daemon-status-command")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hello\nremote change\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRun(t, runner, ctx, repo, "git", "commit", "-am", "remote work")
+	mustRun(t, runner, ctx, repo, "git", "push", "-u", "origin", "vigilante/issue-9-add-daemon-status-command")
+	mustRun(t, runner, ctx, repo, "git", "checkout", "main")
+	mustRun(t, runner, ctx, repo, "git", "branch", "-D", "vigilante/issue-9-add-daemon-status-command")
+
+	worktree, err := CreateIssueWorktree(ctx, runner, state.WatchTarget{Path: repo, Repo: "owner/repo", Branch: "main"}, 9, "Add daemon status command")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "vigilante/issue-9-add-daemon-status-command"; worktree.Branch != want {
+		t.Fatalf("unexpected branch: got %s want %s", worktree.Branch, want)
+	}
+	if worktree.ReusedRemoteBranch != worktree.Branch {
+		t.Fatalf("expected reused remote branch to be recorded: %#v", worktree)
+	}
+	data, err := os.ReadFile(filepath.Join(worktree.Path, "README.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "hello\nremote change\n" {
+		t.Fatalf("expected worktree to include remote branch content, got %q", string(data))
+	}
+}
+
+func TestCreateIssueWorktreePrefersPrimaryRemoteBranchOverLegacyFallback(t *testing.T) {
+	home := t.TempDir()
+	repo := filepath.Join(home, "repo")
+	remote := filepath.Join(home, "remote.git")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(remote, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := environment.ExecRunner{}
+	ctx := context.Background()
+	mustRun(t, runner, ctx, remote, "git", "init", "--bare")
+	mustRun(t, runner, ctx, repo, "git", "init", "--initial-branch=main")
+	mustRun(t, runner, ctx, repo, "git", "config", "user.email", "test@example.com")
+	mustRun(t, runner, ctx, repo, "git", "config", "user.name", "Test User")
+	mustRun(t, runner, ctx, repo, "git", "remote", "add", "origin", remote)
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRun(t, runner, ctx, repo, "git", "add", "README.md")
+	mustRun(t, runner, ctx, repo, "git", "commit", "-m", "init")
+	mustRun(t, runner, ctx, repo, "git", "push", "-u", "origin", "main")
+
+	mustRun(t, runner, ctx, repo, "git", "checkout", "-b", "vigilante/issue-9")
+	if err := os.WriteFile(filepath.Join(repo, "legacy.txt"), []byte("legacy\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRun(t, runner, ctx, repo, "git", "add", "legacy.txt")
+	mustRun(t, runner, ctx, repo, "git", "commit", "-m", "legacy work")
+	mustRun(t, runner, ctx, repo, "git", "push", "-u", "origin", "vigilante/issue-9")
+
+	mustRun(t, runner, ctx, repo, "git", "checkout", "main")
+	mustRun(t, runner, ctx, repo, "git", "checkout", "-b", "vigilante/issue-9-add-daemon-status-command")
+	if err := os.WriteFile(filepath.Join(repo, "primary.txt"), []byte("primary\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustRun(t, runner, ctx, repo, "git", "add", "primary.txt")
+	mustRun(t, runner, ctx, repo, "git", "commit", "-m", "primary work")
+	mustRun(t, runner, ctx, repo, "git", "push", "-u", "origin", "vigilante/issue-9-add-daemon-status-command")
+	mustRun(t, runner, ctx, repo, "git", "checkout", "main")
+	mustRun(t, runner, ctx, repo, "git", "branch", "-D", "vigilante/issue-9")
+	mustRun(t, runner, ctx, repo, "git", "branch", "-D", "vigilante/issue-9-add-daemon-status-command")
+
+	worktree, err := CreateIssueWorktree(ctx, runner, state.WatchTarget{Path: repo, Repo: "owner/repo", Branch: "main"}, 9, "Add daemon status command")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "vigilante/issue-9-add-daemon-status-command"; worktree.Branch != want {
+		t.Fatalf("unexpected branch: got %s want %s", worktree.Branch, want)
+	}
+	if _, err := os.Stat(filepath.Join(worktree.Path, "primary.txt")); err != nil {
+		t.Fatalf("expected primary remote branch contents: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(worktree.Path, "legacy.txt")); err == nil {
+		t.Fatalf("did not expect legacy-only file in preferred primary branch worktree")
+	}
+}
+
 func TestIssueTitleSlug(t *testing.T) {
 	tests := []struct {
 		title string


### PR DESCRIPTION
## Summary
- reuse matching remote issue branches during dispatch before falling back to fresh branch creation
- analyze the reused branch diff against the repo default branch and persist that context into the session and agent prompt flow
- add regression coverage for remote reuse, branch precedence, prompt/context handoff, and diff-analysis failures

## Testing
- go test ./...

Closes #131
