### PR TITLE
Scope session log filenames by repository

### DIFF
--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -17,10 +17,10 @@ import (
 )
 
 func RunIssueSession(ctx context.Context, env *environment.Environment, store *state.Store, target state.WatchTarget, issue ghcli.Issue, session state.Session) state.Session {
-	logPath := store.SessionLogPath(issue.Number)
 	if session.Repo == "" {
 		session.Repo = target.Repo
 	}
+	logPath := store.SessionLogPath(session.Repo, issue.Number)
 	selectedProvider, err := provider.Resolve(session.Provider)
 	if err != nil {
 		session.Status = state.SessionStatusFailed
@@ -171,7 +171,11 @@ func fallbackSessionText(value string, fallback string) string {
 }
 
 func RunConflictResolutionSession(ctx context.Context, env *environment.Environment, store *state.Store, target state.WatchTarget, session state.Session, pr ghcli.PullRequest) error {
-	logPath := store.SessionLogPath(session.IssueNumber)
+	repoSlug := session.Repo
+	if repoSlug == "" {
+		repoSlug = target.Repo
+	}
+	logPath := store.SessionLogPath(repoSlug, session.IssueNumber)
 	selectedProvider, err := provider.Resolve(session.Provider)
 	if err != nil {
 		appendSessionLog(logPath, "conflict resolution provider resolution failed", session, err.Error())

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -49,7 +49,7 @@ func TestRunIssueSessionSuccess(t *testing.T) {
 	if got.Status != state.SessionStatusSuccess {
 		t.Fatalf("unexpected status: %#v", got)
 	}
-	data, err := os.ReadFile(store.SessionLogPath(7))
+	data, err := os.ReadFile(store.SessionLogPath("owner/repo", 7))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +154,7 @@ func TestRunIssueSessionFailureCommentsOnIssue(t *testing.T) {
 	if !strings.Contains(got.LastError, "go test ./...") {
 		t.Fatalf("unexpected error: %#v", got)
 	}
-	data, err := os.ReadFile(store.SessionLogPath(7))
+	data, err := os.ReadFile(store.SessionLogPath("owner/repo", 7))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"syscall"
 	"time"
@@ -169,8 +170,27 @@ func (s *Store) DaemonLogPath() string {
 	return filepath.Join(s.LogsDir(), "vigilante.log")
 }
 
-func (s *Store) SessionLogPath(issueNumber int) string {
-	return filepath.Join(s.LogsDir(), fmt.Sprintf("issue-%d.log", issueNumber))
+var invalidSessionLogNameChars = regexp.MustCompile(`[^A-Za-z0-9]+`)
+
+func (s *Store) SessionLogPath(repoSlug string, issueNumber int) string {
+	return filepath.Join(s.LogsDir(), fmt.Sprintf("%s-issue-%d.log", sanitizeSessionLogRepoSlug(repoSlug), issueNumber))
+}
+
+func sanitizeSessionLogRepoSlug(repoSlug string) string {
+	parts := strings.Split(strings.TrimSpace(repoSlug), "/")
+	sanitized := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = invalidSessionLogNameChars.ReplaceAllString(strings.TrimSpace(part), "-")
+		part = strings.Trim(part, "-")
+		if part == "" {
+			continue
+		}
+		sanitized = append(sanitized, part)
+	}
+	if len(sanitized) == 0 {
+		return "unknown-repo"
+	}
+	return strings.Join(sanitized, "-")
 }
 
 func (s *Store) watchlistPath() string {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -59,6 +59,58 @@ func TestAppendLogFileUsesLocalTimezone(t *testing.T) {
 	}
 }
 
+func TestSessionLogPathUsesRepositoryQualifiedFilename(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	store := NewStore()
+
+	got := store.SessionLogPath("aliengiraffe/vigilante", 179)
+	want := filepath.Join(store.LogsDir(), "aliengiraffe-vigilante-issue-179.log")
+	if got != want {
+		t.Fatalf("expected repository-qualified session log path %q, got %q", want, got)
+	}
+}
+
+func TestSessionLogPathSanitizesRepositorySlug(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	store := NewStore()
+
+	got := store.SessionLogPath("Org Name/repo.name:beta", 7)
+	want := filepath.Join(store.LogsDir(), "Org-Name-repo-name-beta-issue-7.log")
+	if got != want {
+		t.Fatalf("expected sanitized session log path %q, got %q", want, got)
+	}
+}
+
+func TestSessionLogPathDoesNotCollideAcrossRepositories(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	store := NewStore()
+
+	first := store.SessionLogPath("owner-one/repo", 7)
+	second := store.SessionLogPath("owner-two/repo", 7)
+	if first == second {
+		t.Fatalf("expected distinct session log paths for shared issue number, got %q", first)
+	}
+}
+
+func TestSessionLogPathFallsBackWhenRepositorySlugMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	store := NewStore()
+
+	got := store.SessionLogPath(" / ", 7)
+	want := filepath.Join(store.LogsDir(), "unknown-repo-issue-7.log")
+	if got != want {
+		t.Fatalf("expected fallback session log path %q, got %q", want, got)
+	}
+}
+
 func TestWatchTargetMaxParallelDefaultsToSharedValue(t *testing.T) {
 	if got := normalizeMaxParallelSessions(0); got != DefaultMaxParallelSessions {
 		t.Fatalf("expected zero max_parallel_sessions to normalize to shared default %d, got %d", DefaultMaxParallelSessions, got)


### PR DESCRIPTION
## Summary
- scope session log filenames by canonical repository slug
- update runner call sites to use repo-qualified log paths consistently
- add tests for sanitization, missing repo slugs, and shared issue numbers across repos

Closes #179

## Validation
- go test ./...
