### PR TITLE
Add service status and restart CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Useful follow-up commands:
 ```sh
 vigilante list
 vigilante list --running
+vigilante status
+vigilante service restart
 vigilante daemon run --once
 ```
 
@@ -228,6 +230,27 @@ Expected fields:
 ### `vigilante list --running`
 
 Show currently running sessions with their repository, issue number, branch, and worktree path.
+
+### `vigilante status`
+
+Show whether the Vigilante OS-managed user service is installed and currently running.
+
+Expected behavior:
+
+- reports a stable `state` value of `running`, `stopped`, or `not-installed`
+- includes the service manager, service identifier, and installed service file path
+- exits successfully when the service is not installed so operators and scripts can inspect the reported state
+- fails with a clear error on unsupported operating systems or when the underlying service manager cannot be queried
+
+### `vigilante service restart`
+
+Restart the installed Vigilante user service through the operating system service manager.
+
+Expected behavior:
+
+- uses `launchctl` on macOS and `systemctl --user` on Linux
+- restarts the installed managed service instead of launching an unmanaged background process
+- fails clearly when the service is not installed or the platform is unsupported
 
 ### `vigilante cleanup --repo <owner/name> [--issue <n>]`
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -208,12 +208,19 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 			return errors.New("usage: vigilante list [--blocked | --running]")
 		}
 		return a.List(*blockedOnly, *runningOnly)
+	case "status":
+		if len(args) != 1 {
+			return errors.New("usage: vigilante status")
+		}
+		return a.Status(ctx)
 	case "cleanup":
 		return a.runCleanupCommand(ctx, args[1:])
 	case "redispatch":
 		return a.runRedispatchCommand(ctx, args[1:])
 	case "resume":
 		return a.runResumeCommand(ctx, args[1:])
+	case "service":
+		return a.runServiceCommand(ctx, args[1:])
 	case "daemon":
 		return a.runDaemonCommand(ctx, args[1:])
 	case "completion":
@@ -348,6 +355,17 @@ func (a *App) runDaemonCommand(ctx context.Context, args []string) error {
 	return a.DaemonRun(ctx, *interval, *once)
 }
 
+func (a *App) runServiceCommand(ctx context.Context, args []string) error {
+	if len(args) == 0 || isHelpToken(args[0]) {
+		a.printServiceUsage(a.stdout)
+		return nil
+	}
+	if len(args) != 1 || args[0] != "restart" {
+		return errors.New("usage: vigilante service restart")
+	}
+	return a.RestartService(ctx)
+}
+
 func (a *App) runCompletionCommand(args []string) error {
 	fs := flag.NewFlagSet("completion", flag.ContinueOnError)
 	configureFlagSet(fs, func(w io.Writer) {
@@ -374,6 +392,37 @@ func (a *App) runCompletionCommand(args []string) error {
 	}
 	_, err = fmt.Fprint(a.stdout, script)
 	return err
+}
+
+func (a *App) Status(ctx context.Context) error {
+	status, err := service.ServiceStatus(ctx, a.env)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(a.stdout, "state: %s\n", status.State)
+	fmt.Fprintf(a.stdout, "manager: %s\n", status.Manager)
+	fmt.Fprintf(a.stdout, "service: %s\n", status.Service)
+	fmt.Fprintf(a.stdout, "path: %s\n", status.FilePath)
+	if status.Installed {
+		fmt.Fprintln(a.stdout, "installed: yes")
+	} else {
+		fmt.Fprintln(a.stdout, "installed: no")
+	}
+	if status.Running {
+		fmt.Fprintln(a.stdout, "running: yes")
+	} else {
+		fmt.Fprintln(a.stdout, "running: no")
+	}
+	return nil
+}
+
+func (a *App) RestartService(ctx context.Context) error {
+	if err := service.Restart(ctx, a.env); err != nil {
+		return err
+	}
+	fmt.Fprintln(a.stdout, "service restart requested")
+	return nil
 }
 
 func (a *App) Setup(ctx context.Context, installDaemon bool) error {
@@ -2862,11 +2911,13 @@ func (a *App) printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  vigilante watch [-d] [--label value] [--assignee value] [--max-parallel value] [--provider value] <path>")
 	fmt.Fprintln(w, "  vigilante unwatch <path>")
 	fmt.Fprintln(w, "  vigilante list [--blocked | --running]")
+	fmt.Fprintln(w, "  vigilante status")
 	fmt.Fprintln(w, "  vigilante cleanup --repo <owner/name> [--issue <n>]")
 	fmt.Fprintln(w, "  vigilante cleanup --all")
 	fmt.Fprintln(w, "  vigilante redispatch --repo <owner/name> --issue <n>")
 	fmt.Fprintln(w, "  vigilante resume --repo <owner/name> --issue <n>")
 	fmt.Fprintln(w, "  vigilante resume --all-blocked")
+	fmt.Fprintln(w, "  vigilante service restart")
 	fmt.Fprintln(w, "  vigilante daemon run [--once] [--interval duration]")
 	fmt.Fprintln(w, "  vigilante completion <bash|fish|zsh>")
 	fmt.Fprintln(w)
@@ -2878,6 +2929,13 @@ func (a *App) printDaemonUsage(w io.Writer) {
 	fmt.Fprintln(w, "  vigilante daemon run [--once] [--interval duration]")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Use \"vigilante daemon run --help\" for flags.")
+}
+
+func (a *App) printServiceUsage(w io.Writer) {
+	fmt.Fprintln(w, "usage:")
+	fmt.Fprintln(w, "  vigilante service restart")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Use \"vigilante status\" to inspect the installed service.")
 }
 
 func completionScript(shell string) (string, error) {
@@ -2900,7 +2958,7 @@ _vigilante()
     local cur prev words cword
     _init_completion || return
 
-    local commands="setup watch unwatch list cleanup redispatch resume daemon completion"
+    local commands="setup watch unwatch list status cleanup redispatch resume service daemon completion"
     local global_flags="-h --help"
 
     case "${words[1]}" in
@@ -2916,6 +2974,9 @@ _vigilante()
             COMPREPLY=( $(compgen -W "--blocked --running" -- "$cur") )
             return
             ;;
+        status)
+            return
+            ;;
         cleanup)
             COMPREPLY=( $(compgen -W "--repo --issue --all" -- "$cur") )
             return
@@ -2926,6 +2987,10 @@ _vigilante()
             ;;
         resume)
             COMPREPLY=( $(compgen -W "--repo --issue --all-blocked" -- "$cur") )
+            return
+            ;;
+        service)
+            COMPREPLY=( $(compgen -W "restart" -- "$cur") )
             return
             ;;
         daemon)
@@ -2955,9 +3020,11 @@ complete -c vigilante -f -n '__fish_use_subcommand' -a 'setup' -d 'Prepare the m
 complete -c vigilante -f -n '__fish_use_subcommand' -a 'watch' -d 'Register a local repository for issue monitoring'
 complete -c vigilante -f -n '__fish_use_subcommand' -a 'unwatch' -d 'Remove a repository from the watchlist'
 complete -c vigilante -f -n '__fish_use_subcommand' -a 'list' -d 'Show watched repositories or sessions'
+complete -c vigilante -f -n '__fish_use_subcommand' -a 'status' -d 'Show installed service state'
 complete -c vigilante -f -n '__fish_use_subcommand' -a 'cleanup' -d 'Clean up running sessions'
 complete -c vigilante -f -n '__fish_use_subcommand' -a 'redispatch' -d 'Restart one watched issue in a fresh local worktree'
 complete -c vigilante -f -n '__fish_use_subcommand' -a 'resume' -d 'Resume blocked sessions'
+complete -c vigilante -f -n '__fish_use_subcommand' -a 'service' -d 'Run service commands'
 complete -c vigilante -f -n '__fish_use_subcommand' -a 'daemon' -d 'Run daemon commands'
 complete -c vigilante -f -n '__fish_use_subcommand' -a 'completion' -d 'Generate shell completion scripts'
 
@@ -2978,6 +3045,7 @@ complete -c vigilante -n '__fish_seen_subcommand_from redispatch' -l issue
 complete -c vigilante -n '__fish_seen_subcommand_from resume' -l repo
 complete -c vigilante -n '__fish_seen_subcommand_from resume' -l issue
 complete -c vigilante -n '__fish_seen_subcommand_from resume' -l all-blocked
+complete -c vigilante -n '__fish_seen_subcommand_from service' -a 'restart'
 complete -c vigilante -n '__fish_seen_subcommand_from daemon; and not __fish_seen_subcommand_from run' -a 'run'
 complete -c vigilante -n '__fish_seen_subcommand_from run' -l once
 complete -c vigilante -n '__fish_seen_subcommand_from run' -l interval
@@ -2995,9 +3063,11 @@ _vigilante() {
     'watch:Register a local repository for issue monitoring'
     'unwatch:Remove a repository from the watchlist'
     'list:Show watched repositories or sessions'
+    'status:Show installed service state'
     'cleanup:Clean up running sessions'
     'redispatch:Restart one watched issue in a fresh local worktree'
     'resume:Resume blocked sessions'
+    'service:Run service commands'
     'daemon:Run daemon commands'
     'completion:Generate shell completion scripts'
   )
@@ -3017,6 +3087,8 @@ _vigilante() {
     list)
       compadd -- --blocked --running
       ;;
+    status)
+      ;;
     cleanup)
       compadd -- --repo --issue --all
       ;;
@@ -3025,6 +3097,9 @@ _vigilante() {
       ;;
     resume)
       compadd -- --repo --issue --all-blocked
+      ;;
+    service)
+      compadd restart
       ;;
     daemon)
       if (( CURRENT == 3 )); then

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -38,6 +38,8 @@ func TestRunSupportsTopLevelHelpFlags(t *testing.T) {
 			for _, want := range []string{
 				"usage:",
 				"vigilante watch",
+				"vigilante status",
+				"vigilante service restart",
 				"vigilante completion <bash|fish|zsh>",
 				`Use "vigilante <command> --help" for command-specific usage.`,
 			} {
@@ -192,6 +194,138 @@ func TestRunSupportsDaemonHelp(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "usage:\n  vigilante daemon run [--once] [--interval duration]") {
 		t.Fatalf("unexpected output: %q", stdout.String())
+	}
+}
+
+func TestRunSupportsServiceHelp(t *testing.T) {
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+
+	exitCode := app.Run(context.Background(), []string{"service", "--help"})
+	if exitCode != 0 {
+		t.Fatalf("expected success exit code, got %d", exitCode)
+	}
+	if !strings.Contains(stdout.String(), "usage:\n  vigilante service restart") {
+		t.Fatalf("unexpected output: %q", stdout.String())
+	}
+}
+
+func TestStatusCommandReportsServiceState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "vigilante.service")
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unitPath, []byte("unit"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.OS = "linux"
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"systemctl --user show --property=LoadState,ActiveState vigilante.service": "LoadState=loaded\nActiveState=active\n",
+		},
+	}
+
+	exitCode := app.Run(context.Background(), []string{"status"})
+	if exitCode != 0 {
+		t.Fatalf("expected success exit code, got %d", exitCode)
+	}
+	for _, want := range []string{
+		"state: running",
+		"manager: systemd",
+		"service: vigilante.service",
+		"path: " + unitPath,
+		"installed: yes",
+		"running: yes",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("expected output to contain %q, got %q", want, stdout.String())
+		}
+	}
+}
+
+func TestStatusCommandFailsOnUnsupportedOS(t *testing.T) {
+	app := New()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = &stderr
+	app.env.OS = "windows"
+	app.env.Runner = testutil.FakeRunner{}
+
+	exitCode := app.Run(context.Background(), []string{"status"})
+	if exitCode != 1 {
+		t.Fatalf("expected failure exit code, got %d", exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected empty stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), `error: unsupported OS "windows"`) {
+		t.Fatalf("unexpected stderr: %q", stderr.String())
+	}
+}
+
+func TestServiceRestartCommandRequestsRestart(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "vigilante.service")
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unitPath, []byte("unit"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.OS = "linux"
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"systemctl --user show --property=LoadState,ActiveState vigilante.service": "LoadState=loaded\nActiveState=active\n",
+			"systemctl --user restart vigilante.service":                               "",
+		},
+	}
+
+	exitCode := app.Run(context.Background(), []string{"service", "restart"})
+	if exitCode != 0 {
+		t.Fatalf("expected success exit code, got %d", exitCode)
+	}
+	if !strings.Contains(stdout.String(), "service restart requested") {
+		t.Fatalf("unexpected stdout: %q", stdout.String())
+	}
+}
+
+func TestServiceRestartCommandFailsWhenServiceIsNotInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	app := New()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = &stderr
+	app.env.OS = "linux"
+	app.env.Runner = testutil.FakeRunner{}
+
+	exitCode := app.Run(context.Background(), []string{"service", "restart"})
+	if exitCode != 1 {
+		t.Fatalf("expected failure exit code, got %d", exitCode)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("expected empty stdout, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "error: service is not installed") {
+		t.Fatalf("unexpected stderr: %q", stderr.String())
 	}
 }
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -20,6 +20,26 @@ type Config struct {
 	HomeDir    string
 }
 
+const (
+	launchdLabel    = "com.vigilante.agent"
+	systemdUnitName = "vigilante.service"
+)
+
+const (
+	StatusNotInstalled = "not-installed"
+	StatusStopped      = "stopped"
+	StatusRunning      = "running"
+)
+
+type Status struct {
+	Manager   string
+	Service   string
+	FilePath  string
+	State     string
+	Installed bool
+	Running   bool
+}
+
 func Install(ctx context.Context, env *environment.Environment, store *state.Store, selectedProvider provider.Provider) error {
 	cfg, err := BuildConfig(ctx, env, selectedProvider)
 	if err != nil {
@@ -44,7 +64,7 @@ func installLaunchdService(ctx context.Context, env *environment.Environment, st
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	path := filepath.Join(dir, "com.vigilante.agent.plist")
+	path := filepath.Join(dir, launchdLabel+".plist")
 	if err := os.WriteFile(path, []byte(RenderLaunchdPlist(store, cfg)), 0o644); err != nil {
 		return err
 	}
@@ -60,13 +80,13 @@ func installSystemdUserService(ctx context.Context, env *environment.Environment
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	path := filepath.Join(dir, "vigilante.service")
+	path := filepath.Join(dir, systemdUnitName)
 	if err := os.WriteFile(path, []byte(RenderSystemdUnit(store, cfg)), 0o644); err != nil {
 		return err
 	}
 	for _, args := range [][]string{
 		{"--user", "daemon-reload"},
-		{"--user", "enable", "--now", "vigilante.service"},
+		{"--user", "enable", "--now", systemdUnitName},
 	} {
 		if _, err := env.Runner.Run(ctx, "", "systemctl", args...); err != nil {
 			return err
@@ -83,7 +103,7 @@ func RenderLaunchdPlist(store *state.Store, cfg Config) string {
 <plist version="1.0">
 <dict>
   <key>Label</key>
-  <string>com.vigilante.agent</string>
+  <string>%s</string>
   <key>ProgramArguments</key>
   <array>
     <string>%s</string>
@@ -107,7 +127,7 @@ func RenderLaunchdPlist(store *state.Store, cfg Config) string {
   <string>%s/vigilante.err.log</string>
 </dict>
 </plist>
-`, args[0], args[1], args[2], cfg.HomeDir, cfg.PathEnv, store.LogsDir(), store.LogsDir())) + "\n"
+`, launchdLabel, args[0], args[1], args[2], cfg.HomeDir, cfg.PathEnv, store.LogsDir(), store.LogsDir())) + "\n"
 }
 
 func RenderSystemdUnit(store *state.Store, cfg Config) string {
@@ -136,11 +156,98 @@ func FilePath(goos string) (string, error) {
 	}
 	switch goos {
 	case "darwin":
-		return filepath.Join(home, "Library", "LaunchAgents", "com.vigilante.agent.plist"), nil
+		return filepath.Join(home, "Library", "LaunchAgents", launchdLabel+".plist"), nil
 	case "linux":
-		return filepath.Join(home, ".config", "systemd", "user", "vigilante.service"), nil
+		return filepath.Join(home, ".config", "systemd", "user", systemdUnitName), nil
 	default:
 		return "", errors.New("unsupported OS")
+	}
+}
+
+func ServiceStatus(ctx context.Context, env *environment.Environment) (Status, error) {
+	status, err := baseStatus(env.OS)
+	if err != nil {
+		return Status{}, fmt.Errorf("unsupported OS %q", env.OS)
+	}
+
+	if _, err := os.Stat(status.FilePath); err != nil {
+		if os.IsNotExist(err) {
+			return status, nil
+		}
+		return Status{}, err
+	}
+
+	status.Installed = true
+
+	switch env.OS {
+	case "darwin":
+		output, err := env.Runner.Run(ctx, "", "launchctl", "print", launchdTarget())
+		if err != nil {
+			if isLaunchdServiceMissing(output, err) {
+				status.State = StatusStopped
+				return status, nil
+			}
+			return Status{}, fmt.Errorf("query launchd service status: %w", err)
+		}
+		status.Running = launchdOutputIndicatesRunning(output)
+	case "linux":
+		output, err := env.Runner.Run(ctx, "", "systemctl", "--user", "show", "--property=LoadState,ActiveState", systemdUnitName)
+		if err != nil {
+			return Status{}, fmt.Errorf("query systemd user service status: %w", err)
+		}
+		loadState, activeState := parseSystemdShow(output)
+		if loadState == "not-found" {
+			status.Installed = false
+			status.State = StatusNotInstalled
+			return status, nil
+		}
+		status.Running = activeState == "active"
+	}
+
+	if status.Running {
+		status.State = StatusRunning
+	} else {
+		status.State = StatusStopped
+	}
+
+	return status, nil
+}
+
+func Restart(ctx context.Context, env *environment.Environment) error {
+	status, err := ServiceStatus(ctx, env)
+	if err != nil {
+		return err
+	}
+	if !status.Installed {
+		return fmt.Errorf("service is not installed at %s", status.FilePath)
+	}
+
+	switch env.OS {
+	case "darwin":
+		_, err = env.Runner.Run(ctx, "", "launchctl", "kickstart", "-k", launchdTarget())
+	case "linux":
+		_, err = env.Runner.Run(ctx, "", "systemctl", "--user", "restart", systemdUnitName)
+	default:
+		return fmt.Errorf("unsupported OS %q", env.OS)
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func baseStatus(goos string) (Status, error) {
+	path, err := FilePath(goos)
+	if err != nil {
+		return Status{}, err
+	}
+	switch goos {
+	case "darwin":
+		return Status{Manager: "launchd", Service: launchdLabel, FilePath: path, State: StatusNotInstalled}, nil
+	case "linux":
+		return Status{Manager: "systemd", Service: systemdUnitName, FilePath: path, State: StatusNotInstalled}, nil
+	default:
+		return Status{}, errors.New("unsupported OS")
 	}
 }
 
@@ -288,4 +395,33 @@ func macOSBinaryContext(executable string, resolvedPath string, removedAttrs []s
 		return context
 	}
 	return context + fmt.Sprintf(" removed_xattrs=%s", strings.Join(removedAttrs, ","))
+}
+
+func launchdTarget() string {
+	return fmt.Sprintf("gui/%d/%s", os.Getuid(), launchdLabel)
+}
+
+func isLaunchdServiceMissing(output string, err error) bool {
+	combined := strings.ToLower(strings.TrimSpace(output + "\n" + err.Error()))
+	return strings.Contains(combined, "could not find service") || strings.Contains(combined, "service not found")
+}
+
+func launchdOutputIndicatesRunning(output string) bool {
+	lower := strings.ToLower(output)
+	return strings.Contains(lower, "pid = ") || strings.Contains(lower, "\"pid\" =")
+}
+
+func parseSystemdShow(output string) (string, string) {
+	var loadState string
+	var activeState string
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "LoadState="):
+			loadState = strings.TrimPrefix(line, "LoadState=")
+		case strings.HasPrefix(line, "ActiveState="):
+			activeState = strings.TrimPrefix(line, "ActiveState=")
+		}
+	}
+	return loadState, activeState
 }

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -212,6 +212,196 @@ func TestBuildConfigFailsWhenProviderVersionIsIncompatible(t *testing.T) {
 	}
 }
 
+func TestServiceStatusReportsLaunchdRunning(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "com.vigilante.agent.plist")
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(plistPath, []byte("plist"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := &environment.Environment{
+		OS: "darwin",
+		Runner: testutil.FakeRunner{
+			Outputs: map[string]string{
+				testutil.Key("launchctl", "print", launchdTarget()): "pid = 412\nstate = running\n",
+			},
+		},
+	}
+
+	status, err := ServiceStatus(context.Background(), env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.Installed || !status.Running || status.State != StatusRunning {
+		t.Fatalf("unexpected status: %#v", status)
+	}
+	if status.Manager != "launchd" || status.Service != launchdLabel || status.FilePath != plistPath {
+		t.Fatalf("unexpected service metadata: %#v", status)
+	}
+}
+
+func TestServiceStatusReportsLaunchdStoppedWhenServiceIsUnloaded(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "com.vigilante.agent.plist")
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(plistPath, []byte("plist"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := &environment.Environment{
+		OS: "darwin",
+		Runner: testutil.FakeRunner{
+			Errors: map[string]error{
+				testutil.Key("launchctl", "print", launchdTarget()): errors.New("Could not find service"),
+			},
+		},
+	}
+
+	status, err := ServiceStatus(context.Background(), env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.Installed || status.Running || status.State != StatusStopped {
+		t.Fatalf("unexpected status: %#v", status)
+	}
+}
+
+func TestServiceStatusReportsSystemdRunning(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "vigilante.service")
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unitPath, []byte("unit"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := &environment.Environment{
+		OS: "linux",
+		Runner: testutil.FakeRunner{
+			Outputs: map[string]string{
+				testutil.Key("systemctl", "--user", "show", "--property=LoadState,ActiveState", systemdUnitName): "LoadState=loaded\nActiveState=active\n",
+			},
+		},
+	}
+
+	status, err := ServiceStatus(context.Background(), env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.Installed || !status.Running || status.State != StatusRunning {
+		t.Fatalf("unexpected status: %#v", status)
+	}
+}
+
+func TestServiceStatusReportsNotInstalledWhenUnitFileIsMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	env := &environment.Environment{
+		OS:     "linux",
+		Runner: testutil.FakeRunner{},
+	}
+
+	status, err := ServiceStatus(context.Background(), env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Installed || status.Running || status.State != StatusNotInstalled {
+		t.Fatalf("unexpected status: %#v", status)
+	}
+	if status.FilePath != filepath.Join(home, ".config", "systemd", "user", "vigilante.service") {
+		t.Fatalf("unexpected service file path: %#v", status)
+	}
+}
+
+func TestServiceStatusReturnsErrorWhenSystemdStatusFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "vigilante.service")
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unitPath, []byte("unit"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := &environment.Environment{
+		OS: "linux",
+		Runner: testutil.FakeRunner{
+			Errors: map[string]error{
+				testutil.Key("systemctl", "--user", "show", "--property=LoadState,ActiveState", systemdUnitName): errors.New("dbus unavailable"),
+			},
+		},
+	}
+
+	_, err := ServiceStatus(context.Background(), env)
+	if err == nil || !strings.Contains(err.Error(), "query systemd user service status") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRestartUsesLaunchctlKickstart(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	plistPath := filepath.Join(home, "Library", "LaunchAgents", "com.vigilante.agent.plist")
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(plistPath, []byte("plist"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &recordingRunner{
+		FakeRunner: testutil.FakeRunner{
+			Outputs: map[string]string{
+				testutil.Key("launchctl", "print", launchdTarget()):           "pid = 412\nstate = running\n",
+				testutil.Key("launchctl", "kickstart", "-k", launchdTarget()): "",
+			},
+		},
+	}
+
+	env := &environment.Environment{OS: "darwin", Runner: runner}
+	if err := Restart(context.Background(), env); err != nil {
+		t.Fatal(err)
+	}
+
+	wantCalls := []string{
+		testutil.Key("launchctl", "print", launchdTarget()),
+		testutil.Key("launchctl", "kickstart", "-k", launchdTarget()),
+	}
+	if !reflect.DeepEqual(runner.calls, wantCalls) {
+		t.Fatalf("unexpected command sequence:\n got: %#v\nwant: %#v", runner.calls, wantCalls)
+	}
+}
+
+func TestRestartReturnsErrorWhenServiceIsNotInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	env := &environment.Environment{OS: "linux", Runner: testutil.FakeRunner{}}
+	err := Restart(context.Background(), env)
+	if err == nil || !strings.Contains(err.Error(), "service is not installed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRestartReturnsUnsupportedOSError(t *testing.T) {
+	env := &environment.Environment{OS: "windows", Runner: testutil.FakeRunner{}}
+	err := Restart(context.Background(), env)
+	if err == nil || !strings.Contains(err.Error(), `unsupported OS "windows"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestPrepareMacOSDaemonBinaryUsesResolvedPath(t *testing.T) {
 	dir := t.TempDir()
 	resolvedPath := filepath.Join(dir, "Caskroom", "vigilante", "1.2.3", "vigilante")


### PR DESCRIPTION
## Summary
- add service-layer status and restart helpers for launchd and systemd user services
- add `vigilante status` and `vigilante service restart` with help/completion wiring
- document the new commands and cover the new CLI/service behavior with tests

Closes #178.

## Validation
- `go test ./internal/service ./internal/app`
- `go test ./...`
