### PR TITLE
Fix macOS setup -d failures for Homebrew installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,19 @@ Expected behavior:
   - `vigilante-local-service-dependencies`
 - installs or updates the daemon definition when requested
 
+On macOS, `vigilante setup -d` resolves Homebrew-style symlinks before it prepares the daemon binary. The launchd plist still uses the invoked path, but Vigilante removes `com.apple.provenance` and `com.apple.quarantine` from the resolved binary when present, ad-hoc signs that binary, and runs `spctl --assess --type execute -vv` against the resolved path before loading the service.
+
+If Gatekeeper still rejects the binary, the error now reports both the assessed path and the invoked path when they differ. A useful manual recovery sequence is:
+
+```sh
+realbin="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' /opt/homebrew/bin/vigilante)"
+xattr "$realbin"
+xattr -d com.apple.provenance "$realbin" 2>/dev/null || true
+xattr -d com.apple.quarantine "$realbin" 2>/dev/null || true
+codesign --force --sign - "$realbin"
+spctl --assess --type execute -vv "$realbin"
+```
+
 ## Development Mode
 
 For fast local iteration, prefer running `vigilante` in the foreground instead of going through the installed OS service on every change.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -193,11 +193,8 @@ func TestWatchUpdatesExistingTarget(t *testing.T) {
 	app.stdout = &stdout
 	app.stderr = testutil.IODiscard{}
 	app.env.OS = "darwin"
-	executablePath, err := os.Executable()
-	if err != nil {
-		t.Fatal(err)
-	}
 	launchAgentPath := filepath.Join(home, "Library", "LaunchAgents", "com.vigilante.agent.plist")
+	executablePath := environment.ExecutablePath()
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: map[string]string{
@@ -208,9 +205,9 @@ func TestWatchUpdatesExistingTarget(t *testing.T) {
 			`/bin/sh -lc PATH="/usr/bin:/bin:/Users/test/.local/bin" command -v 'gh'`:     "/usr/bin/gh\n",
 			`/bin/sh -lc PATH="/usr/bin:/bin:/Users/test/.local/bin" command -v 'codex'`:  "/Users/test/.local/bin/codex\n",
 			`/bin/sh -lc PATH="/usr/bin:/bin:/Users/test/.local/bin" 'codex' --version`:   "codex 0.114.0\n",
-			testutil.Key("xattr", "-d", "com.apple.provenance", executablePath):           "",
+			testutil.Key("xattr", executablePath):                                         "",
 			testutil.Key("codesign", "--force", "--sign", "-", executablePath):            "",
-			testutil.Key("spctl", "--assess", "--type", "execute", "-vv", executablePath): "accepted\n",
+			testutil.Key("spctl", "--assess", "--type", "execute", "-vv", executablePath): "",
 			testutil.Key("launchctl", "unload", launchAgentPath):                          "",
 			testutil.Key("launchctl", "load", launchAgentPath):                            "",
 			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                     "true\n",

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -37,6 +37,9 @@ func Install(ctx context.Context, env *environment.Environment, store *state.Sto
 }
 
 func installLaunchdService(ctx context.Context, env *environment.Environment, store *state.Store, cfg Config) error {
+	if err := prepareMacOSDaemonBinary(ctx, env.Runner, cfg.Executable); err != nil {
+		return err
+	}
 	dir := filepath.Join(cfg.HomeDir, "Library", "LaunchAgents")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
@@ -45,27 +48,10 @@ func installLaunchdService(ctx context.Context, env *environment.Environment, st
 	if err := os.WriteFile(path, []byte(RenderLaunchdPlist(store, cfg)), 0o644); err != nil {
 		return err
 	}
-	if err := prepareLaunchdBinary(ctx, env, cfg.Executable); err != nil {
-		return err
-	}
 	_, _ = env.Runner.Run(ctx, "", "launchctl", "unload", path)
 	if _, err := env.Runner.Run(ctx, "", "launchctl", "load", path); err != nil {
 		return err
 	}
-	return nil
-}
-
-func prepareLaunchdBinary(ctx context.Context, env *environment.Environment, executable string) error {
-	_, _ = env.Runner.Run(ctx, "", "xattr", "-d", "com.apple.provenance", executable)
-
-	if output, err := env.Runner.Run(ctx, "", "codesign", "--force", "--sign", "-", executable); err != nil {
-		return fmt.Errorf("prepare macOS daemon binary %q for launchd: %s", executable, commandFailure("codesign", output, err))
-	}
-
-	if output, err := env.Runner.Run(ctx, "", "spctl", "--assess", "--type", "execute", "-vv", executable); err != nil {
-		return fmt.Errorf("macOS rejected daemon binary %q: %s", executable, commandFailure("spctl", output, err))
-	}
-
 	return nil
 }
 
@@ -243,10 +229,63 @@ func shellQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
 }
 
-func commandFailure(command string, output string, err error) string {
-	output = strings.TrimSpace(output)
-	if output == "" {
-		return fmt.Sprintf("%s failed: %v", command, err)
+func prepareMacOSDaemonBinary(ctx context.Context, runner environment.Runner, executable string) error {
+	resolvedPath, err := filepath.EvalSymlinks(executable)
+	if err != nil {
+		return fmt.Errorf("resolve macOS daemon binary %q: %w", executable, err)
 	}
-	return fmt.Sprintf("%s failed: %v (%s)", command, err, output)
+
+	attrs, err := listExtendedAttributes(ctx, runner, resolvedPath)
+	if err != nil {
+		return fmt.Errorf("inspect macOS extended attributes for daemon binary %q: %w", resolvedPath, err)
+	}
+
+	removedAttrs := []string{}
+	for _, attr := range []string{"com.apple.provenance", "com.apple.quarantine"} {
+		if _, ok := attrs[attr]; !ok {
+			continue
+		}
+		if _, err := runner.Run(ctx, "", "xattr", "-d", attr, resolvedPath); err != nil {
+			return fmt.Errorf("remove macOS extended attribute %q from daemon binary %q: %w", attr, resolvedPath, err)
+		}
+		removedAttrs = append(removedAttrs, attr)
+	}
+
+	if _, err := runner.Run(ctx, "", "codesign", "--force", "--sign", "-", resolvedPath); err != nil {
+		return fmt.Errorf("ad-hoc sign macOS daemon binary %s: %w", macOSBinaryContext(executable, resolvedPath, removedAttrs), err)
+	}
+	if _, err := runner.Run(ctx, "", "spctl", "--assess", "--type", "execute", "-vv", resolvedPath); err != nil {
+		return fmt.Errorf("macOS rejected daemon binary %s: %w", macOSBinaryContext(executable, resolvedPath, removedAttrs), err)
+	}
+
+	return nil
+}
+
+func listExtendedAttributes(ctx context.Context, runner environment.Runner, path string) (map[string]struct{}, error) {
+	output, err := runner.Run(ctx, "", "xattr", path)
+	if err != nil {
+		return nil, err
+	}
+
+	attrs := map[string]struct{}{}
+	for _, line := range strings.Split(output, "\n") {
+		attr := strings.TrimSpace(line)
+		if attr == "" {
+			continue
+		}
+		attrs[attr] = struct{}{}
+	}
+	return attrs, nil
+}
+
+func macOSBinaryContext(executable string, resolvedPath string, removedAttrs []string) string {
+	context := fmt.Sprintf("assessed_path=%q", resolvedPath)
+	if filepath.Clean(executable) != filepath.Clean(resolvedPath) {
+		context += fmt.Sprintf(" invoked_path=%q", executable)
+	}
+	if len(removedAttrs) == 0 {
+		context += " removed_xattrs=none"
+		return context
+	}
+	return context + fmt.Sprintf(" removed_xattrs=%s", strings.Join(removedAttrs, ","))
 }

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -3,7 +3,9 @@ package service
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -12,6 +14,16 @@ import (
 	"github.com/nicobistolfi/vigilante/internal/state"
 	"github.com/nicobistolfi/vigilante/internal/testutil"
 )
+
+type recordingRunner struct {
+	testutil.FakeRunner
+	calls []string
+}
+
+func (r *recordingRunner) Run(ctx context.Context, dir string, name string, args ...string) (string, error) {
+	r.calls = append(r.calls, testutil.Key(name, args...))
+	return r.FakeRunner.Run(ctx, dir, name, args...)
+}
 
 func TestRenderLaunchdPlist(t *testing.T) {
 	t.Setenv("VIGILANTE_HOME", t.TempDir())
@@ -200,63 +212,123 @@ func TestBuildConfigFailsWhenProviderVersionIsIncompatible(t *testing.T) {
 	}
 }
 
-func TestInstallLaunchdServicePreparesBinaryBeforeReload(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	store := state.NewStore()
-	cfg := Config{
-		Executable: filepath.Join(home, ".local", "bin", "vigilante"),
-		PathEnv:    "/opt/homebrew/bin:/usr/bin:/bin",
-		HomeDir:    home,
+func TestPrepareMacOSDaemonBinaryUsesResolvedPath(t *testing.T) {
+	dir := t.TempDir()
+	resolvedPath := filepath.Join(dir, "Caskroom", "vigilante", "1.2.3", "vigilante")
+	if err := os.MkdirAll(filepath.Dir(resolvedPath), 0o755); err != nil {
+		t.Fatal(err)
 	}
-	launchAgentPath := filepath.Join(home, "Library", "LaunchAgents", "com.vigilante.agent.plist")
-	env := &environment.Environment{
-		OS: "darwin",
-		Runner: testutil.FakeRunner{
+	if err := os.WriteFile(resolvedPath, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	invokedPath := filepath.Join(dir, "bin", "vigilante")
+	if err := os.MkdirAll(filepath.Dir(invokedPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(resolvedPath, invokedPath); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &recordingRunner{
+		FakeRunner: testutil.FakeRunner{
 			Outputs: map[string]string{
-				testutil.Key("xattr", "-d", "com.apple.provenance", cfg.Executable):           "",
-				testutil.Key("codesign", "--force", "--sign", "-", cfg.Executable):            "",
-				testutil.Key("spctl", "--assess", "--type", "execute", "-vv", cfg.Executable): "accepted\n",
-				testutil.Key("launchctl", "unload", launchAgentPath):                          "",
-				testutil.Key("launchctl", "load", launchAgentPath):                            "",
+				testutil.Key("xattr", resolvedPath):                                         "com.apple.provenance\ncom.apple.quarantine\ncom.example.keep\n",
+				testutil.Key("xattr", "-d", "com.apple.provenance", resolvedPath):           "",
+				testutil.Key("xattr", "-d", "com.apple.quarantine", resolvedPath):           "",
+				testutil.Key("codesign", "--force", "--sign", "-", resolvedPath):            "",
+				testutil.Key("spctl", "--assess", "--type", "execute", "-vv", resolvedPath): "",
 			},
 		},
 	}
 
-	if err := installLaunchdService(context.Background(), env, store, cfg); err != nil {
+	if err := prepareMacOSDaemonBinary(context.Background(), runner, invokedPath); err != nil {
 		t.Fatal(err)
+	}
+
+	wantCalls := []string{
+		testutil.Key("xattr", resolvedPath),
+		testutil.Key("xattr", "-d", "com.apple.provenance", resolvedPath),
+		testutil.Key("xattr", "-d", "com.apple.quarantine", resolvedPath),
+		testutil.Key("codesign", "--force", "--sign", "-", resolvedPath),
+		testutil.Key("spctl", "--assess", "--type", "execute", "-vv", resolvedPath),
+	}
+	if !reflect.DeepEqual(runner.calls, wantCalls) {
+		t.Fatalf("unexpected command sequence:\n got: %#v\nwant: %#v", runner.calls, wantCalls)
 	}
 }
 
-func TestInstallLaunchdServiceFailsWhenBinaryStillRejected(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	store := state.NewStore()
-	cfg := Config{
-		Executable: filepath.Join(home, ".local", "bin", "vigilante"),
-		PathEnv:    "/opt/homebrew/bin:/usr/bin:/bin",
-		HomeDir:    home,
+func TestPrepareMacOSDaemonBinarySkipsMissingKnownAttrs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vigilante")
+	if err := os.WriteFile(path, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
 	}
-	env := &environment.Environment{
-		OS: "darwin",
-		Runner: testutil.FakeRunner{
+
+	runner := &recordingRunner{
+		FakeRunner: testutil.FakeRunner{
 			Outputs: map[string]string{
-				testutil.Key("xattr", "-d", "com.apple.provenance", cfg.Executable): "",
-				testutil.Key("codesign", "--force", "--sign", "-", cfg.Executable):  "",
-			},
-			Errors: map[string]error{
-				testutil.Key("spctl", "--assess", "--type", "execute", "-vv", cfg.Executable): errors.New("exit status 3"),
+				testutil.Key("xattr", path):                                         "com.example.keep\n",
+				testutil.Key("codesign", "--force", "--sign", "-", path):            "",
+				testutil.Key("spctl", "--assess", "--type", "execute", "-vv", path): "",
 			},
 		},
 	}
 
-	err := installLaunchdService(context.Background(), env, store, cfg)
+	if err := prepareMacOSDaemonBinary(context.Background(), runner, path); err != nil {
+		t.Fatal(err)
+	}
+
+	wantCalls := []string{
+		testutil.Key("xattr", path),
+		testutil.Key("codesign", "--force", "--sign", "-", path),
+		testutil.Key("spctl", "--assess", "--type", "execute", "-vv", path),
+	}
+	if !reflect.DeepEqual(runner.calls, wantCalls) {
+		t.Fatalf("unexpected command sequence:\n got: %#v\nwant: %#v", runner.calls, wantCalls)
+	}
+}
+
+func TestPrepareMacOSDaemonBinaryReportsSymlinkContextOnSpctlFailure(t *testing.T) {
+	dir := t.TempDir()
+	resolvedPath := filepath.Join(dir, "Caskroom", "vigilante", "1.2.3", "vigilante")
+	if err := os.MkdirAll(filepath.Dir(resolvedPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(resolvedPath, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	invokedPath := filepath.Join(dir, "bin", "vigilante")
+	if err := os.MkdirAll(filepath.Dir(invokedPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(resolvedPath, invokedPath); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &recordingRunner{
+		FakeRunner: testutil.FakeRunner{
+			Outputs: map[string]string{
+				testutil.Key("xattr", resolvedPath):                              "",
+				testutil.Key("codesign", "--force", "--sign", "-", resolvedPath): "",
+			},
+			Errors: map[string]error{
+				testutil.Key("spctl", "--assess", "--type", "execute", "-vv", resolvedPath): errors.New("exit status 3 (/opt/homebrew/bin/vigilante: rejected)"),
+			},
+		},
+	}
+
+	err := prepareMacOSDaemonBinary(context.Background(), runner, invokedPath)
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "macOS rejected daemon binary") || !strings.Contains(err.Error(), "spctl failed") {
-		t.Fatalf("unexpected error: %v", err)
+	if !strings.Contains(err.Error(), resolvedPath) {
+		t.Fatalf("error missing resolved path: %v", err)
+	}
+	if !strings.Contains(err.Error(), invokedPath) {
+		t.Fatalf("error missing invoked path: %v", err)
+	}
+	if !strings.Contains(err.Error(), "removed_xattrs=none") {
+		t.Fatalf("error missing xattr context: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- resolve the macOS daemon binary symlink before xattr cleanup, ad-hoc signing, and `spctl` assessment
- remove `com.apple.provenance` and `com.apple.quarantine` when present, while keeping missing attrs non-fatal
- document the Homebrew/macOS recovery flow and cover the new behavior with unit tests

Closes #153.

## Validation
- `go test ./...`
- `go build ./...`
