### PR TITLE
Teach PR maintenance to remediate failing CI checks

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1125,7 +1125,7 @@ func (a *App) maintainOpenPullRequest(ctx context.Context, session *state.Sessio
 	session.LastMaintainedAt = a.clock().Format(time.RFC3339)
 	session.UpdatedAt = session.LastMaintainedAt
 	if !rebased {
-		return a.tryAutoSquashMerge(ctx, session, pr)
+		return a.maintainPullRequestChecks(ctx, session, pr)
 	}
 
 	if _, err := a.env.Runner.Run(ctx, session.WorktreePath, "go", "test", "./..."); err != nil {
@@ -1150,16 +1150,33 @@ func (a *App) maintainOpenPullRequest(ctx context.Context, session *state.Sessio
 	return ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body)
 }
 
-func (a *App) tryAutoSquashMerge(ctx context.Context, session *state.Session, pr ghcli.PullRequest) error {
+func (a *App) maintainPullRequestChecks(ctx context.Context, session *state.Session, pr ghcli.PullRequest) error {
 	details, err := ghcli.GetPullRequestDetails(ctx, a.env.Runner, session.Repo, pr.Number)
 	if err != nil {
 		return err
 	}
-	if !ghcli.HasAnyLabel(details.Labels, "automerge") {
+	if err := a.handleFailingPullRequestChecks(ctx, session, *details); err != nil {
+		return err
+	}
+	if requiredChecksState(details.StatusCheckRollup) == "failing" {
+		return nil
+	}
+	return a.tryAutoSquashMerge(ctx, session, *details)
+}
+
+func (a *App) tryAutoSquashMerge(ctx context.Context, session *state.Session, pr ghcli.PullRequest) error {
+	checkState := requiredChecksState(pr.StatusCheckRollup)
+	if !ghcli.HasAnyLabel(pr.Labels, "automerge") {
+		if checkState == "pending" {
+			session.LastMaintenanceError = fmt.Sprintf("pr maintenance waiting for required checks on PR #%d", pr.Number)
+		} else if checkState == "passing" {
+			session.LastCIRemediationFingerprint = ""
+			session.LastCIRemediationAttemptedAt = ""
+		}
 		return nil
 	}
 
-	waitReason := automergeWaitReason(*details)
+	waitReason := automergeWaitReason(pr)
 	if waitReason != "" {
 		session.LastMaintenanceError = waitReason
 		a.state.AppendDaemonLog("automerge waiting repo=%s issue=%d pr=%d branch=%s reason=%s", session.Repo, session.IssueNumber, pr.Number, session.Branch, waitReason)
@@ -1171,6 +1188,80 @@ func (a *App) tryAutoSquashMerge(ctx context.Context, session *state.Session, pr
 	}
 
 	a.state.AppendDaemonLog("automerge merged repo=%s issue=%d pr=%d branch=%s strategy=squash", session.Repo, session.IssueNumber, pr.Number, session.Branch)
+	return nil
+}
+
+func (a *App) handleFailingPullRequestChecks(ctx context.Context, session *state.Session, pr ghcli.PullRequest) error {
+	checkState := requiredChecksState(pr.StatusCheckRollup)
+	switch checkState {
+	case "pending":
+		if !ghcli.HasAnyLabel(pr.Labels, "automerge") {
+			session.LastMaintenanceError = fmt.Sprintf("pr maintenance waiting for required checks on PR #%d", pr.Number)
+		}
+		return nil
+	case "passing":
+		session.LastCIRemediationFingerprint = ""
+		session.LastCIRemediationAttemptedAt = ""
+		return nil
+	}
+
+	failingChecks := failingStatusChecks(pr.StatusCheckRollup)
+	if len(failingChecks) == 0 {
+		return nil
+	}
+	fingerprint := ciFailureFingerprint(pr.Number, failingChecks)
+	if fingerprint == session.LastCIRemediationFingerprint {
+		blocked := state.BlockedReason{
+			Kind:      "unknown_operator_action_required",
+			Operation: "ci remediation",
+			Summary:   fmt.Sprintf("CI remediation already ran for PR #%d but the same failing checks are still unresolved", pr.Number),
+			Detail:    formatFailingChecksSummary(failingChecks),
+		}
+		markSessionBlocked(session, "ci_remediation", blocked, a.clock())
+		session.LastMaintenanceError = blocked.Summary
+		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+			Stage:      "CI Needs Manual Review",
+			Emoji:      "🧱",
+			Percent:    94,
+			ETAMinutes: 10,
+			Items: []string{
+				fmt.Sprintf("PR #%d still reports the same failing checks after an automated remediation attempt.", pr.Number),
+				fmt.Sprintf("Failing checks: %s", formatFailingChecksSummary(failingChecks)),
+				fmt.Sprintf("Next step: inspect the branch `%s`, apply a manual fix, then run `%s` or request resume from GitHub.", session.Branch, session.ResumeHint),
+			},
+			Tagline: "One clean retry is enough to prove the point.",
+		})
+		a.commentOnIssueBestEffort(ctx, session.Repo, session.IssueNumber, body, "ci remediation blocked")
+		return nil
+	}
+
+	startBody := ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "CI Remediation Started",
+		Emoji:      "🛠️",
+		Percent:    80,
+		ETAMinutes: 12,
+		Items: []string{
+			fmt.Sprintf("Vigilante detected failing required checks on PR #%d and is launching a focused remediation pass.", pr.Number),
+			fmt.Sprintf("Failing checks: %s", formatFailingChecksSummary(failingChecks)),
+			"Next step: investigate the failure, apply the smallest fix that restores CI, and push to the existing PR branch.",
+		},
+		Tagline: "Tight loop, targeted repair.",
+	})
+	a.commentOnIssueBestEffort(ctx, session.Repo, session.IssueNumber, startBody, "ci remediation start")
+
+	target := state.WatchTarget{Path: session.RepoPath, Repo: session.Repo, Branch: "main"}
+	if err := issuerunner.RunCIRemediationSession(ctx, a.env, a.state, target, *session, pr, failingChecks); err != nil {
+		blocked := classifyBlockedReason("ci_remediation", "coding agent remediation", err)
+		markSessionBlocked(session, "ci_remediation", blocked, a.clock())
+		session.LastMaintenanceError = err.Error()
+		session.LastCIRemediationFingerprint = fingerprint
+		session.LastCIRemediationAttemptedAt = a.clock().Format(time.RFC3339)
+		return nil
+	}
+
+	session.LastCIRemediationFingerprint = fingerprint
+	session.LastCIRemediationAttemptedAt = a.clock().Format(time.RFC3339)
+	session.LastMaintenanceError = fmt.Sprintf("ci remediation dispatched for PR #%d; waiting for updated checks", pr.Number)
 	return nil
 }
 
@@ -1681,6 +1772,8 @@ func (a *App) resetSessionForRedispatch(ctx context.Context, session *state.Sess
 	session.PullRequestMergedAt = ""
 	session.LastMaintainedAt = ""
 	session.LastMaintenanceError = ""
+	session.LastCIRemediationFingerprint = ""
+	session.LastCIRemediationAttemptedAt = ""
 	session.BlockedAt = ""
 	session.BlockedStage = ""
 	session.BlockedReason = state.BlockedReason{}
@@ -1728,6 +1821,8 @@ func (a *App) resumeBlockedSession(ctx context.Context, session *state.Session, 
 	var err error
 	switch session.BlockedStage {
 	case "pr_maintenance":
+		err = a.resumeBlockedMaintenance(ctx, session)
+	case "ci_remediation":
 		err = a.resumeBlockedMaintenance(ctx, session)
 	case "conflict_resolution":
 		err = a.resumeBlockedConflictResolution(ctx, session)
@@ -2151,6 +2246,53 @@ func requiredChecksState(checks []ghcli.StatusCheckRoll) string {
 	return "passing"
 }
 
+func failingStatusChecks(checks []ghcli.StatusCheckRoll) []ghcli.StatusCheckRoll {
+	failing := make([]ghcli.StatusCheckRoll, 0, len(checks))
+	for _, check := range checks {
+		switch strings.ToUpper(strings.TrimSpace(check.Conclusion)) {
+		case "ACTION_REQUIRED", "CANCELLED", "FAILURE", "STALE", "STARTUP_FAILURE", "TIMED_OUT":
+			failing = append(failing, check)
+		}
+	}
+	sort.Slice(failing, func(i, j int) bool {
+		return failingCheckName(failing[i]) < failingCheckName(failing[j])
+	})
+	return failing
+}
+
+func ciFailureFingerprint(prNumber int, checks []ghcli.StatusCheckRoll) string {
+	parts := []string{fmt.Sprintf("pr:%d", prNumber)}
+	for _, check := range checks {
+		parts = append(parts, strings.Join([]string{
+			failingCheckName(check),
+			strings.ToUpper(strings.TrimSpace(check.State)),
+			strings.ToUpper(strings.TrimSpace(check.Conclusion)),
+		}, ":"))
+	}
+	return strings.Join(parts, "|")
+}
+
+func formatFailingChecksSummary(checks []ghcli.StatusCheckRoll) string {
+	if len(checks) == 0 {
+		return "unknown failing checks"
+	}
+	parts := make([]string, 0, len(checks))
+	for _, check := range checks {
+		parts = append(parts, fmt.Sprintf("%s (%s)", failingCheckName(check), strings.ToLower(fallbackText(strings.TrimSpace(check.Conclusion), "unknown"))))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func failingCheckName(check ghcli.StatusCheckRoll) string {
+	if name := strings.TrimSpace(check.Name); name != "" {
+		return name
+	}
+	if context := strings.TrimSpace(check.Context); context != "" {
+		return context
+	}
+	return "unnamed-check"
+}
+
 func summarizeText(text string) string {
 	text = strings.TrimSpace(text)
 	if len(text) > 400 {
@@ -2229,6 +2371,8 @@ func clearBlockedState(session *state.Session, now time.Time, source string) {
 	session.UpdatedAt = session.RecoveredAt
 	session.LastError = ""
 	session.LastMaintenanceError = ""
+	session.LastCIRemediationFingerprint = ""
+	session.LastCIRemediationAttemptedAt = ""
 	session.LastResumeSource = source
 	session.LastResumeFailureFingerprint = ""
 	session.LastResumeFailureCommentedAt = ""

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -3963,13 +3963,34 @@ func TestScanOnceAutomergeWaitsForPendingChecks(t *testing.T) {
 	}
 }
 
-func TestScanOnceAutomergeWaitsForFailingChecks(t *testing.T) {
+func TestScanOnceFailingChecksTriggerCIRemediation(t *testing.T) {
 	app, _ := newPullRequestMaintenanceTestApp(t, map[string]string{
 		"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
 		"git fetch origin main":  "ok",
 		"git status --porcelain": "",
 		"git rebase origin/main": "Current branch vigilante/issue-1 is up to date.\n",
-		"gh pr view --repo owner/repo 31 --json number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("automerge", "BLOCKED", "APPROVED", "COMPLETED", "FAILURE"),
+		"gh pr view --repo owner/repo 31 --json number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("", "BLOCKED", "APPROVED", "COMPLETED", "FAILURE"),
+		"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+			Stage:      "CI Remediation Started",
+			Emoji:      "🛠️",
+			Percent:    80,
+			ETAMinutes: 12,
+			Items: []string{
+				"Vigilante detected failing required checks on PR #31 and is launching a focused remediation pass.",
+				"Failing checks: test (failure)",
+				"Next step: investigate the failure, apply the smallest fix that restores CI, and push to the existing PR branch.",
+			},
+			Tagline: "Tight loop, targeted repair.",
+		}): "ok",
+		"codex --version": "codex 0.114.0",
+		ciRemediationPromptCommand(filepath.Join("/tmp/repo", ".worktrees", "vigilante", "issue-1"), "owner/repo", "/tmp/repo", state.Session{
+			IssueNumber:  1,
+			IssueTitle:   "first",
+			IssueURL:     "https://github.com/owner/repo/issues/1",
+			WorktreePath: filepath.Join("/tmp/repo", ".worktrees", "vigilante", "issue-1"),
+			Branch:       "vigilante/issue-1",
+			Provider:     "codex",
+		}, ghcli.PullRequest{Number: 31, URL: "https://github.com/owner/repo/pull/31"}, []ghcli.StatusCheckRoll{{Context: "test", State: "COMPLETED", Conclusion: "FAILURE"}}): "fixed and pushed",
 		"gh api user --jq .login": "nicobistolfi\n",
 		"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
 	})
@@ -3983,8 +4004,64 @@ func TestScanOnceAutomergeWaitsForFailingChecks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if sessions[0].LastMaintenanceError != "automerge waiting for required checks to pass on PR #31" {
-		t.Fatalf("expected failing-checks wait state, got: %#v", sessions[0])
+	if sessions[0].Status != state.SessionStatusSuccess {
+		t.Fatalf("expected maintenance to stay active after remediation dispatch: %#v", sessions[0])
+	}
+	if sessions[0].LastMaintenanceError != "ci remediation dispatched for PR #31; waiting for updated checks" {
+		t.Fatalf("expected remediation wait state, got: %#v", sessions[0])
+	}
+	if sessions[0].LastCIRemediationFingerprint == "" || sessions[0].LastCIRemediationAttemptedAt == "" {
+		t.Fatalf("expected remediation fingerprint tracking, got: %#v", sessions[0])
+	}
+}
+
+func TestScanOnceRepeatedIdenticalFailingChecksBlockForManualReview(t *testing.T) {
+	app, _ := newPullRequestMaintenanceTestApp(t, map[string]string{
+		"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
+		"git fetch origin main":  "ok",
+		"git status --porcelain": "",
+		"git rebase origin/main": "Current branch vigilante/issue-1 is up to date.\n",
+		"gh pr view --repo owner/repo 31 --json number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("", "BLOCKED", "APPROVED", "COMPLETED", "FAILURE"),
+		"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+			Stage:      "CI Needs Manual Review",
+			Emoji:      "🧱",
+			Percent:    94,
+			ETAMinutes: 10,
+			Items: []string{
+				"PR #31 still reports the same failing checks after an automated remediation attempt.",
+				"Failing checks: test (failure)",
+				"Next step: inspect the branch `vigilante/issue-1`, apply a manual fix, then run `vigilante resume --repo owner/repo --issue 1` or request resume from GitHub.",
+			},
+			Tagline: "One clean retry is enough to prove the point.",
+		}): "ok",
+		"gh api user --jq .login": "nicobistolfi\n",
+		"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+	})
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessions[0].LastCIRemediationFingerprint = ciFailureFingerprint(31, []ghcli.StatusCheckRoll{{Context: "test", State: "COMPLETED", Conclusion: "FAILURE"}})
+	sessions[0].LastCIRemediationAttemptedAt = "2026-03-17T19:30:00Z"
+	if err := app.state.SaveSessions(sessions); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	app.waitForSessions()
+
+	sessions, err = app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions[0].Status != state.SessionStatusBlocked || sessions[0].BlockedStage != "ci_remediation" {
+		t.Fatalf("expected manual-review block after repeated failure, got: %#v", sessions[0])
+	}
+	if sessions[0].ResumeHint != "vigilante resume --repo owner/repo --issue 1" {
+		t.Fatalf("unexpected resume hint: %#v", sessions[0])
 	}
 }
 
@@ -4484,4 +4561,13 @@ func resumeDiagnosticSummaryCommandForProvider(worktreePath string, providerID s
 	default:
 		return resumeDiagnosticSummaryCommand(worktreePath, session, previousStage)
 	}
+}
+
+func ciRemediationPromptCommand(worktreePath string, repo string, repoPath string, session state.Session, pr ghcli.PullRequest, checks []ghcli.StatusCheckRoll) string {
+	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildCIRemediationPrompt(
+		state.WatchTarget{Path: repoPath, Repo: repo},
+		session,
+		pr,
+		checks,
+	))
 }

--- a/internal/provider/claude.go
+++ b/internal/provider/claude.go
@@ -61,3 +61,15 @@ func (claudeProvider) BuildConflictResolutionInvocation(task ConflictTask) (Invo
 		},
 	}, nil
 }
+
+func (claudeProvider) BuildCIRemediationInvocation(task CIRemediationTask) (Invocation, error) {
+	return Invocation{
+		Dir:  task.Session.WorktreePath,
+		Name: "claude",
+		Args: []string{
+			"--print",
+			"--permission-mode", "acceptEdits",
+			skill.BuildCIRemediationPromptForRuntime(skill.RuntimeClaude, task.Target, task.Session, task.PR, task.FailingChecks),
+		},
+	}, nil
+}

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -58,3 +58,15 @@ func (codexProvider) BuildConflictResolutionInvocation(task ConflictTask) (Invoc
 		},
 	}, nil
 }
+
+func (codexProvider) BuildCIRemediationInvocation(task CIRemediationTask) (Invocation, error) {
+	return Invocation{
+		Name: "codex",
+		Args: []string{
+			"exec",
+			"--cd", task.Session.WorktreePath,
+			"--dangerously-bypass-approvals-and-sandbox",
+			skill.BuildCIRemediationPrompt(task.Target, task.Session, task.PR, task.FailingChecks),
+		},
+	}, nil
+}

--- a/internal/provider/gemini.go
+++ b/internal/provider/gemini.go
@@ -58,3 +58,15 @@ func (geminiProvider) BuildConflictResolutionInvocation(task ConflictTask) (Invo
 		},
 	}, nil
 }
+
+func (geminiProvider) BuildCIRemediationInvocation(task CIRemediationTask) (Invocation, error) {
+	return Invocation{
+		Dir:  task.Session.WorktreePath,
+		Name: "gemini",
+		Args: []string{
+			"--prompt",
+			skill.BuildCIRemediationPromptForRuntime(skill.RuntimeGemini, task.Target, task.Session, task.PR, task.FailingChecks),
+			"--yolo",
+		},
+	}, nil
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -31,6 +31,13 @@ type ConflictTask struct {
 	PR      ghcli.PullRequest
 }
 
+type CIRemediationTask struct {
+	Target        state.WatchTarget
+	Session       state.Session
+	PR            ghcli.PullRequest
+	FailingChecks []ghcli.StatusCheckRoll
+}
+
 type Provider interface {
 	ID() string
 	DisplayName() string
@@ -39,6 +46,7 @@ type Provider interface {
 	BuildIssuePreflightInvocation(task IssueTask) (Invocation, error)
 	BuildIssueInvocation(task IssueTask) (Invocation, error)
 	BuildConflictResolutionInvocation(task ConflictTask) (Invocation, error)
+	BuildCIRemediationInvocation(task CIRemediationTask) (Invocation, error)
 }
 
 var registry = map[string]Provider{

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -116,6 +116,21 @@ func TestClaudeInvocationUsesWorktreeDirForHeadlessRuns(t *testing.T) {
 	}
 	wantConflictArgs := []string{"--print", "--permission-mode", "acceptEdits", skill.BuildConflictResolutionPromptForRuntime(skill.RuntimeClaude, target, session, pr)}
 	assertInvocationArgs(t, conflictInvocation.Args, wantConflictArgs)
+
+	remediationInvocation, err := selectedProvider.BuildCIRemediationInvocation(CIRemediationTask{
+		Target:        target,
+		Session:       session,
+		PR:            pr,
+		FailingChecks: []ghcli.StatusCheckRoll{{Context: "test", Conclusion: "FAILURE"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if remediationInvocation.Dir != "/tmp/worktree" {
+		t.Fatalf("expected remediation dir to be worktree, got %#v", remediationInvocation)
+	}
+	wantRemediationArgs := []string{"--print", "--permission-mode", "acceptEdits", skill.BuildCIRemediationPromptForRuntime(skill.RuntimeClaude, target, session, pr, []ghcli.StatusCheckRoll{{Context: "test", Conclusion: "FAILURE"}})}
+	assertInvocationArgs(t, remediationInvocation.Args, wantRemediationArgs)
 }
 
 func TestResolveIssueLabelUsesRegisteredProviderIDs(t *testing.T) {
@@ -286,5 +301,9 @@ func (p testProvider) BuildIssueInvocation(task IssueTask) (Invocation, error) {
 }
 
 func (p testProvider) BuildConflictResolutionInvocation(task ConflictTask) (Invocation, error) {
+	return Invocation{}, nil
+}
+
+func (p testProvider) BuildCIRemediationInvocation(task CIRemediationTask) (Invocation, error) {
 	return Invocation{}, nil
 }

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -217,6 +217,53 @@ func RunConflictResolutionSession(ctx context.Context, env *environment.Environm
 	return nil
 }
 
+func RunCIRemediationSession(ctx context.Context, env *environment.Environment, store *state.Store, target state.WatchTarget, session state.Session, pr ghcli.PullRequest, failingChecks []ghcli.StatusCheckRoll) error {
+	repoSlug := session.Repo
+	if repoSlug == "" {
+		repoSlug = target.Repo
+	}
+	logPath := store.SessionLogPath(repoSlug, session.IssueNumber)
+	selectedProvider, err := provider.Resolve(session.Provider)
+	if err != nil {
+		appendSessionLog(logPath, "ci remediation provider resolution failed", session, err.Error())
+		return err
+	}
+	session.Provider = selectedProvider.ID()
+	appendSessionLog(logPath, "ci remediation started", session, fmt.Sprintf("pr=%d url=%s", pr.Number, pr.URL))
+	if err := provider.ValidateRuntimeCompatibility(ctx, env.Runner, selectedProvider); err != nil {
+		appendSessionLog(logPath, "ci remediation provider compatibility failed", session, err.Error())
+		return err
+	}
+
+	invocation, err := selectedProvider.BuildCIRemediationInvocation(provider.CIRemediationTask{Target: target, Session: session, PR: pr, FailingChecks: failingChecks})
+	if err != nil {
+		appendSessionLog(logPath, "ci remediation invocation build failed", session, err.Error())
+		return err
+	}
+	output, err := env.Runner.Run(ctx, invocation.Dir, invocation.Name, invocation.Args...)
+	if err != nil {
+		appendSessionLog(logPath, "ci remediation failed", session, combineLogDetails(output, err.Error()))
+		blocked := classifyBlockedFailure("ci_remediation", invocation.Name, output, err)
+		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+			Stage:      "CI Remediation Blocked",
+			Emoji:      "🧯",
+			Percent:    92,
+			ETAMinutes: 10,
+			Items: []string{
+				blockedCIRemediationMessage(blocked, pr.Number, session.Branch, selectedProvider.ID()),
+				blocking.CauseLine(blocked),
+				fmt.Sprintf("Next step: fix the blocker, then run `%s` or request resume from GitHub.", buildResumeHint(session)),
+			},
+			Tagline: "Stop the loop before it turns into noise.",
+		})
+		_ = ghcli.CommentOnIssue(ctx, env.Runner, target.Repo, session.IssueNumber, body)
+		return err
+	}
+
+	appendSessionLog(logPath, "ci remediation succeeded", session, output)
+	return nil
+}
+
 func summarizeError(err error) string {
 	text := strings.TrimSpace(err.Error())
 	if len(text) > 400 {
@@ -250,6 +297,13 @@ func blockedPreflightMessage(blocked state.BlockedReason, providerID string) str
 		return fmt.Sprintf("The `%s` provider hit a usage or subscription limit during issue preflight.", providerID)
 	}
 	return "Repository baseline validation failed before issue implementation began."
+}
+
+func blockedCIRemediationMessage(blocked state.BlockedReason, prNumber int, branch string, providerID string) string {
+	if blocked.Kind == "provider_quota" {
+		return fmt.Sprintf("CI remediation for PR #%d on `%s` stopped because the `%s` account hit a usage or subscription limit.", prNumber, branch, providerID)
+	}
+	return fmt.Sprintf("CI remediation for PR #%d on `%s` did not complete automatically.", prNumber, branch)
 }
 
 func blockedPreflightItems(blocked state.BlockedReason, providerID string, preflightOutput string, resumeHint string) []string {

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -205,6 +205,49 @@ func TestRunConflictResolutionSessionFailureCommentsOnIssue(t *testing.T) {
 	}
 }
 
+func TestRunCIRemediationSessionFailureCommentsOnIssue(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"codex --version": "codex 0.114.0",
+			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "CI Remediation Blocked",
+				Emoji:      "🧯",
+				Percent:    92,
+				ETAMinutes: 10,
+				Items: []string{
+					"CI remediation for PR #17 on `vigilante/issue-7` did not complete automatically.",
+					"Cause class: `provider_runtime_error`.",
+					"Next step: fix the blocker, then run `vigilante resume --repo owner/repo --issue 7` or request resume from GitHub.",
+				},
+				Tagline: "Stop the loop before it turns into noise.",
+			}): "ok",
+		},
+		Errors: map[string]error{
+			"codex exec --cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox Use the `vigilante-issue-implementation` skill for this task.\nRepository: owner/repo\nLocal repository path: /tmp/repo\nIssue: #7 - Demo\nIssue URL: https://github.com/owner/repo/issues/7\nPull Request: #17\nPull Request URL: https://github.com/owner/repo/pull/17\nWorktree path: /tmp/worktree\nBranch: vigilante/issue-7\nCI remediation context: GitHub reported failing required checks for this existing PR.\nFailing check: test (state=COMPLETED conclusion=FAILURE)\nInvestigate the failing CI checks, reproduce the problem locally when practical, and make the minimal code or configuration fix needed to get the PR green again.\nUse `gh issue comment` for progress updates and blockers, push any successful fix to the existing PR branch, and do not open a new pull request.\nIf GitHub exposes a failing check summary or log URL during your investigation, use it. At minimum, work from the failing check identifiers listed above.\nIf you cannot fix the failure safely, leave a concise GitHub comment explaining the blocker and exit with a non-zero status so Vigilante can stop and hand off to a human.\nKeep the changes minimal and focused on restoring CI for the existing pull request.": errors.New("codex exec [--cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox prompt]: exit status 1"),
+		},
+	}
+	env := &environment.Environment{OS: "darwin", Runner: runner}
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := RunCIRemediationSession(
+		context.Background(),
+		env,
+		store,
+		state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"},
+		state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, IssueTitle: "Demo", IssueURL: "https://github.com/owner/repo/issues/7", WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7"},
+		ghcli.PullRequest{Number: 17, URL: "https://github.com/owner/repo/pull/17"},
+		[]ghcli.StatusCheckRoll{{Context: "test", State: "COMPLETED", Conclusion: "FAILURE"}},
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
 func TestRunIssueSessionSuccessWithClaudeProvider(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -427,6 +427,48 @@ func BuildConflictResolutionPromptForRuntime(runtime string, target state.WatchT
 	return strings.Join(lines, "\n")
 }
 
+func BuildCIRemediationPrompt(target state.WatchTarget, session state.Session, pr ghcli.PullRequest, checks []ghcli.StatusCheckRoll) string {
+	return BuildCIRemediationPromptForRuntime(RuntimeCodex, target, session, pr, checks)
+}
+
+func BuildCIRemediationPromptForRuntime(runtime string, target state.WatchTarget, session state.Session, pr ghcli.PullRequest, checks []ghcli.StatusCheckRoll) string {
+	lines := []string{}
+	if runtimeUsesInlineSkillHeader(runtime) {
+		lines = append(lines, InlineSkillHeader(IssueImplementationSkill(target)))
+	} else {
+		lines = append(lines, fmt.Sprintf("Use the `%s` skill for this task.", IssueImplementationSkill(target)))
+	}
+	lines = append(lines,
+		fmt.Sprintf("Repository: %s", target.Repo),
+		fmt.Sprintf("Local repository path: %s", target.Path),
+		fmt.Sprintf("Issue: #%d - %s", session.IssueNumber, session.IssueTitle),
+		fmt.Sprintf("Issue URL: %s", session.IssueURL),
+		fmt.Sprintf("Pull Request: #%d", pr.Number),
+		fmt.Sprintf("Pull Request URL: %s", pr.URL),
+		fmt.Sprintf("Worktree path: %s", session.WorktreePath),
+		fmt.Sprintf("Branch: %s", session.Branch),
+		"CI remediation context: GitHub reported failing required checks for this existing PR.",
+	)
+	for _, check := range checks {
+		name := strings.TrimSpace(check.Name)
+		if name == "" {
+			name = strings.TrimSpace(check.Context)
+		}
+		if name == "" {
+			name = "unnamed-check"
+		}
+		lines = append(lines, fmt.Sprintf("Failing check: %s (state=%s conclusion=%s)", name, fallbackPromptText(strings.TrimSpace(check.State), "unknown"), fallbackPromptText(strings.TrimSpace(check.Conclusion), "unknown")))
+	}
+	lines = append(lines,
+		"Investigate the failing CI checks, reproduce the problem locally when practical, and make the minimal code or configuration fix needed to get the PR green again.",
+		"Use `gh issue comment` for progress updates and blockers, push any successful fix to the existing PR branch, and do not open a new pull request.",
+		"If GitHub exposes a failing check summary or log URL during your investigation, use it. At minimum, work from the failing check identifiers listed above.",
+		"If you cannot fix the failure safely, leave a concise GitHub comment explaining the blocker and exit with a non-zero status so Vigilante can stop and hand off to a human.",
+		"Keep the changes minimal and focused on restoring CI for the existing pull request.",
+	)
+	return strings.Join(lines, "\n")
+}
+
 func runtimeUsesInlineSkillHeader(runtime string) bool {
 	switch strings.TrimSpace(runtime) {
 	case RuntimeClaude, RuntimeGemini:

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -416,6 +416,18 @@ func TestBuildConflictResolutionPrompt(t *testing.T) {
 	}
 }
 
+func TestBuildCIRemediationPrompt(t *testing.T) {
+	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
+	session := state.Session{IssueNumber: 12, IssueTitle: "Fix bug", IssueURL: "https://example.com/issues/12", WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12"}
+	pr := ghcli.PullRequest{Number: 88, URL: "https://example.com/pull/88"}
+	prompt := BuildCIRemediationPrompt(target, session, pr, []ghcli.StatusCheckRoll{{Context: "test", Conclusion: "FAILURE"}})
+	for _, text := range []string{"Use the `vigilante-issue-implementation` skill", "Pull Request: #88", "CI remediation context", "Failing check: test", "do not open a new pull request", "exit with a non-zero status"} {
+		if !strings.Contains(prompt, text) {
+			t.Fatalf("prompt missing %q: %s", text, prompt)
+		}
+	}
+}
+
 func TestEnsureInstalledForClaudeCreatesCommandsAndSkills(t *testing.T) {
 	dir := t.TempDir()
 	repoRoot := t.TempDir()

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -72,6 +72,8 @@ type Session struct {
 	PullRequestMergedAt            string        `json:"pull_request_merged_at,omitempty"`
 	LastMaintainedAt               string        `json:"last_maintained_at,omitempty"`
 	LastMaintenanceError           string        `json:"last_maintenance_error,omitempty"`
+	LastCIRemediationFingerprint   string        `json:"last_ci_remediation_fingerprint,omitempty"`
+	LastCIRemediationAttemptedAt   string        `json:"last_ci_remediation_attempted_at,omitempty"`
 	BlockedAt                      string        `json:"blocked_at,omitempty"`
 	BlockedStage                   string        `json:"blocked_stage,omitempty"`
 	BlockedReason                  BlockedReason `json:"blocked_reason,omitempty"`


### PR DESCRIPTION
## Summary
- teach PR maintenance to launch a focused CI remediation run when required checks fail
- track failing-check fingerprints so identical unresolved failures stop in a blocked manual-review state instead of looping
- add dedicated remediation prompt/invocation coverage across app, runner, provider, and skill tests

## Testing
- go test ./...

Closes #184