### PR TITLE
Fix Claude provider permissions and add session invocation logging

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2672,7 +2672,7 @@ func buildResumeFailureSummaryInvocation(selectedProvider provider.Provider, wor
 			Name: "claude",
 			Args: []string{
 				"--print",
-				"--permission-mode", "acceptEdits",
+				"--dangerously-skip-permissions",
 				prompt,
 			},
 		}, nil

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -4344,7 +4344,7 @@ func resumeDiagnosticSummaryCommand(worktreePath string, session state.Session, 
 func resumeDiagnosticSummaryCommandForProvider(worktreePath string, providerID string, session state.Session, previousStage string) string {
 	switch providerID {
 	case "claude":
-		return testutil.Key("claude", "--print", "--permission-mode", "acceptEdits", buildResumeFailureSummaryPrompt(session, previousStage))
+		return testutil.Key("claude", "--print", "--dangerously-skip-permissions", buildResumeFailureSummaryPrompt(session, previousStage))
 	case "gemini":
 		return testutil.Key("gemini", "--prompt", buildResumeFailureSummaryPrompt(session, previousStage), "--yolo")
 	default:

--- a/internal/provider/claude.go
+++ b/internal/provider/claude.go
@@ -32,7 +32,7 @@ func (claudeProvider) BuildIssuePreflightInvocation(task IssueTask) (Invocation,
 		Name: "claude",
 		Args: []string{
 			"--print",
-			"--permission-mode", "acceptEdits",
+			"--dangerously-skip-permissions",
 			skill.BuildIssuePreflightPrompt(task.Target, task.Issue, task.Session),
 		},
 	}, nil
@@ -44,7 +44,7 @@ func (claudeProvider) BuildIssueInvocation(task IssueTask) (Invocation, error) {
 		Name: "claude",
 		Args: []string{
 			"--print",
-			"--permission-mode", "acceptEdits",
+			"--dangerously-skip-permissions",
 			skill.BuildIssuePromptForRuntime(skill.RuntimeClaude, task.Target, task.Issue, task.Session),
 		},
 	}, nil
@@ -56,7 +56,7 @@ func (claudeProvider) BuildConflictResolutionInvocation(task ConflictTask) (Invo
 		Name: "claude",
 		Args: []string{
 			"--print",
-			"--permission-mode", "acceptEdits",
+			"--dangerously-skip-permissions",
 			skill.BuildConflictResolutionPromptForRuntime(skill.RuntimeClaude, task.Target, task.Session, task.PR),
 		},
 	}, nil

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -94,7 +94,7 @@ func TestClaudeInvocationUsesWorktreeDirForHeadlessRuns(t *testing.T) {
 	if preflight.Dir != "/tmp/worktree" {
 		t.Fatalf("expected preflight dir to be worktree, got %#v", preflight)
 	}
-	wantPreflightArgs := []string{"--print", "--permission-mode", "acceptEdits", skill.BuildIssuePreflightPrompt(target, issue, session)}
+	wantPreflightArgs := []string{"--print", "--dangerously-skip-permissions", skill.BuildIssuePreflightPrompt(target, issue, session)}
 	assertInvocationArgs(t, preflight.Args, wantPreflightArgs)
 
 	issueInvocation, err := selectedProvider.BuildIssueInvocation(IssueTask{Target: target, Issue: issue, Session: session})
@@ -104,7 +104,7 @@ func TestClaudeInvocationUsesWorktreeDirForHeadlessRuns(t *testing.T) {
 	if issueInvocation.Dir != "/tmp/worktree" {
 		t.Fatalf("expected issue dir to be worktree, got %#v", issueInvocation)
 	}
-	wantIssueArgs := []string{"--print", "--permission-mode", "acceptEdits", skill.BuildIssuePromptForRuntime(skill.RuntimeClaude, target, issue, session)}
+	wantIssueArgs := []string{"--print", "--dangerously-skip-permissions", skill.BuildIssuePromptForRuntime(skill.RuntimeClaude, target, issue, session)}
 	assertInvocationArgs(t, issueInvocation.Args, wantIssueArgs)
 
 	conflictInvocation, err := selectedProvider.BuildConflictResolutionInvocation(ConflictTask{Target: target, Session: session, PR: pr})
@@ -114,7 +114,7 @@ func TestClaudeInvocationUsesWorktreeDirForHeadlessRuns(t *testing.T) {
 	if conflictInvocation.Dir != "/tmp/worktree" {
 		t.Fatalf("expected conflict dir to be worktree, got %#v", conflictInvocation)
 	}
-	wantConflictArgs := []string{"--print", "--permission-mode", "acceptEdits", skill.BuildConflictResolutionPromptForRuntime(skill.RuntimeClaude, target, session, pr)}
+	wantConflictArgs := []string{"--print", "--dangerously-skip-permissions", skill.BuildConflictResolutionPromptForRuntime(skill.RuntimeClaude, target, session, pr)}
 	assertInvocationArgs(t, conflictInvocation.Args, wantConflictArgs)
 }
 

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -86,6 +86,8 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 		appendSessionLog(logPath, "issue preflight invocation build failed", session, err.Error())
 		return session
 	}
+	appendSessionLog(logPath, "issue preflight invocation starting", session, formatInvocationDebug(preflightInvocation))
+	preflightStart := time.Now()
 	preflightOutput, err := env.Runner.Run(ctx, preflightInvocation.Dir, preflightInvocation.Name, preflightInvocation.Args...)
 	if err != nil {
 		if errors.Is(err, context.Canceled) || ctx.Err() != nil {
@@ -115,7 +117,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 		_ = ghcli.CommentOnIssue(ctx, env.Runner, target.Repo, issue.Number, body)
 		return session
 	}
-	appendSessionLog(logPath, "issue preflight succeeded", session, preflightOutput)
+	appendSessionLog(logPath, fmt.Sprintf("issue preflight succeeded duration=%s output_bytes=%d", time.Since(preflightStart).Truncate(time.Second), len(preflightOutput)), session, preflightOutput)
 
 	invocation, err := selectedProvider.BuildIssueInvocation(provider.IssueTask{Target: target, Issue: issue, Session: session})
 	if err != nil {
@@ -127,6 +129,8 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 		appendSessionLog(logPath, "issue invocation build failed", session, err.Error())
 		return session
 	}
+	appendSessionLog(logPath, "issue invocation starting", session, formatInvocationDebug(invocation))
+	invocationStart := time.Now()
 	output, err := env.Runner.Run(ctx, invocation.Dir, invocation.Name, invocation.Args...)
 	session.EndedAt = time.Now().UTC().Format(time.RFC3339)
 	session.LastHeartbeatAt = session.EndedAt
@@ -141,7 +145,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 		blocked := classifyBlockedFailure("issue_execution", invocation.Name, output, err)
 		markSessionBlocked(&session, "issue_execution", blocked, time.Now().UTC())
 		session.LastError = err.Error()
-		appendSessionLog(logPath, "session failed", session, combineLogDetails(output, err.Error()))
+		appendSessionLog(logPath, fmt.Sprintf("session failed duration=%s output_bytes=%d", time.Since(invocationStart).Truncate(time.Second), len(output)), session, combineLogDetails(output, err.Error()))
 		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
 			Stage:      "Blocked",
 			Emoji:      "🛑",
@@ -159,7 +163,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 	}
 
 	session.Status = state.SessionStatusSuccess
-	appendSessionLog(logPath, "session succeeded", session, output)
+	appendSessionLog(logPath, fmt.Sprintf("session succeeded duration=%s output_bytes=%d", time.Since(invocationStart).Truncate(time.Second), len(output)), session, output)
 	return session
 }
 
@@ -335,6 +339,21 @@ func appendSessionLog(path string, event string, session state.Session, details 
 		_, _ = fmt.Fprintln(f, strings.TrimSpace(details))
 	}
 	_, _ = fmt.Fprintln(f)
+}
+
+func formatInvocationDebug(inv provider.Invocation) string {
+	lines := []string{
+		fmt.Sprintf("dir=%s", inv.Dir),
+		fmt.Sprintf("cmd=%s", inv.Name),
+	}
+	for i, arg := range inv.Args {
+		if len(arg) > 200 {
+			lines = append(lines, fmt.Sprintf("arg[%d]=(%d bytes) %s...", i, len(arg), arg[:200]))
+		} else {
+			lines = append(lines, fmt.Sprintf("arg[%d]=%s", i, arg))
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 func combineLogDetails(output string, errText string) string {

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -223,12 +223,12 @@ func TestRunIssueSessionSuccessWithClaudeProvider(t *testing.T) {
 				},
 				Tagline: "Make it simple, but significant.",
 			}): "ok",
-			testutil.Key("claude", "--print", "--permission-mode", "acceptEdits", skill.BuildIssuePreflightPrompt(
+			testutil.Key("claude", "--print", "--dangerously-skip-permissions", skill.BuildIssuePreflightPrompt(
 				state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"},
 				ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"},
 				state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "claude"},
 			)): "baseline ok",
-			testutil.Key("claude", "--print", "--permission-mode", "acceptEdits", skill.BuildIssuePromptForRuntime(
+			testutil.Key("claude", "--print", "--dangerously-skip-permissions", skill.BuildIssuePromptForRuntime(
 				skill.RuntimeClaude,
 				state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"},
 				ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"},


### PR DESCRIPTION
Use --dangerously-skip-permissions instead of --permission-mode acceptEdits for Claude headless execution. The previous mode only auto-approved file edits, blocking git push, gh commands, and other shell operations in headless --print mode. This prevented the agent from pushing branches, opening PRs, or posting issue comments.

Also add invocation debug logging to the session runner: log the full command, args, duration, and output size for both preflight and main execution so issues are diagnosable from ~/.vigilante/logs/issue-N.log.

Closes #188