### PR TITLE
Propose issue labeling system for Vigilante execution state

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -1,0 +1,179 @@
+{
+  "work_classification_policy": {
+    "owner": "repository maintainers",
+    "notes": [
+      "Repo-specific planning labels such as bug, feature, or good first issue remain user-managed.",
+      "Vigilante should not add or remove work-classification labels automatically."
+    ]
+  },
+  "labels": [
+    {
+      "name": "vigilante:queued",
+      "color": "BFDADC",
+      "group": "execution-state",
+      "behavior": "informational",
+      "applied_by": "vigilante",
+      "description": "The issue is eligible for dispatch and waiting for a worker slot.",
+      "notes": [
+        "Set when Vigilante decides the issue is ready to run but has not started execution yet.",
+        "Clear when execution begins or when the issue becomes ineligible."
+      ]
+    },
+    {
+      "name": "vigilante:running",
+      "color": "0E8A16",
+      "group": "execution-state",
+      "behavior": "informational",
+      "applied_by": "vigilante",
+      "description": "A coding-agent session is currently executing for the issue.",
+      "notes": [
+        "Replaces vigilante:queued while a worktree session is active."
+      ]
+    },
+    {
+      "name": "vigilante:blocked",
+      "color": "D93F0B",
+      "group": "execution-state",
+      "behavior": "informational",
+      "applied_by": "vigilante",
+      "description": "Execution cannot continue until a blocker is resolved.",
+      "notes": [
+        "Pair with exactly one vigilante:needs-* label when the next step is known."
+      ]
+    },
+    {
+      "name": "vigilante:ready-for-review",
+      "color": "FBCA04",
+      "group": "execution-state",
+      "behavior": "informational",
+      "applied_by": "vigilante",
+      "description": "Implementation is complete enough for a human to review the resulting PR or branch.",
+      "notes": [
+        "Preferred first-class review handoff label."
+      ]
+    },
+    {
+      "name": "vigilante:awaiting-user-validation",
+      "color": "F9D0C4",
+      "group": "execution-state",
+      "behavior": "informational",
+      "applied_by": "vigilante",
+      "description": "Changes are ready for product or operator validation before the issue is considered done.",
+      "notes": [
+        "Use when code review is complete but a human still needs to validate behavior."
+      ]
+    },
+    {
+      "name": "vigilante:done",
+      "color": "5319E7",
+      "group": "execution-state",
+      "behavior": "informational",
+      "applied_by": "vigilante",
+      "description": "Vigilante completed its work on the issue and no further automation is expected.",
+      "notes": [
+        "Typically set after merge, explicit operator completion, or another terminal success condition."
+      ]
+    },
+    {
+      "name": "vigilante:needs-review",
+      "color": "D4C5F9",
+      "group": "intervention",
+      "behavior": "informational",
+      "applied_by": "vigilante",
+      "description": "A human should review the implementation output before Vigilante continues or closes the loop.",
+      "notes": [
+        "Can coexist with vigilante:ready-for-review or vigilante:blocked depending on the workflow stage."
+      ]
+    },
+    {
+      "name": "vigilante:needs-human-input",
+      "color": "F7C6C7",
+      "group": "intervention",
+      "behavior": "informational",
+      "applied_by": "vigilante",
+      "description": "The agent is waiting on product, operator, or repository-owner guidance.",
+      "notes": [
+        "Use for ambiguous requirements, missing decisions, or manual approvals."
+      ]
+    },
+    {
+      "name": "vigilante:needs-provider-fix",
+      "color": "E99695",
+      "group": "intervention",
+      "behavior": "informational",
+      "applied_by": "vigilante",
+      "description": "Execution is blocked by provider auth, quota, or runtime setup issues.",
+      "notes": [
+        "Maps naturally from existing blocked provider failure classes."
+      ]
+    },
+    {
+      "name": "vigilante:needs-git-fix",
+      "color": "C2E0C6",
+      "group": "intervention",
+      "behavior": "informational",
+      "applied_by": "vigilante",
+      "description": "Execution is blocked by repository or git state that requires human repair.",
+      "notes": [
+        "Use for auth failures, dirty worktrees, rebase conflicts, or branch repair."
+      ]
+    },
+    {
+      "name": "codex",
+      "color": "1D76DB",
+      "group": "provider-routing",
+      "behavior": "control",
+      "applied_by": "human",
+      "description": "Routes the issue to the Codex provider for execution.",
+      "notes": [
+        "Existing control behavior remains unchanged."
+      ]
+    },
+    {
+      "name": "claude",
+      "color": "0052CC",
+      "group": "provider-routing",
+      "behavior": "control",
+      "applied_by": "human",
+      "description": "Routes the issue to the Claude provider for execution.",
+      "notes": [
+        "Existing control behavior remains unchanged."
+      ]
+    },
+    {
+      "name": "gemini",
+      "color": "006B75",
+      "group": "provider-routing",
+      "behavior": "control",
+      "applied_by": "human",
+      "description": "Routes the issue to the Gemini provider for execution.",
+      "notes": [
+        "Existing control behavior remains unchanged."
+      ]
+    },
+    {
+      "name": "vigilante:resume",
+      "color": "C5DEF5",
+      "group": "control",
+      "behavior": "control",
+      "applied_by": "human",
+      "description": "Requests that Vigilante resume a blocked session.",
+      "notes": [
+        "Preferred namespaced control label.",
+        "Vigilante should remove it after acknowledging the resume request."
+      ]
+    },
+    {
+      "name": "resume",
+      "color": "C5DEF5",
+      "group": "control",
+      "behavior": "control",
+      "applied_by": "human",
+      "description": "Legacy compatibility alias for vigilante:resume.",
+      "alias_for": "vigilante:resume",
+      "notes": [
+        "Keep until existing operator workflows are migrated."
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -497,6 +497,35 @@ For pull requests tied to an active Vigilante session:
 - if the PR has an `automerge` label, attempt a GitHub squash merge only after required checks pass and GitHub reports the PR is mergeable
 - never force through branch protection, required reviews, or failing checks
 
+## Issue Labeling System
+
+Vigilante should use a small issue-label taxonomy that complements issue comments instead of replacing them. The repository-owned proposal lives in [`.github/labels.json`](.github/labels.json).
+
+Label ownership rules:
+
+- Work-classification labels such as `bug`, `feature`, and `good first issue` remain repository-managed and should not be changed by Vigilante.
+- `vigilante:*` lifecycle and intervention labels are primarily informational and should be set or cleared by Vigilante as the issue moves through execution.
+- Provider-routing labels `codex`, `claude`, and `gemini` keep their existing control semantics and remain human-managed overrides.
+- `vigilante:resume` is the preferred control label for unblocking a paused session; `resume` remains a legacy-compatible alias.
+
+Proposed groups:
+
+- Execution state: `vigilante:queued`, `vigilante:running`, `vigilante:blocked`, `vigilante:ready-for-review`, `vigilante:awaiting-user-validation`, `vigilante:done`
+- Human-intervention state: `vigilante:needs-review`, `vigilante:needs-human-input`, `vigilante:needs-provider-fix`, `vigilante:needs-git-fix`
+- Provider routing controls: `codex`, `claude`, `gemini`
+- Explicit control labels: `vigilante:resume` and legacy `resume`
+
+Recommended lifecycle:
+
+1. When an issue becomes eligible but has not started, add `vigilante:queued`.
+2. When execution starts, replace `vigilante:queued` with `vigilante:running`.
+3. If execution stalls on a known blocker, replace `vigilante:running` with `vigilante:blocked` and add exactly one matching `vigilante:needs-*` label when possible.
+4. When implementation is ready for a human to inspect, replace blocked or running state with `vigilante:ready-for-review`, keeping `vigilante:needs-review` when a human handoff is still pending.
+5. When code review is complete but a product or operator check is still required, use `vigilante:awaiting-user-validation`.
+6. When the issue reaches a terminal successful state, clear transient labels and leave `vigilante:done`.
+
+This keeps control semantics narrow while making the issue list readable at a glance. Existing label-based behaviors stay compatible: watch-target allowlists still match repository-managed labels, provider overrides still use provider ids, and blocked-session recovery still honors both `resume` and `vigilante:resume`.
+
 ## Headless Agent Execution Contract
 
 When `vigilante` launches a coding agent for an issue, it should:

--- a/internal/github/labels_manifest_test.go
+++ b/internal/github/labels_manifest_test.go
@@ -1,0 +1,137 @@
+package ghcli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+type labelManifest struct {
+	Labels []labelSpec `json:"labels"`
+}
+
+type labelSpec struct {
+	Name        string   `json:"name"`
+	Group       string   `json:"group"`
+	Behavior    string   `json:"behavior"`
+	Description string   `json:"description"`
+	AliasFor    string   `json:"alias_for"`
+	Notes       []string `json:"notes"`
+}
+
+func TestIssueLabelManifestDefinesExpectedGroups(t *testing.T) {
+	manifest := loadLabelManifest(t)
+
+	if len(manifest.Labels) == 0 {
+		t.Fatal("expected label manifest entries")
+	}
+
+	seenNames := map[string]bool{}
+	groups := map[string]int{}
+	for _, label := range manifest.Labels {
+		if label.Name == "" {
+			t.Fatal("expected every label to have a name")
+		}
+		if seenNames[label.Name] {
+			t.Fatalf("duplicate label name %q", label.Name)
+		}
+		seenNames[label.Name] = true
+		if label.Group == "" {
+			t.Fatalf("expected label %q to declare a group", label.Name)
+		}
+		if label.Behavior != "informational" && label.Behavior != "control" {
+			t.Fatalf("unexpected behavior for %q: %q", label.Name, label.Behavior)
+		}
+		if label.Description == "" {
+			t.Fatalf("expected label %q to include a description", label.Name)
+		}
+		groups[label.Group]++
+	}
+
+	for _, group := range []string{"execution-state", "intervention", "provider-routing", "control"} {
+		if groups[group] == 0 {
+			t.Fatalf("expected at least one label in group %q", group)
+		}
+	}
+}
+
+func TestIssueLabelManifestKeepsCompatibilityControls(t *testing.T) {
+	manifest := loadLabelManifest(t)
+
+	labels := map[string]labelSpec{}
+	for _, label := range manifest.Labels {
+		labels[label.Name] = label
+	}
+
+	for _, provider := range []string{"codex", "claude", "gemini"} {
+		label, ok := labels[provider]
+		if !ok {
+			t.Fatalf("expected provider label %q", provider)
+		}
+		if label.Group != "provider-routing" || label.Behavior != "control" {
+			t.Fatalf("expected provider label %q to remain a control routing label: %#v", provider, label)
+		}
+	}
+
+	resume, ok := labels["vigilante:resume"]
+	if !ok {
+		t.Fatal("expected vigilante:resume in label manifest")
+	}
+	if resume.Group != "control" || resume.Behavior != "control" {
+		t.Fatalf("expected vigilante:resume to be a control label: %#v", resume)
+	}
+
+	legacy, ok := labels["resume"]
+	if !ok {
+		t.Fatal("expected legacy resume alias in label manifest")
+	}
+	if legacy.AliasFor != "vigilante:resume" {
+		t.Fatalf("expected resume alias to target vigilante:resume, got %#v", legacy)
+	}
+}
+
+func TestIssueLabelManifestIncludesHumanReviewStates(t *testing.T) {
+	manifest := loadLabelManifest(t)
+
+	labels := map[string]labelSpec{}
+	for _, label := range manifest.Labels {
+		labels[label.Name] = label
+	}
+
+	for _, name := range []string{
+		"vigilante:ready-for-review",
+		"vigilante:awaiting-user-validation",
+		"vigilante:needs-review",
+		"vigilante:needs-human-input",
+	} {
+		label, ok := labels[name]
+		if !ok {
+			t.Fatalf("expected review or human-input label %q", name)
+		}
+		if label.Behavior != "informational" {
+			t.Fatalf("expected %q to stay informational, got %#v", name, label)
+		}
+	}
+}
+
+func loadLabelManifest(t *testing.T) labelManifest {
+	t.Helper()
+
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve runtime caller")
+	}
+	path := filepath.Join(filepath.Dir(file), "..", "..", ".github", "labels.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read label manifest: %v", err)
+	}
+
+	var manifest labelManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("parse label manifest: %v", err)
+	}
+	return manifest
+}


### PR DESCRIPTION
## Summary
- add a repository-owned issue label manifest in `.github/labels.json`
- document the proposed Vigilante issue label taxonomy and lifecycle in the README
- add tests that enforce group coverage, compatibility controls, and human-review labels

Closes #169

## Validation
- `go test ./...`
