### PR TITLE
Pass OTEL_URL_PATH into the GoReleaser release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,4 +63,5 @@ jobs:
           HOMEBREW_GITHUB_API_TOKEN: ${{ steps.tap_token.outputs.token }}
           OTEL_ENDPOINT: ${{ secrets.OTEL_ENDPOINT }}
           OTEL_TOKEN: ${{ secrets.OTEL_TOKEN }}
+          OTEL_URL_PATH: ${{ secrets.OTEL_URL_PATH }}
         run: goreleaser release --clean

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,7 @@ builds:
       - CGO_ENABLED=0
       - OTEL_ENDPOINT
       - OTEL_TOKEN
+      - OTEL_URL_PATH
       - DISTRO
     ldflags:
       - -X github.com/nicobistolfi/vigilante/internal/build.Version={{ .Version }}


### PR DESCRIPTION
## Summary
- pass `OTEL_URL_PATH` into the GitHub Actions release job alongside the existing telemetry secrets
- forward `OTEL_URL_PATH` through `.goreleaser.yml` build envs for parity with the rest of the release-time telemetry wiring

Closes #192.

## Validation
- `go run github.com/goreleaser/goreleaser/v2@latest check`
