### PR TITLE
Add Nx issue implementation skill for monorepo dispatch

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -215,6 +215,7 @@ func TestSetupCreatesStateLayoutAndSkill(t *testing.T) {
 		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteIssueImplementation, "SKILL.md"),
 		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteIssueImplementationOnMonorepo, "SKILL.md"),
 		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteIssueImplementationOnTurborepo, "SKILL.md"),
+		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteIssueImplementationOnNx, "SKILL.md"),
 		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteIssueImplementationOnGradleMultiProject, "SKILL.md"),
 		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteConflictResolution, "SKILL.md"),
 		filepath.Join(app.state.CodexHome(), "skills", skill.DockerComposeLaunch, "SKILL.md"),

--- a/internal/repo/repo_test.go
+++ b/internal/repo/repo_test.go
@@ -142,6 +142,28 @@ func TestClassifyGradleMultiProjectFromSettingsInclude(t *testing.T) {
 	}
 }
 
+func TestClassifyNxRepoFromNxConfig(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "nx.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pnpm-workspace.yaml"), []byte("packages:\n  - apps/*\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Classify(dir)
+
+	if got.Shape != ShapeMonorepo {
+		t.Fatalf("expected nx classification, got %#v", got)
+	}
+	if len(got.ProcessHints.WorkspaceConfigFiles) != 2 {
+		t.Fatalf("expected nx and workspace config hints, got %#v", got.ProcessHints)
+	}
+	if got.MonorepoStack != MonorepoStackNx {
+		t.Fatalf("expected nx monorepo stack, got %#v", got)
+	}
+}
+
 func TestClassifyFallsBackSafelyForAmbiguousRepo(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, "apps", "web"), 0o755); err != nil {

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -343,6 +343,58 @@ func TestRunIssueSessionUsesMonorepoSkillWhenClassified(t *testing.T) {
 	}
 }
 
+func TestRunIssueSessionUsesNxSkillWhenClassified(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	target := state.WatchTarget{
+		Path: "/tmp/repo",
+		Repo: "owner/repo",
+		Classification: repo.Classification{
+			Shape:         repo.ShapeMonorepo,
+			MonorepoStack: repo.MonorepoStackNx,
+			ProcessHints: repo.ProcessHints{
+				WorkspaceConfigFiles: []string{"nx.json", "pnpm-workspace.yaml"},
+				MultiPackageRoots:    []string{"apps", "libs"},
+			},
+		},
+	}
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"codex --version": "codex 0.114.0",
+			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Vigilante Session Start",
+				Emoji:      "🧢",
+				Percent:    20,
+				ETAMinutes: 25,
+				Items: []string{
+					"Vigilante launched this implementation session in `/tmp/worktree`.",
+					"Branch: `vigilante/issue-7`.",
+					"Current stage: handing the issue off to the configured coding agent (`Codex`) for investigation and implementation.",
+				},
+				Tagline: "Make it simple, but significant.",
+			}): "ok",
+			preflightPromptCommand("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", "vigilante/issue-7"): "baseline ok",
+			testutil.Key("codex", "exec", "--cd", "/tmp/worktree", "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePrompt(
+				target,
+				ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"},
+				state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "codex"},
+			)): "done",
+		},
+	}
+	env := &environment.Environment{OS: "darwin", Runner: runner}
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
+
+	got := RunIssueSession(context.Background(), env, store, target, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+
+	if got.Status != state.SessionStatusSuccess {
+		t.Fatalf("unexpected status: %#v", got)
+	}
+}
+
 func TestRunIssueSessionFailsWhenProviderVersionIsIncompatible(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -308,6 +308,40 @@ func TestBuildIssuePromptSelectsGradleMultiProjectSkill(t *testing.T) {
 	}
 }
 
+func TestBuildIssuePromptSelectsNxSkill(t *testing.T) {
+	target := state.WatchTarget{
+		Path: "/tmp/repo",
+		Repo: "owner/repo",
+		Classification: repo.Classification{
+			Shape:         repo.ShapeMonorepo,
+			MonorepoStack: repo.MonorepoStackNx,
+			ProcessHints: repo.ProcessHints{
+				WorkspaceConfigFiles: []string{"nx.json", "pnpm-workspace.yaml"},
+				MultiPackageRoots:    []string{"apps", "libs"},
+			},
+		},
+	}
+	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
+	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
+
+	prompt := BuildIssuePrompt(target, issue, session)
+
+	for _, text := range []string{
+		"Use the `vigilante-issue-implementation-on-nx` skill",
+		"Detected repo shape: monorepo",
+		"Detected monorepo stack: nx",
+		"Selected issue implementation skill: vigilante-issue-implementation-on-nx",
+		`"monorepo_stack":"nx"`,
+		`"implementation_skill":"vigilante-issue-implementation-on-nx"`,
+		`"workspace_config_files":["nx.json","pnpm-workspace.yaml"]`,
+		`"multi_package_roots":["apps","libs"]`,
+	} {
+		if !strings.Contains(prompt, text) {
+			t.Fatalf("prompt missing %q: %s", text, prompt)
+		}
+	}
+}
+
 func TestBuildIssuePreflightPrompt(t *testing.T) {
 	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
 	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}


### PR DESCRIPTION
## Summary
- add a bundled Nx-specific issue implementation skill and agent metadata
- classify Nx repos distinctly from generic monorepos and route issue prompts to the Nx skill
- cover skill installation, prompt selection, and session routing with Nx-focused tests

Closes #68.

## Validation
- go test ./...
