### PR TITLE
Provision Vigilante labels before syncing issue state

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -69,10 +69,12 @@ type App struct {
 	clock  func() time.Time
 	env    *environment.Environment
 
-	sessionMu sync.Mutex
-	sessionWG sync.WaitGroup
-	cancelMu  sync.Mutex
-	cancels   map[string]context.CancelFunc
+	sessionMu                 sync.Mutex
+	sessionWG                 sync.WaitGroup
+	cancelMu                  sync.Mutex
+	cancels                   map[string]context.CancelFunc
+	repoLabelProvisioningMu   sync.Mutex
+	repoLabelsProvisionedOnce map[string]bool
 }
 
 type stringListFlag []string
@@ -93,11 +95,12 @@ func (f *stringListFlag) Set(value string) error {
 func New() *App {
 	store := state.NewStore()
 	return &App{
-		stdout:  os.Stdout,
-		stderr:  os.Stderr,
-		state:   store,
-		clock:   time.Now().UTC,
-		cancels: make(map[string]context.CancelFunc),
+		stdout:                    os.Stdout,
+		stderr:                    os.Stderr,
+		state:                     store,
+		clock:                     time.Now().UTC,
+		cancels:                   make(map[string]context.CancelFunc),
+		repoLabelsProvisionedOnce: make(map[string]bool),
 		env: &environment.Environment{
 			OS: runtime.GOOS,
 			Runner: environment.LoggingRunner{
@@ -2413,11 +2416,41 @@ func (a *App) syncSessionIssueLabels(ctx context.Context, session state.Session,
 }
 
 func (a *App) syncIssueManagedLabels(ctx context.Context, repo string, issueNumber int, desired []string) error {
+	if err := a.ensureRepositoryLabelsProvisioned(ctx, repo); err != nil {
+		return err
+	}
 	details, err := ghcli.GetIssueDetails(ctx, a.env.Runner, repo, issueNumber)
 	if err != nil {
 		return err
 	}
 	return ghcli.SyncIssueLabels(ctx, a.env.Runner, repo, issueNumber, details.Labels, desired, managedIssueLabels)
+}
+
+func (a *App) ensureRepositoryLabelsProvisioned(ctx context.Context, repo string) error {
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return nil
+	}
+
+	a.repoLabelProvisioningMu.Lock()
+	if a.repoLabelsProvisionedOnce[repo] {
+		a.repoLabelProvisioningMu.Unlock()
+		return nil
+	}
+	a.repoLabelProvisioningMu.Unlock()
+
+	labels, err := ghcli.LoadRepositoryLabelSpecs()
+	if err != nil {
+		return fmt.Errorf("load Vigilante label manifest: %w", err)
+	}
+	if err := ghcli.EnsureRepositoryLabels(ctx, a.env.Runner, repo, labels); err != nil {
+		return fmt.Errorf("provision Vigilante labels for repo %s: %w", repo, err)
+	}
+
+	a.repoLabelProvisioningMu.Lock()
+	a.repoLabelsProvisionedOnce[repo] = true
+	a.repoLabelProvisioningMu.Unlock()
+	return nil
 }
 
 func sessionManagedLabels(session state.Session, pr *ghcli.PullRequest) []string {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -121,7 +121,8 @@ func TestSyncIssueManagedLabelsQueued(t *testing.T) {
 	app.stderr = testutil.IODiscard{}
 	app.env.Runner = testutil.FakeRunner{
 		Outputs: map[string]string{
-			"gh api repos/owner/repo/issues/7": `{"labels":[{"name":"bug"},{"name":"vigilante:running"}]}`,
+			"gh api repos/owner/repo/labels?per_page=100":                                                     `[{"name":"bug"},{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:blocked"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"resume"}]`,
+			"gh api repos/owner/repo/issues/7":                                                                `{"labels":[{"name":"bug"},{"name":"vigilante:running"}]}`,
 			"gh issue edit --repo owner/repo 7 --add-label vigilante:queued --remove-label vigilante:running": "ok",
 		},
 	}
@@ -137,6 +138,7 @@ func TestSyncSessionIssueLabelsUsesPullRequestReviewState(t *testing.T) {
 	app.stderr = testutil.IODiscard{}
 	app.env.Runner = testutil.FakeRunner{
 		Outputs: map[string]string{
+			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:blocked"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"resume"}]`,
 			"gh pr view --repo owner/repo 17 --json number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup": `{"number":17,"url":"https://github.com/owner/repo/pull/17","state":"OPEN","mergedAt":null,"labels":[],"isDraft":false,"mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[{"context":"test","state":"COMPLETED","conclusion":"SUCCESS"}]}`,
 			"gh api repos/owner/repo/issues/7": `{"labels":[{"name":"vigilante:ready-for-review"},{"name":"vigilante:needs-review"}]}`,
 			"gh issue edit --repo owner/repo 7 --add-label vigilante:awaiting-user-validation --remove-label vigilante:needs-review --remove-label vigilante:ready-for-review": "ok",
@@ -150,6 +152,38 @@ func TestSyncSessionIssueLabelsUsesPullRequestReviewState(t *testing.T) {
 		PullRequestNumber: 17,
 	}, nil)
 	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSyncIssueManagedLabelsProvisionMissingRepositoryLabels(t *testing.T) {
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"bug"}]`,
+			"gh api --method POST repos/owner/repo/labels -f name=vigilante:queued -f color=BFDADC -f description=The issue is eligible for dispatch and waiting for a worker slot.":                                           "ok",
+			"gh api --method POST repos/owner/repo/labels -f name=vigilante:running -f color=0E8A16 -f description=A coding-agent session is currently executing for the issue.":                                               "ok",
+			"gh api --method POST repos/owner/repo/labels -f name=vigilante:blocked -f color=D93F0B -f description=Execution cannot continue until a blocker is resolved.":                                                     "ok",
+			"gh api --method POST repos/owner/repo/labels -f name=vigilante:ready-for-review -f color=FBCA04 -f description=Implementation is complete enough for a human to review the resulting PR or branch.":               "ok",
+			"gh api --method POST repos/owner/repo/labels -f name=vigilante:awaiting-user-validation -f color=F9D0C4 -f description=Changes are ready for product or operator validation before the issue is considered done.": "ok",
+			"gh api --method POST repos/owner/repo/labels -f name=vigilante:done -f color=5319E7 -f description=Vigilante completed its work on the issue and no further automation is expected.":                              "ok",
+			"gh api --method POST repos/owner/repo/labels -f name=vigilante:needs-review -f color=D4C5F9 -f description=A human should review the implementation output before Vigilante continues or closes the loop.":        "ok",
+			"gh api --method POST repos/owner/repo/labels -f name=vigilante:needs-human-input -f color=F7C6C7 -f description=The agent is waiting on product, operator, or repository-owner guidance.":                         "ok",
+			"gh api --method POST repos/owner/repo/labels -f name=vigilante:needs-provider-fix -f color=E99695 -f description=Execution is blocked by provider auth, quota, or runtime setup issues.":                          "ok",
+			"gh api --method POST repos/owner/repo/labels -f name=vigilante:needs-git-fix -f color=C2E0C6 -f description=Execution is blocked by repository or git state that requires human repair.":                          "ok",
+			"gh api --method POST repos/owner/repo/labels -f name=codex -f color=1D76DB -f description=Routes the issue to the Codex provider for execution.":                                                                  "ok",
+			"gh api --method POST repos/owner/repo/labels -f name=claude -f color=0052CC -f description=Routes the issue to the Claude provider for execution.":                                                                "ok",
+			"gh api --method POST repos/owner/repo/labels -f name=gemini -f color=006B75 -f description=Routes the issue to the Gemini provider for execution.":                                                                "ok",
+			"gh api --method POST repos/owner/repo/labels -f name=vigilante:resume -f color=C5DEF5 -f description=Requests that Vigilante resume a blocked session.":                                                           "ok",
+			"gh api --method POST repos/owner/repo/labels -f name=resume -f color=C5DEF5 -f description=Legacy compatibility alias for vigilante:resume.":                                                                      "ok",
+			"gh api repos/owner/repo/issues/7":                               `{"labels":[{"name":"bug"}]}`,
+			"gh issue edit --repo owner/repo 7 --add-label vigilante:queued": "ok",
+		},
+	}
+
+	if err := app.syncIssueManagedLabels(context.Background(), "owner/repo", 7, []string{labelQueued}); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -56,6 +56,10 @@ type IssueDetails struct {
 	Labels []Label `json:"labels"`
 }
 
+type RepositoryLabelDetails struct {
+	Name string `json:"name"`
+}
+
 func ListOpenIssues(ctx context.Context, runner environment.Runner, repo string, assignee string) ([]Issue, error) {
 	resolvedAssignee, err := resolveAssignee(ctx, runner, assignee)
 	if err != nil {
@@ -246,6 +250,65 @@ func AddIssueCommentReaction(ctx context.Context, runner environment.Runner, rep
 
 func RemoveIssueLabel(ctx context.Context, runner environment.Runner, repo string, number int, label string) error {
 	_, err := runner.Run(ctx, "", "gh", "issue", "edit", "--repo", repo, fmt.Sprintf("%d", number), "--remove-label", label)
+	return err
+}
+
+func EnsureRepositoryLabels(ctx context.Context, runner environment.Runner, repo string, desired []RepositoryLabelSpec) error {
+	current, err := ListRepositoryLabels(ctx, runner, repo)
+	if err != nil {
+		return fmt.Errorf("list repository labels: %w", err)
+	}
+
+	currentSet := make(map[string]struct{}, len(current))
+	for _, label := range current {
+		name := strings.TrimSpace(label.Name)
+		if name == "" {
+			continue
+		}
+		currentSet[name] = struct{}{}
+	}
+
+	for _, label := range desired {
+		name := strings.TrimSpace(label.Name)
+		if name == "" {
+			continue
+		}
+		if _, ok := currentSet[name]; ok {
+			continue
+		}
+		if err := CreateRepositoryLabel(ctx, runner, repo, label); err != nil {
+			return fmt.Errorf("create repository label %q: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+func ListRepositoryLabels(ctx context.Context, runner environment.Runner, repo string) ([]RepositoryLabelDetails, error) {
+	output, err := runner.Run(ctx, "", "gh", "api", fmt.Sprintf("repos/%s/labels?per_page=100", repo))
+	if err != nil {
+		return nil, err
+	}
+
+	var labels []RepositoryLabelDetails
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &labels); err != nil {
+		return nil, fmt.Errorf("parse gh repository labels output: %w", err)
+	}
+	return labels, nil
+}
+
+func CreateRepositoryLabel(ctx context.Context, runner environment.Runner, repo string, label RepositoryLabelSpec) error {
+	args := []string{
+		"api",
+		"--method", "POST",
+		fmt.Sprintf("repos/%s/labels", repo),
+		"-f", "name=" + label.Name,
+		"-f", "color=" + label.Color,
+	}
+	if label.Description != "" {
+		args = append(args, "-f", "description="+label.Description)
+	}
+	_, err := runner.Run(ctx, "", "gh", args...)
 	return err
 }
 

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -218,6 +218,75 @@ func TestSyncIssueLabelsNoopsWhenManagedStateAlreadyMatches(t *testing.T) {
 	}
 }
 
+func TestEnsureRepositoryLabelsCreatesMissingLabelsFromManifest(t *testing.T) {
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"bug"},{"name":"vigilante:queued"}]`,
+			"gh api --method POST repos/owner/repo/labels -f name=vigilante:running -f color=0E8A16 -f description=A coding-agent session is currently executing for the issue.": "ok",
+		},
+	}
+
+	err := EnsureRepositoryLabels(
+		context.Background(),
+		runner,
+		"owner/repo",
+		[]RepositoryLabelSpec{
+			{Name: "vigilante:queued", Color: "BFDADC", Description: "The issue is eligible for dispatch and waiting for a worker slot."},
+			{Name: "vigilante:running", Color: "0E8A16", Description: "A coding-agent session is currently executing for the issue."},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnsureRepositoryLabelsNoopsWhenLabelsAlreadyExist(t *testing.T) {
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"vigilante:queued"},{"name":"vigilante:running"}]`,
+		},
+	}
+
+	err := EnsureRepositoryLabels(
+		context.Background(),
+		runner,
+		"owner/repo",
+		[]RepositoryLabelSpec{
+			{Name: "vigilante:queued", Color: "BFDADC", Description: "The issue is eligible for dispatch and waiting for a worker slot."},
+			{Name: "vigilante:running", Color: "0E8A16", Description: "A coding-agent session is currently executing for the issue."},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEnsureRepositoryLabelsSurfacesProvisioningFailure(t *testing.T) {
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/labels?per_page=100": `[]`,
+		},
+		Errors: map[string]error{
+			"gh api --method POST repos/owner/repo/labels -f name=vigilante:queued -f color=BFDADC -f description=The issue is eligible for dispatch and waiting for a worker slot.": context.DeadlineExceeded,
+		},
+	}
+
+	err := EnsureRepositoryLabels(
+		context.Background(),
+		runner,
+		"owner/repo",
+		[]RepositoryLabelSpec{
+			{Name: "vigilante:queued", Color: "BFDADC", Description: "The issue is eligible for dispatch and waiting for a worker slot."},
+		},
+	)
+	if err == nil {
+		t.Fatal("expected provisioning error")
+	}
+	if got := err.Error(); got != `create repository label "vigilante:queued": context deadline exceeded` {
+		t.Fatalf("unexpected error: %s", got)
+	}
+}
+
 func TestFindPullRequestForBranch(t *testing.T) {
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{

--- a/internal/github/labels_manifest.go
+++ b/internal/github/labels_manifest.go
@@ -1,0 +1,60 @@
+package ghcli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"strings"
+	"sync"
+
+	skillassets "github.com/nicobistolfi/vigilante"
+)
+
+type RepositoryLabelSpec struct {
+	Name        string `json:"name"`
+	Color       string `json:"color"`
+	Description string `json:"description"`
+}
+
+type labelsManifest struct {
+	Labels []RepositoryLabelSpec `json:"labels"`
+}
+
+var (
+	manifestLabelsOnce sync.Once
+	manifestLabels     []RepositoryLabelSpec
+	manifestLabelsErr  error
+)
+
+func LoadRepositoryLabelSpecs() ([]RepositoryLabelSpec, error) {
+	manifestLabelsOnce.Do(func() {
+		data, err := fs.ReadFile(skillassets.LabelsManifest, ".github/labels.json")
+		if err != nil {
+			manifestLabelsErr = fmt.Errorf("read embedded labels manifest: %w", err)
+			return
+		}
+
+		var manifest labelsManifest
+		if err := json.Unmarshal(data, &manifest); err != nil {
+			manifestLabelsErr = fmt.Errorf("parse embedded labels manifest: %w", err)
+			return
+		}
+
+		manifestLabels = make([]RepositoryLabelSpec, 0, len(manifest.Labels))
+		for _, label := range manifest.Labels {
+			label.Name = strings.TrimSpace(label.Name)
+			label.Color = strings.TrimSpace(label.Color)
+			label.Description = strings.TrimSpace(label.Description)
+			if label.Name == "" {
+				continue
+			}
+			manifestLabels = append(manifestLabels, label)
+		}
+	})
+	if manifestLabelsErr != nil {
+		return nil, manifestLabelsErr
+	}
+	labels := make([]RepositoryLabelSpec, len(manifestLabels))
+	copy(labels, manifestLabels)
+	return labels, nil
+}

--- a/internal/github/labels_manifest_test.go
+++ b/internal/github/labels_manifest_test.go
@@ -14,6 +14,7 @@ type labelManifest struct {
 
 type labelSpec struct {
 	Name        string   `json:"name"`
+	Color       string   `json:"color"`
 	Group       string   `json:"group"`
 	Behavior    string   `json:"behavior"`
 	Description string   `json:"description"`
@@ -112,6 +113,30 @@ func TestIssueLabelManifestIncludesHumanReviewStates(t *testing.T) {
 		}
 		if label.Behavior != "informational" {
 			t.Fatalf("expected %q to stay informational, got %#v", name, label)
+		}
+	}
+}
+
+func TestLoadRepositoryLabelSpecsUsesCanonicalManifest(t *testing.T) {
+	manifest := loadLabelManifest(t)
+
+	labels, err := LoadRepositoryLabelSpecs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(labels) != len(manifest.Labels) {
+		t.Fatalf("expected %d labels from embedded manifest, got %d", len(manifest.Labels), len(labels))
+	}
+
+	for i, label := range labels {
+		if label.Name != manifest.Labels[i].Name {
+			t.Fatalf("unexpected label at index %d: %#v", i, label)
+		}
+		if label.Color != manifest.Labels[i].Color {
+			t.Fatalf("unexpected color for %q: %#v", label.Name, label)
+		}
+		if label.Description != manifest.Labels[i].Description {
+			t.Fatalf("unexpected description for %q: %#v", label.Name, label)
 		}
 	}
 }

--- a/labelassets.go
+++ b/labelassets.go
@@ -1,0 +1,8 @@
+package skillassets
+
+import "embed"
+
+// LabelsManifest contains the canonical Vigilante repository label definitions.
+//
+//go:embed .github/labels.json
+var LabelsManifest embed.FS


### PR DESCRIPTION
## Summary
- provision the canonical Vigilante repository labels from `.github/labels.json` before issue label sync runs
- embed the manifest in the binary and add idempotent GitHub helpers to list/create missing repository labels
- cover manifest loading, provisioning create/no-op/error cases, and app-level sync against an unbootstrapped repo

Closes #187

## Validation
- `go test ./...`