### PR TITLE
Auto squash-merge automerge PRs after checks pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,14 @@ Initial rules:
 
 Future policy can expand to richer label filters, assignment rules, and priority queues.
 
+## Pull Request Maintenance
+
+For pull requests tied to an active Vigilante session:
+
+- keep the branch updated against `origin/main` through the existing maintenance loop
+- if the PR has an `automerge` label, attempt a GitHub squash merge only after required checks pass and GitHub reports the PR is mergeable
+- never force through branch protection, required reviews, or failing checks
+
 ## Headless Agent Execution Contract
 
 When `vigilante` launches a coding agent for an issue, it should:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -758,7 +758,6 @@ func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session
 				}
 				continue
 			}
-			session.LastMaintenanceError = ""
 			continue
 		}
 
@@ -827,6 +826,8 @@ func (a *App) waitForSessions() {
 }
 
 func (a *App) maintainOpenPullRequest(ctx context.Context, session *state.Session, pr ghcli.PullRequest) error {
+	session.LastMaintenanceError = ""
+
 	if _, err := a.env.Runner.Run(ctx, session.WorktreePath, "git", "fetch", "origin", "main"); err != nil {
 		return err
 	}
@@ -870,7 +871,7 @@ func (a *App) maintainOpenPullRequest(ctx context.Context, session *state.Sessio
 	session.LastMaintainedAt = a.clock().Format(time.RFC3339)
 	session.UpdatedAt = session.LastMaintainedAt
 	if !rebased {
-		return nil
+		return a.tryAutoSquashMerge(ctx, session, pr)
 	}
 
 	if _, err := a.env.Runner.Run(ctx, session.WorktreePath, "go", "test", "./..."); err != nil {
@@ -893,6 +894,30 @@ func (a *App) maintainOpenPullRequest(ctx context.Context, session *state.Sessio
 		Tagline: "Success is where preparation and opportunity meet.",
 	})
 	return ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body)
+}
+
+func (a *App) tryAutoSquashMerge(ctx context.Context, session *state.Session, pr ghcli.PullRequest) error {
+	details, err := ghcli.GetPullRequestDetails(ctx, a.env.Runner, session.Repo, pr.Number)
+	if err != nil {
+		return err
+	}
+	if !ghcli.HasAnyLabel(details.Labels, "automerge") {
+		return nil
+	}
+
+	waitReason := automergeWaitReason(*details)
+	if waitReason != "" {
+		session.LastMaintenanceError = waitReason
+		a.state.AppendDaemonLog("automerge waiting repo=%s issue=%d pr=%d branch=%s reason=%s", session.Repo, session.IssueNumber, pr.Number, session.Branch, waitReason)
+		return nil
+	}
+
+	if err := ghcli.MergePullRequestSquash(ctx, a.env.Runner, session.Repo, pr.Number); err != nil {
+		return fmt.Errorf("squash automerge pr #%d: %w", pr.Number, err)
+	}
+
+	a.state.AppendDaemonLog("automerge merged repo=%s issue=%d pr=%d branch=%s strategy=squash", session.Repo, session.IssueNumber, pr.Number, session.Branch)
+	return nil
 }
 
 func (a *App) listBlockedSessions() error {
@@ -1626,6 +1651,78 @@ func shouldCommentMaintenanceFailure(session state.Session, err error) bool {
 
 func summarizeMaintenanceError(err error) string {
 	return summarizeText(err.Error())
+}
+
+func automergeWaitReason(pr ghcli.PullRequest) string {
+	if pr.IsDraft {
+		return fmt.Sprintf("automerge waiting for PR #%d to leave draft state", pr.Number)
+	}
+
+	switch strings.TrimSpace(pr.ReviewDecision) {
+	case "CHANGES_REQUESTED":
+		return fmt.Sprintf("automerge waiting for review changes on PR #%d", pr.Number)
+	case "REVIEW_REQUIRED":
+		return fmt.Sprintf("automerge waiting for required reviews on PR #%d", pr.Number)
+	}
+
+	checkState := requiredChecksState(pr.StatusCheckRollup)
+	switch checkState {
+	case "pending":
+		return fmt.Sprintf("automerge waiting for required checks on PR #%d", pr.Number)
+	case "failing":
+		return fmt.Sprintf("automerge waiting for required checks to pass on PR #%d", pr.Number)
+	}
+
+	switch strings.TrimSpace(pr.MergeStateStatus) {
+	case "", "CLEAN":
+		return ""
+	case "BLOCKED":
+		return fmt.Sprintf("automerge waiting for GitHub mergeability on PR #%d: blocked", pr.Number)
+	case "BEHIND":
+		return fmt.Sprintf("automerge waiting for GitHub mergeability on PR #%d: branch is behind base", pr.Number)
+	case "DIRTY":
+		return fmt.Sprintf("automerge waiting for GitHub mergeability on PR #%d: merge conflicts detected", pr.Number)
+	case "DRAFT":
+		return fmt.Sprintf("automerge waiting for GitHub mergeability on PR #%d: pull request is draft", pr.Number)
+	case "HAS_HOOKS":
+		return fmt.Sprintf("automerge waiting for GitHub mergeability on PR #%d: pre-merge hooks still pending", pr.Number)
+	case "UNKNOWN", "UNSTABLE":
+		return fmt.Sprintf("automerge waiting for GitHub mergeability on PR #%d: state %s", pr.Number, strings.ToLower(pr.MergeStateStatus))
+	default:
+		return fmt.Sprintf("automerge waiting for GitHub mergeability on PR #%d: state %s", pr.Number, strings.ToLower(pr.MergeStateStatus))
+	}
+}
+
+func requiredChecksState(checks []ghcli.StatusCheckRoll) string {
+	if len(checks) == 0 {
+		return "passing"
+	}
+
+	pending := false
+	for _, check := range checks {
+		state := strings.ToUpper(strings.TrimSpace(check.State))
+		conclusion := strings.ToUpper(strings.TrimSpace(check.Conclusion))
+
+		switch conclusion {
+		case "ACTION_REQUIRED", "CANCELLED", "FAILURE", "STALE", "STARTUP_FAILURE", "TIMED_OUT":
+			return "failing"
+		}
+
+		switch state {
+		case "", "COMPLETED", "SUCCESS":
+		default:
+			pending = true
+		}
+
+		if state == "COMPLETED" && conclusion == "" {
+			pending = true
+		}
+	}
+
+	if pending {
+		return "pending"
+	}
+	return "passing"
 }
 
 func summarizeText(text string) string {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -3001,6 +3001,180 @@ func TestScanOnceMaintainsOpenPullRequest(t *testing.T) {
 	}
 }
 
+func TestScanOnceAutoSquashMergesLabeledPullRequestAfterChecksPass(t *testing.T) {
+	app, stdout := newPullRequestMaintenanceTestApp(t, map[string]string{
+		"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
+		"git fetch origin main":  "ok",
+		"git status --porcelain": "",
+		"git rebase origin/main": "Current branch vigilante/issue-1 is up to date.\n",
+		"gh pr view --repo owner/repo 31 --json number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("automerge", "CLEAN", "APPROVED", "COMPLETED", "SUCCESS"),
+		"gh pr merge --repo owner/repo 31 --squash --delete-branch":                                                                         "ok",
+		"gh api user --jq .login": "nicobistolfi\n",
+		"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+	})
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	app.waitForSessions()
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions[0].LastMaintenanceError != "" {
+		t.Fatalf("unexpected maintenance wait state: %#v", sessions[0])
+	}
+	if got := stdout.String(); !strings.Contains(got, "repo: owner/repo no eligible issues (0 open)") {
+		t.Fatalf("unexpected output: %s", got)
+	}
+}
+
+func TestScanOnceAutomergeWaitsForPendingChecks(t *testing.T) {
+	app, _ := newPullRequestMaintenanceTestApp(t, map[string]string{
+		"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
+		"git fetch origin main":  "ok",
+		"git status --porcelain": "",
+		"git rebase origin/main": "Current branch vigilante/issue-1 is up to date.\n",
+		"gh pr view --repo owner/repo 31 --json number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("automerge", "BLOCKED", "APPROVED", "PENDING", ""),
+		"gh api user --jq .login": "nicobistolfi\n",
+		"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+	})
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	app.waitForSessions()
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions[0].LastMaintenanceError != "automerge waiting for required checks on PR #31" {
+		t.Fatalf("expected pending-checks wait state, got: %#v", sessions[0])
+	}
+}
+
+func TestScanOnceAutomergeWaitsForFailingChecks(t *testing.T) {
+	app, _ := newPullRequestMaintenanceTestApp(t, map[string]string{
+		"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
+		"git fetch origin main":  "ok",
+		"git status --porcelain": "",
+		"git rebase origin/main": "Current branch vigilante/issue-1 is up to date.\n",
+		"gh pr view --repo owner/repo 31 --json number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("automerge", "BLOCKED", "APPROVED", "COMPLETED", "FAILURE"),
+		"gh api user --jq .login": "nicobistolfi\n",
+		"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+	})
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	app.waitForSessions()
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions[0].LastMaintenanceError != "automerge waiting for required checks to pass on PR #31" {
+		t.Fatalf("expected failing-checks wait state, got: %#v", sessions[0])
+	}
+}
+
+func TestScanOnceAutomergeWaitsForMergeabilityConstraints(t *testing.T) {
+	app, _ := newPullRequestMaintenanceTestApp(t, map[string]string{
+		"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
+		"git fetch origin main":  "ok",
+		"git status --porcelain": "",
+		"git rebase origin/main": "Current branch vigilante/issue-1 is up to date.\n",
+		"gh pr view --repo owner/repo 31 --json number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("automerge", "BLOCKED", "REVIEW_REQUIRED", "COMPLETED", "SUCCESS"),
+		"gh api user --jq .login": "nicobistolfi\n",
+		"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+	})
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	app.waitForSessions()
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions[0].LastMaintenanceError != "automerge waiting for required reviews on PR #31" {
+		t.Fatalf("expected mergeability wait state, got: %#v", sessions[0])
+	}
+}
+
+func TestScanOnceDoesNotAutomergeUnlabeledPullRequest(t *testing.T) {
+	app, _ := newPullRequestMaintenanceTestApp(t, map[string]string{
+		"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
+		"git fetch origin main":  "ok",
+		"git status --porcelain": "",
+		"git rebase origin/main": "Current branch vigilante/issue-1 is up to date.\n",
+		"gh pr view --repo owner/repo 31 --json number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("", "CLEAN", "APPROVED", "COMPLETED", "SUCCESS"),
+		"gh api user --jq .login": "nicobistolfi\n",
+		"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+	})
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	app.waitForSessions()
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions[0].LastMaintenanceError != "" {
+		t.Fatalf("expected unlabeled PR to skip automerge cleanly, got: %#v", sessions[0])
+	}
+}
+
+func newPullRequestMaintenanceTestApp(t *testing.T, outputs map[string]string) (*App, *bytes.Buffer) {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	var stdout bytes.Buffer
+	app := New()
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs:   outputs,
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:     "/tmp/repo",
+		Repo:         "owner/repo",
+		IssueNumber:  1,
+		IssueTitle:   "first",
+		IssueURL:     "https://github.com/owner/repo/issues/1",
+		Branch:       "vigilante/issue-1",
+		WorktreePath: filepath.Join("/tmp/repo", ".worktrees", "vigilante", "issue-1"),
+		Status:       state.SessionStatusSuccess,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	return app, &stdout
+}
+
+func automergePRDetailsJSON(label string, mergeState string, reviewDecision string, checkState string, conclusion string) string {
+	labelJSON := "[]"
+	if label != "" {
+		labelJSON = fmt.Sprintf(`[{"name":"%s"}]`, label)
+	}
+	return fmt.Sprintf(`{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null,"labels":%s,"isDraft":false,"mergeStateStatus":"%s","reviewDecision":"%s","statusCheckRollup":[{"context":"test","state":"%s","conclusion":"%s"}]}`, labelJSON, mergeState, reviewDecision, checkState, conclusion)
+}
+
 func TestScanOnceSkipsWhenAnotherProcessHoldsScanLock(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
@@ -3221,9 +3395,10 @@ func TestScanOnceRecoversStalledSessionIntoPRMaintenance(t *testing.T) {
 				},
 				Tagline: "Fall seven times, stand up eight.",
 			}): "ok",
-			"git fetch origin main":   "ok",
-			"git status --porcelain":  "",
-			"git rebase origin/main":  "Current branch vigilante/issue-1 is up to date.\n",
+			"git fetch origin main":  "ok",
+			"git status --porcelain": "",
+			"git rebase origin/main": "Current branch vigilante/issue-1 is up to date.\n",
+			"gh pr view --repo owner/repo 31 --json number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("", "CLEAN", "APPROVED", "COMPLETED", "SUCCESS"),
 			"gh api user --jq .login": "nicobistolfi\n",
 			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
 		},

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -25,10 +25,22 @@ type Label struct {
 }
 
 type PullRequest struct {
-	Number   int        `json:"number"`
-	URL      string     `json:"url"`
-	State    string     `json:"state"`
-	MergedAt *time.Time `json:"mergedAt"`
+	Number            int               `json:"number"`
+	URL               string            `json:"url"`
+	State             string            `json:"state"`
+	MergedAt          *time.Time        `json:"mergedAt"`
+	Labels            []Label           `json:"labels"`
+	IsDraft           bool              `json:"isDraft"`
+	MergeStateStatus  string            `json:"mergeStateStatus"`
+	ReviewDecision    string            `json:"reviewDecision"`
+	StatusCheckRollup []StatusCheckRoll `json:"statusCheckRollup"`
+}
+
+type StatusCheckRoll struct {
+	Context    string `json:"context"`
+	Name       string `json:"name"`
+	State      string `json:"state"`
+	Conclusion string `json:"conclusion"`
 }
 
 type IssueComment struct {
@@ -304,6 +316,35 @@ func FindPullRequestForBranch(ctx context.Context, runner environment.Runner, re
 		return nil, nil
 	}
 	return &prs[0], nil
+}
+
+func GetPullRequestDetails(ctx context.Context, runner environment.Runner, repo string, number int) (*PullRequest, error) {
+	output, err := runner.Run(
+		ctx,
+		"",
+		"gh",
+		"pr",
+		"view",
+		"--repo",
+		repo,
+		fmt.Sprintf("%d", number),
+		"--json",
+		"number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var pr PullRequest
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &pr); err != nil {
+		return nil, fmt.Errorf("parse gh pr view output: %w", err)
+	}
+	return &pr, nil
+}
+
+func MergePullRequestSquash(ctx context.Context, runner environment.Runner, repo string, number int) error {
+	_, err := runner.Run(ctx, "", "gh", "pr", "merge", "--repo", repo, fmt.Sprintf("%d", number), "--squash", "--delete-branch")
+	return err
 }
 
 func issueAPIPath(repo string, number int) string {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -205,6 +205,40 @@ func TestFindPullRequestForBranch(t *testing.T) {
 	}
 }
 
+func TestGetPullRequestDetails(t *testing.T) {
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh pr view --repo owner/repo 17 --json number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup": `{"number":17,"url":"https://github.com/owner/repo/pull/17","state":"OPEN","mergedAt":null,"labels":[{"name":"automerge"}],"isDraft":false,"mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[{"context":"test","state":"COMPLETED","conclusion":"SUCCESS"}]}`,
+		},
+	}
+
+	pr, err := GetPullRequestDetails(context.Background(), runner, "owner/repo", 17)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pr.Number != 17 || pr.MergeStateStatus != "CLEAN" || pr.ReviewDecision != "APPROVED" {
+		t.Fatalf("unexpected pull request details: %#v", pr)
+	}
+	if len(pr.Labels) != 1 || pr.Labels[0].Name != "automerge" {
+		t.Fatalf("expected automerge label, got: %#v", pr.Labels)
+	}
+	if len(pr.StatusCheckRollup) != 1 || pr.StatusCheckRollup[0].Conclusion != "SUCCESS" {
+		t.Fatalf("unexpected status checks: %#v", pr.StatusCheckRollup)
+	}
+}
+
+func TestMergePullRequestSquash(t *testing.T) {
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh pr merge --repo owner/repo 17 --squash --delete-branch": "ok",
+		},
+	}
+
+	if err := MergePullRequestSquash(context.Background(), runner, "owner/repo", 17); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestFindCleanupComment(t *testing.T) {
 	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
 	comments := []IssueComment{


### PR DESCRIPTION
## Summary
- add label-gated squash automerge to the existing PR maintenance loop
- wait for required checks, reviews, and GitHub mergeability before merging
- document the `automerge` behavior and cover the new maintenance cases with tests

Closes #155

## Validation
- `go test ./...`