### PR TITLE
Add monorepo stack routing and compose-launch contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,15 @@ Expected behavior:
 - installs the bundled coding-agent skills for regular runtime use, including any companion files under each skill directory
   - `vigilante-issue-implementation`
   - `vigilante-issue-implementation-on-monorepo`
+  - `vigilante-issue-implementation-on-turborepo`
+  - `vigilante-issue-implementation-on-nx`
+  - `vigilante-issue-implementation-on-rush`
+  - `vigilante-issue-implementation-on-bazel`
+  - `vigilante-issue-implementation-on-gradle`
   - `vigilante-conflict-resolution`
   - `vigilante-create-issue`
   - `vigilante-local-service-dependencies`
+  - `docker-compose-launch`
 - installs or updates the daemon definition when requested
 
 On macOS, `vigilante setup -d` resolves Homebrew-style symlinks before it prepares the daemon binary. The launchd plist still uses the invoked path, but Vigilante removes `com.apple.provenance` and `com.apple.quarantine` from the resolved binary when present, ad-hoc signs that binary, and runs `spctl --assess --type execute -vv` against the resolved path before loading the service.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -90,7 +90,9 @@ func TestSetupCreatesStateLayoutAndSkill(t *testing.T) {
 		filepath.Join(app.state.Root(), "logs"),
 		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteIssueImplementation, "SKILL.md"),
 		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteIssueImplementationOnMonorepo, "SKILL.md"),
+		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteIssueImplementationOnTurborepo, "SKILL.md"),
 		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteConflictResolution, "SKILL.md"),
+		filepath.Join(app.state.CodexHome(), "skills", skill.DockerComposeLaunch, "SKILL.md"),
 	} {
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("expected %s to exist: %v", path, err)

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -20,6 +20,17 @@ const (
 	ShapeMonorepo    Shape = "monorepo"
 )
 
+type MonorepoStack string
+
+const (
+	MonorepoStackUnknown   MonorepoStack = "unknown"
+	MonorepoStackTurborepo MonorepoStack = "turborepo"
+	MonorepoStackNx        MonorepoStack = "nx"
+	MonorepoStackRush      MonorepoStack = "rush"
+	MonorepoStackBazel     MonorepoStack = "bazel"
+	MonorepoStackGradle    MonorepoStack = "gradle"
+)
+
 type ProcessHints struct {
 	WorkspaceConfigFiles   []string `json:"workspace_config_files,omitempty"`
 	WorkspaceManifestFiles []string `json:"workspace_manifest_files,omitempty"`
@@ -27,8 +38,9 @@ type ProcessHints struct {
 }
 
 type Classification struct {
-	Shape        Shape        `json:"shape"`
-	ProcessHints ProcessHints `json:"process_hints,omitempty"`
+	Shape         Shape         `json:"shape"`
+	MonorepoStack MonorepoStack `json:"monorepo_stack,omitempty"`
+	ProcessHints  ProcessHints  `json:"process_hints,omitempty"`
 }
 
 type Info struct {
@@ -98,11 +110,32 @@ func Classify(path string) Classification {
 		len(classification.ProcessHints.WorkspaceManifestFiles) > 0 ||
 		len(classification.ProcessHints.MultiPackageRoots) >= 2 {
 		classification.Shape = ShapeMonorepo
+		classification.MonorepoStack = detectMonorepoStack(absPath)
 	}
 	slices.Sort(classification.ProcessHints.WorkspaceConfigFiles)
 	slices.Sort(classification.ProcessHints.WorkspaceManifestFiles)
 	slices.Sort(classification.ProcessHints.MultiPackageRoots)
 	return classification
+}
+
+func detectMonorepoStack(absPath string) MonorepoStack {
+	switch {
+	case fileExists(filepath.Join(absPath, "turbo.json")):
+		return MonorepoStackTurborepo
+	case fileExists(filepath.Join(absPath, "nx.json")):
+		return MonorepoStackNx
+	case fileExists(filepath.Join(absPath, "rush.json")):
+		return MonorepoStackRush
+	case fileExists(filepath.Join(absPath, "WORKSPACE")) ||
+		fileExists(filepath.Join(absPath, "WORKSPACE.bazel")) ||
+		fileExists(filepath.Join(absPath, "MODULE.bazel")):
+		return MonorepoStackBazel
+	case fileExists(filepath.Join(absPath, "settings.gradle")) ||
+		fileExists(filepath.Join(absPath, "settings.gradle.kts")):
+		return MonorepoStackGradle
+	default:
+		return MonorepoStackUnknown
+	}
 }
 
 func ParseGitHubRepo(remote string) (string, error) {

--- a/internal/repo/repo_test.go
+++ b/internal/repo/repo_test.go
@@ -66,14 +66,20 @@ func TestClassifyMonorepoFromWorkspaceSignals(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "pnpm-workspace.yaml"), []byte("packages:\n  - apps/*\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(dir, "turbo.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	got := Classify(dir)
 
 	if got.Shape != ShapeMonorepo {
 		t.Fatalf("expected monorepo classification, got %#v", got)
 	}
-	if len(got.ProcessHints.WorkspaceConfigFiles) != 1 || got.ProcessHints.WorkspaceConfigFiles[0] != "pnpm-workspace.yaml" {
-		t.Fatalf("expected workspace config hint, got %#v", got.ProcessHints)
+	if len(got.ProcessHints.WorkspaceConfigFiles) != 2 {
+		t.Fatalf("expected workspace config hints, got %#v", got.ProcessHints)
+	}
+	if got.MonorepoStack != MonorepoStackTurborepo {
+		t.Fatalf("expected turborepo stack, got %#v", got)
 	}
 }
 
@@ -90,6 +96,25 @@ func TestClassifyFallsBackSafelyForAmbiguousRepo(t *testing.T) {
 	}
 	if len(got.ProcessHints.MultiPackageRoots) != 1 || got.ProcessHints.MultiPackageRoots[0] != "apps" {
 		t.Fatalf("expected ambiguous multi-package hint to be preserved, got %#v", got.ProcessHints)
+	}
+	if got.MonorepoStack != "" {
+		t.Fatalf("expected no monorepo stack for traditional repo fallback, got %#v", got)
+	}
+}
+
+func TestClassifyMonorepoUsesUnknownStackFallback(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "pnpm-workspace.yaml"), []byte("packages:\n  - apps/*\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Classify(dir)
+
+	if got.Shape != ShapeMonorepo {
+		t.Fatalf("expected monorepo classification, got %#v", got)
+	}
+	if got.MonorepoStack != MonorepoStackUnknown {
+		t.Fatalf("expected unknown monorepo stack fallback, got %#v", got)
 	}
 }
 

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -298,9 +298,10 @@ func TestRunIssueSessionUsesMonorepoSkillWhenClassified(t *testing.T) {
 		Path: "/tmp/repo",
 		Repo: "owner/repo",
 		Classification: repo.Classification{
-			Shape: repo.ShapeMonorepo,
+			Shape:         repo.ShapeMonorepo,
+			MonorepoStack: repo.MonorepoStackTurborepo,
 			ProcessHints: repo.ProcessHints{
-				WorkspaceConfigFiles: []string{"pnpm-workspace.yaml"},
+				WorkspaceConfigFiles: []string{"pnpm-workspace.yaml", "turbo.json"},
 				MultiPackageRoots:    []string{"apps", "packages"},
 			},
 		},

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -17,9 +17,15 @@ import (
 
 const VigilanteIssueImplementation = "vigilante-issue-implementation"
 const VigilanteIssueImplementationOnMonorepo = "vigilante-issue-implementation-on-monorepo"
+const VigilanteIssueImplementationOnTurborepo = "vigilante-issue-implementation-on-turborepo"
+const VigilanteIssueImplementationOnNx = "vigilante-issue-implementation-on-nx"
+const VigilanteIssueImplementationOnRush = "vigilante-issue-implementation-on-rush"
+const VigilanteIssueImplementationOnBazel = "vigilante-issue-implementation-on-bazel"
+const VigilanteIssueImplementationOnGradle = "vigilante-issue-implementation-on-gradle"
 const VigilanteConflictResolution = "vigilante-conflict-resolution"
 const VigilanteCreateIssue = "vigilante-create-issue"
 const VigilanteLocalServiceDependencies = "vigilante-local-service-dependencies"
+const DockerComposeLaunch = "docker-compose-launch"
 
 const RuntimeCodex = "codex"
 const RuntimeClaude = "claude"
@@ -29,9 +35,15 @@ func VigilanteSkillNames() []string {
 	return []string{
 		VigilanteIssueImplementation,
 		VigilanteIssueImplementationOnMonorepo,
+		VigilanteIssueImplementationOnTurborepo,
+		VigilanteIssueImplementationOnNx,
+		VigilanteIssueImplementationOnRush,
+		VigilanteIssueImplementationOnBazel,
+		VigilanteIssueImplementationOnGradle,
 		VigilanteConflictResolution,
 		VigilanteCreateIssue,
 		VigilanteLocalServiceDependencies,
+		DockerComposeLaunch,
 	}
 }
 
@@ -174,14 +186,34 @@ func BuildIssuePromptForRuntime(runtime string, target state.WatchTarget, issue 
 			"Continue from the reused branch state and build on top of the existing diff instead of restarting from scratch.",
 		)
 	}
+	if normalizedRepoShape(target) == string(repo.ShapeMonorepo) {
+		lines = append(lines,
+			fmt.Sprintf("Detected monorepo stack: %s", normalizedMonorepoStack(target)),
+			fmt.Sprintf("Monorepo execution context JSON: %s", monorepoExecutionContextJSON(target, selectedSkill)),
+			fmt.Sprintf("When local services are required, use the `%s` skill instead of inventing ad hoc compose logic.", DockerComposeLaunch),
+		)
+	}
 	return strings.Join(lines, "\n")
 }
 
 func IssueImplementationSkill(target state.WatchTarget) string {
-	if normalizedRepoShape(target) == string(repo.ShapeMonorepo) {
+	if normalizedRepoShape(target) != string(repo.ShapeMonorepo) {
+		return VigilanteIssueImplementation
+	}
+	switch normalizedMonorepoStack(target) {
+	case string(repo.MonorepoStackTurborepo):
+		return VigilanteIssueImplementationOnTurborepo
+	case string(repo.MonorepoStackNx):
+		return VigilanteIssueImplementationOnNx
+	case string(repo.MonorepoStackRush):
+		return VigilanteIssueImplementationOnRush
+	case string(repo.MonorepoStackBazel):
+		return VigilanteIssueImplementationOnBazel
+	case string(repo.MonorepoStackGradle):
+		return VigilanteIssueImplementationOnGradle
+	default:
 		return VigilanteIssueImplementationOnMonorepo
 	}
-	return VigilanteIssueImplementation
 }
 
 func normalizedRepoShape(target state.WatchTarget) string {
@@ -192,16 +224,31 @@ func normalizedRepoShape(target state.WatchTarget) string {
 	return shape
 }
 
+func normalizedMonorepoStack(target state.WatchTarget) string {
+	stack := strings.TrimSpace(string(target.Classification.MonorepoStack))
+	if stack == "" && normalizedRepoShape(target) == string(repo.ShapeMonorepo) {
+		return string(repo.MonorepoStackUnknown)
+	}
+	return stack
+}
+
 func repoClassificationJSON(target state.WatchTarget) string {
 	classification := target.Classification
 	if strings.TrimSpace(string(classification.Shape)) == "" {
 		classification.Shape = repo.ShapeTraditional
 	}
 	payload := struct {
-		Shape        repo.Shape         `json:"shape"`
-		ProcessHints *repo.ProcessHints `json:"process_hints,omitempty"`
+		Shape         repo.Shape         `json:"shape"`
+		MonorepoStack repo.MonorepoStack `json:"monorepo_stack,omitempty"`
+		ProcessHints  *repo.ProcessHints `json:"process_hints,omitempty"`
 	}{
 		Shape: classification.Shape,
+	}
+	if classification.Shape == repo.ShapeMonorepo {
+		if strings.TrimSpace(string(classification.MonorepoStack)) == "" {
+			classification.MonorepoStack = repo.MonorepoStackUnknown
+		}
+		payload.MonorepoStack = classification.MonorepoStack
 	}
 	if len(classification.ProcessHints.WorkspaceConfigFiles) > 0 ||
 		len(classification.ProcessHints.WorkspaceManifestFiles) > 0 ||
@@ -211,6 +258,39 @@ func repoClassificationJSON(target state.WatchTarget) string {
 	data, err := json.Marshal(payload)
 	if err != nil {
 		return `{"shape":"traditional"}`
+	}
+	return string(data)
+}
+
+func monorepoExecutionContextJSON(target state.WatchTarget, selectedSkill string) string {
+	payload := struct {
+		Stack               string             `json:"stack"`
+		ImplementationSkill string             `json:"implementation_skill"`
+		ProcessHints        *repo.ProcessHints `json:"process_hints,omitempty"`
+		LocalServices       struct {
+			Required              bool     `json:"required"`
+			LaunchSkill           string   `json:"launch_skill"`
+			Scope                 string   `json:"scope"`
+			SupportedServiceTypes []string `json:"supported_service_types"`
+			OutputFields          []string `json:"output_fields"`
+		} `json:"local_services"`
+	}{
+		Stack:               normalizedMonorepoStack(target),
+		ImplementationSkill: selectedSkill,
+	}
+	if len(target.Classification.ProcessHints.WorkspaceConfigFiles) > 0 ||
+		len(target.Classification.ProcessHints.WorkspaceManifestFiles) > 0 ||
+		len(target.Classification.ProcessHints.MultiPackageRoots) > 0 {
+		payload.ProcessHints = &target.Classification.ProcessHints
+	}
+	payload.LocalServices.Required = false
+	payload.LocalServices.LaunchSkill = DockerComposeLaunch
+	payload.LocalServices.Scope = "assigned_worktree"
+	payload.LocalServices.SupportedServiceTypes = []string{"mysql", "mariadb", "postgres", "mongodb"}
+	payload.LocalServices.OutputFields = []string{"status", "services", "mechanism", "commands", "connection", "cleanup", "artifacts", "notes"}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Sprintf(`{"stack":"%s","implementation_skill":"%s"}`, normalizedMonorepoStack(target), selectedSkill)
 	}
 	return string(data)
 }

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -166,15 +166,21 @@ func TestBuildIssuePromptIncludesReusedRemoteBranchContext(t *testing.T) {
 }
 
 func TestVigilanteSkillNamesIncludesLocalServiceDependencies(t *testing.T) {
-	found := false
+	foundLocalServices := false
+	foundComposeLaunch := false
 	for _, name := range VigilanteSkillNames() {
 		if name == VigilanteLocalServiceDependencies {
-			found = true
-			break
+			foundLocalServices = true
+		}
+		if name == DockerComposeLaunch {
+			foundComposeLaunch = true
 		}
 	}
-	if !found {
+	if !foundLocalServices {
 		t.Fatalf("expected %s to be bundled", VigilanteLocalServiceDependencies)
+	}
+	if !foundComposeLaunch {
+		t.Fatalf("expected %s to be bundled", DockerComposeLaunch)
 	}
 }
 
@@ -183,9 +189,10 @@ func TestBuildIssuePromptSelectsMonorepoSkill(t *testing.T) {
 		Path: "/tmp/repo",
 		Repo: "owner/repo",
 		Classification: repo.Classification{
-			Shape: repo.ShapeMonorepo,
+			Shape:         repo.ShapeMonorepo,
+			MonorepoStack: repo.MonorepoStackTurborepo,
 			ProcessHints: repo.ProcessHints{
-				WorkspaceConfigFiles: []string{"pnpm-workspace.yaml"},
+				WorkspaceConfigFiles: []string{"pnpm-workspace.yaml", "turbo.json"},
 				MultiPackageRoots:    []string{"apps", "packages"},
 			},
 		},
@@ -196,11 +203,42 @@ func TestBuildIssuePromptSelectsMonorepoSkill(t *testing.T) {
 	prompt := BuildIssuePrompt(target, issue, session)
 
 	for _, text := range []string{
-		"Use the `vigilante-issue-implementation-on-monorepo` skill",
+		"Use the `vigilante-issue-implementation-on-turborepo` skill",
 		"Detected repo shape: monorepo",
-		"Selected issue implementation skill: vigilante-issue-implementation-on-monorepo",
-		`"workspace_config_files":["pnpm-workspace.yaml"]`,
+		"Detected monorepo stack: turborepo",
+		"Selected issue implementation skill: vigilante-issue-implementation-on-turborepo",
+		`"monorepo_stack":"turborepo"`,
+		`"implementation_skill":"vigilante-issue-implementation-on-turborepo"`,
+		`"workspace_config_files":["pnpm-workspace.yaml","turbo.json"]`,
+		`"turbo.json"`,
 		`"multi_package_roots":["apps","packages"]`,
+		`"launch_skill":"docker-compose-launch"`,
+		`"supported_service_types":["mysql","mariadb","postgres","mongodb"]`,
+	} {
+		if !strings.Contains(prompt, text) {
+			t.Fatalf("prompt missing %q: %s", text, prompt)
+		}
+	}
+}
+
+func TestBuildIssuePromptFallsBackForUnknownMonorepoStack(t *testing.T) {
+	target := state.WatchTarget{
+		Path: "/tmp/repo",
+		Repo: "owner/repo",
+		Classification: repo.Classification{
+			Shape:         repo.ShapeMonorepo,
+			MonorepoStack: repo.MonorepoStackUnknown,
+		},
+	}
+	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
+	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
+
+	prompt := BuildIssuePrompt(target, issue, session)
+
+	for _, text := range []string{
+		"Use the `vigilante-issue-implementation-on-monorepo` skill",
+		"Detected monorepo stack: unknown",
+		"Selected issue implementation skill: vigilante-issue-implementation-on-monorepo",
 	} {
 		if !strings.Contains(prompt, text) {
 			t.Fatalf("prompt missing %q: %s", text, prompt)
@@ -361,6 +399,28 @@ func TestIssueImplementationSkillDefaultsToTraditional(t *testing.T) {
 	}
 }
 
+func TestIssueImplementationSkillMapsKnownMonorepoStacks(t *testing.T) {
+	tests := map[repo.MonorepoStack]string{
+		repo.MonorepoStackTurborepo: VigilanteIssueImplementationOnTurborepo,
+		repo.MonorepoStackNx:        VigilanteIssueImplementationOnNx,
+		repo.MonorepoStackRush:      VigilanteIssueImplementationOnRush,
+		repo.MonorepoStackBazel:     VigilanteIssueImplementationOnBazel,
+		repo.MonorepoStackGradle:    VigilanteIssueImplementationOnGradle,
+		repo.MonorepoStackUnknown:   VigilanteIssueImplementationOnMonorepo,
+	}
+	for stack, want := range tests {
+		target := state.WatchTarget{
+			Classification: repo.Classification{
+				Shape:         repo.ShapeMonorepo,
+				MonorepoStack: stack,
+			},
+		}
+		if got := IssueImplementationSkill(target); got != want {
+			t.Fatalf("stack %s: got %s want %s", stack, got, want)
+		}
+	}
+}
+
 func TestVigilanteCreateIssueSkillCoversIssueTypeClassification(t *testing.T) {
 	body, err := os.ReadFile(repoSkillPath(VigilanteCreateIssue))
 	if err != nil {
@@ -426,13 +486,45 @@ func TestLocalServiceDependenciesSkillCoversStructuredOutputAndFailureModes(t *t
 }
 
 func TestIssueImplementationSkillsReferenceLocalServiceDependencySkill(t *testing.T) {
-	for _, name := range []string{VigilanteIssueImplementation, VigilanteIssueImplementationOnMonorepo} {
+	for _, name := range []string{
+		VigilanteIssueImplementationOnMonorepo,
+		VigilanteIssueImplementationOnTurborepo,
+		VigilanteIssueImplementationOnNx,
+		VigilanteIssueImplementationOnRush,
+		VigilanteIssueImplementationOnBazel,
+		VigilanteIssueImplementationOnGradle,
+	} {
 		body, err := os.ReadFile(repoSkillPath(name))
 		if err != nil {
 			t.Fatal(err)
 		}
-		if !strings.Contains(string(body), VigilanteLocalServiceDependencies) {
+		text := string(body)
+		if !strings.Contains(text, VigilanteLocalServiceDependencies) {
 			t.Fatalf("%s does not mention %s", name, VigilanteLocalServiceDependencies)
+		}
+		if !strings.Contains(text, DockerComposeLaunch) {
+			t.Fatalf("%s does not mention %s", name, DockerComposeLaunch)
+		}
+	}
+}
+
+func TestDockerComposeLaunchSkillDocumentsSharedContract(t *testing.T) {
+	body, err := os.ReadFile(repoSkillPath(DockerComposeLaunch))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	text := string(body)
+	for _, snippet := range []string{
+		"assigned worktree",
+		"`required`: `true` or `false`",
+		"`service_types`: one or more of `mysql`, `mariadb`, `postgres`, or `mongodb`",
+		"`status`: `ready`, `not_needed`, or `failed`",
+		"`connection`",
+		"`cleanup`",
+	} {
+		if !strings.Contains(text, snippet) {
+			t.Fatalf("skill missing %q", snippet)
 		}
 	}
 }

--- a/skillassets.go
+++ b/skillassets.go
@@ -4,5 +4,5 @@ import "embed"
 
 // Skills contains built-in runtime skill files for installed binaries.
 //
-//go:embed skills/vigilante-issue-implementation skills/vigilante-issue-implementation-on-monorepo skills/vigilante-conflict-resolution skills/vigilante-create-issue skills/vigilante-local-service-dependencies
+//go:embed skills/vigilante-issue-implementation skills/vigilante-issue-implementation-on-monorepo skills/vigilante-issue-implementation-on-turborepo skills/vigilante-issue-implementation-on-nx skills/vigilante-issue-implementation-on-rush skills/vigilante-issue-implementation-on-bazel skills/vigilante-issue-implementation-on-gradle skills/vigilante-conflict-resolution skills/vigilante-create-issue skills/vigilante-local-service-dependencies skills/docker-compose-launch
 var Skills embed.FS

--- a/skills/docker-compose-launch/SKILL.md
+++ b/skills/docker-compose-launch/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: docker-compose-launch
+description: Launch worktree-scoped local services for issue implementation when a monorepo skill requires database dependencies.
+---
+
+# Docker Compose Launch
+
+## Overview
+Use this skill only when the selected implementation workflow explicitly needs local services before app startup, migrations, or tests can run. Keep all service startup scoped to the assigned worktree and treat Docker Compose as a reusable helper for local implementation and test dependencies only.
+
+## Invocation Contract
+The parent implementation skill should pass or infer this contract before acting:
+
+- `required`: `true` or `false`
+- `worktree_path`: absolute path to the assigned worktree
+- `service_types`: one or more of `mysql`, `mariadb`, `postgres`, or `mongodb`
+- `reason`: short explanation of which app, package, migration, or test command needs the services
+- `preferred_mechanism`: repository-native compose file, repo script, or fallback compose generation
+
+If `required` is `false`, return `status: not_needed` and do nothing else.
+
+## Execution Rules
+- Prefer repository-owned `docker-compose.yml`, `docker-compose.yaml`, `compose.yml`, or `compose.yaml` files before generating new files.
+- Prefer repository scripts or task-runner commands that already wrap Compose when they are documented and usable.
+- Namespace any generated project name, file, network, volume, or container identifiers to the assigned worktree.
+- Wait for service readiness before reporting success.
+- Surface the exact startup and teardown commands that were used.
+
+## Structured Result
+Return a concise structured summary using these fields:
+
+- `status`: `ready`, `not_needed`, or `failed`
+- `services`: services that were started or detected
+- `mechanism`: `repo_compose`, `repo_script`, or `generated_fallback`
+- `commands`: startup, readiness, and teardown commands
+- `connection`: host, port, database, username, URL, or env hints when available
+- `cleanup`: explicit stop command, or `none`
+- `artifacts`: compose files or env files created or reused
+- `notes`: concise caveats or follow-up steps
+
+## Guardrails
+- Do not launch services outside the assigned worktree scope.
+- Do not assume every repository needs Docker Compose.
+- Do not replace a documented repository-native startup flow with a generated one unless the native path is unusable.
+- Do not claim success until the requested service is accepting connections.

--- a/skills/docker-compose-launch/agents/openai.yaml
+++ b/skills/docker-compose-launch/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Docker Compose Launch"
+  short_description: "Launch worktree-scoped local database services for monorepo issue implementation"
+  default_prompt: "Use $docker-compose-launch only when the selected implementation workflow requires local services, scope startup to the assigned worktree, and return structured connection and cleanup details."

--- a/skills/vigilante-issue-implementation-on-bazel/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-bazel/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: vigilante-issue-implementation-on-bazel
+description: Implement a GitHub issue end-to-end when Vigilante dispatches work for a Bazel monorepo.
+---
+
+# Vigilante Bazel Issue Implementation
+
+## Focus
+- Read the prompt for the detected stack, workspace hints, and shared local-service contract before changing code.
+- Limit edits and validation to the affected Bazel targets unless broader changes are required.
+- If local services are required, call `vigilante-local-service-dependencies` first and then use the shared `docker-compose-launch` contract instead of writing ad hoc Compose logic.
+
+## Workflow
+- Follow the base `vigilante-issue-implementation-on-monorepo` workflow for issue comments, validation, push, and PR creation.
+- Use Bazel-native target commands when they exist and match the touched code.
+- Keep service startup scoped to the assigned worktree and only for implementation or test dependencies.

--- a/skills/vigilante-issue-implementation-on-bazel/agents/openai.yaml
+++ b/skills/vigilante-issue-implementation-on-bazel/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Vigilante Bazel Issue Implementation"
+  short_description: "Implement a Vigilante-dispatched issue in a Bazel monorepo"
+  default_prompt: "Use $vigilante-issue-implementation-on-bazel to implement the assigned Bazel issue in the provided worktree, respect target scope, comment on the issue, and open a PR."

--- a/skills/vigilante-issue-implementation-on-gradle/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-gradle/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: vigilante-issue-implementation-on-gradle
+description: Implement a GitHub issue end-to-end when Vigilante dispatches work for a Gradle monorepo.
+---
+
+# Vigilante Gradle Monorepo Issue Implementation
+
+## Focus
+- Read the prompt for the detected stack, workspace hints, and shared local-service contract before changing code.
+- Limit edits and validation to the affected Gradle projects unless broader changes are required.
+- If local services are required, call `vigilante-local-service-dependencies` first and then use the shared `docker-compose-launch` contract instead of writing ad hoc Compose logic.
+
+## Workflow
+- Follow the base `vigilante-issue-implementation-on-monorepo` workflow for issue comments, validation, push, and PR creation.
+- Use Gradle-native project commands when they exist and match the touched modules.
+- Keep service startup scoped to the assigned worktree and only for implementation or test dependencies.

--- a/skills/vigilante-issue-implementation-on-gradle/agents/openai.yaml
+++ b/skills/vigilante-issue-implementation-on-gradle/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Vigilante Gradle Monorepo Issue Implementation"
+  short_description: "Implement a Vigilante-dispatched issue in a Gradle monorepo"
+  default_prompt: "Use $vigilante-issue-implementation-on-gradle to implement the assigned Gradle monorepo issue in the provided worktree, respect project scope, comment on the issue, and open a PR."

--- a/skills/vigilante-issue-implementation-on-monorepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-monorepo/SKILL.md
@@ -10,6 +10,7 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 
 ## Monorepo Focus
 - Read the repo/process context supplied in the prompt before changing code.
+- Read the detected monorepo stack and shared local-service contract from the prompt before choosing commands.
 - Limit edits to the packages, apps, or shared modules required for the issue.
 - Prefer targeted validation for the touched workspace scope before broader monorepo validation.
 - Avoid unrelated cross-package refactors unless they are required to complete the issue safely.
@@ -37,6 +38,7 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - Keep changes scoped to the issue.
 - Prefer native repository tooling and avoid unnecessary new dependencies.
 - If the affected workspace needs local services, call the bundled `vigilante-local-service-dependencies` skill and reuse its structured output before creating workspace-specific ad hoc service setup.
+- When containerized local services are still needed after that analysis, use the shared `docker-compose-launch` contract from the prompt so service startup remains scoped to the assigned worktree.
 
 5. Validate incrementally
 - Run the most relevant package/app/workspace checks first, then expand only if needed.

--- a/skills/vigilante-issue-implementation-on-nx/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-nx/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: vigilante-issue-implementation-on-nx
+description: Implement a GitHub issue end-to-end when Vigilante dispatches work for an Nx monorepo.
+---
+
+# Vigilante Nx Issue Implementation
+
+## Focus
+- Read the prompt for the detected stack, workspace hints, and shared local-service contract before changing code.
+- Limit edits and validation to the affected Nx apps or libs unless broader changes are required.
+- If local services are required, call `vigilante-local-service-dependencies` first and then use the shared `docker-compose-launch` contract instead of writing ad hoc Compose logic.
+
+## Workflow
+- Follow the base `vigilante-issue-implementation-on-monorepo` workflow for issue comments, validation, push, and PR creation.
+- Use Nx-native workspace commands when they exist and match the touched projects.
+- Keep service startup scoped to the assigned worktree and only for implementation or test dependencies.

--- a/skills/vigilante-issue-implementation-on-nx/agents/openai.yaml
+++ b/skills/vigilante-issue-implementation-on-nx/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Vigilante Nx Issue Implementation"
+  short_description: "Implement a Vigilante-dispatched issue in an Nx monorepo"
+  default_prompt: "Use $vigilante-issue-implementation-on-nx to implement the assigned Nx issue in the provided worktree, respect project scope, comment on the issue, and open a PR."

--- a/skills/vigilante-issue-implementation-on-rush/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-rush/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: vigilante-issue-implementation-on-rush
+description: Implement a GitHub issue end-to-end when Vigilante dispatches work for a Rush monorepo.
+---
+
+# Vigilante Rush Issue Implementation
+
+## Focus
+- Read the prompt for the detected stack, workspace hints, and shared local-service contract before changing code.
+- Limit edits and validation to the affected Rush projects unless broader changes are required.
+- If local services are required, call `vigilante-local-service-dependencies` first and then use the shared `docker-compose-launch` contract instead of writing ad hoc Compose logic.
+
+## Workflow
+- Follow the base `vigilante-issue-implementation-on-monorepo` workflow for issue comments, validation, push, and PR creation.
+- Use Rush-native workspace commands when they exist and match the touched projects.
+- Keep service startup scoped to the assigned worktree and only for implementation or test dependencies.

--- a/skills/vigilante-issue-implementation-on-rush/agents/openai.yaml
+++ b/skills/vigilante-issue-implementation-on-rush/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Vigilante Rush Issue Implementation"
+  short_description: "Implement a Vigilante-dispatched issue in a Rush monorepo"
+  default_prompt: "Use $vigilante-issue-implementation-on-rush to implement the assigned Rush issue in the provided worktree, respect project scope, comment on the issue, and open a PR."

--- a/skills/vigilante-issue-implementation-on-turborepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-turborepo/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: vigilante-issue-implementation-on-turborepo
+description: Implement a GitHub issue end-to-end when Vigilante dispatches work for a Turborepo monorepo.
+---
+
+# Vigilante Turborepo Issue Implementation
+
+## Focus
+- Read the prompt for the detected stack, workspace hints, and shared local-service contract before changing code.
+- Limit edits and validation to the affected Turborepo packages unless broader changes are required.
+- If local services are required, call `vigilante-local-service-dependencies` first and then use the shared `docker-compose-launch` contract instead of writing ad hoc Compose logic.
+
+## Workflow
+- Follow the base `vigilante-issue-implementation-on-monorepo` workflow for issue comments, validation, push, and PR creation.
+- Use Turborepo-native workspace commands when they exist and match the touched packages.
+- Keep service startup scoped to the assigned worktree and only for implementation or test dependencies.

--- a/skills/vigilante-issue-implementation-on-turborepo/agents/openai.yaml
+++ b/skills/vigilante-issue-implementation-on-turborepo/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Vigilante Turborepo Issue Implementation"
+  short_description: "Implement a Vigilante-dispatched issue in a Turborepo monorepo"
+  default_prompt: "Use $vigilante-issue-implementation-on-turborepo to implement the assigned Turborepo issue in the provided worktree, respect workspace scope, comment on the issue, and open a PR."


### PR DESCRIPTION
## Summary
- add structured monorepo stack classification and route monorepo issue prompts to stack-specific skills with a safe fallback
- add a shared `docker-compose-launch` skill contract for worktree-scoped local service startup
- expand bundled skill assets and tests to cover stack routing, prompt context, and setup installation

## Validation
- go test ./...

Closes #156