### PR TITLE
Increase OpenTelemetry timeout budget for PostHog log export

### DIFF
--- a/cmd/vigilante/main.go
+++ b/cmd/vigilante/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/nicobistolfi/vigilante/internal/app"
 	"github.com/nicobistolfi/vigilante/internal/build"
@@ -33,7 +32,7 @@ func run() int {
 		fmt.Fprintln(os.Stderr, "warning: telemetry disabled:", err)
 		manager = &telemetry.Manager{}
 	}
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), telemetry.ShutdownTimeout())
 	defer cancel()
 	defer func() {
 		if err := manager.Shutdown(shutdownCtx); err != nil {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -20,7 +20,10 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
-const exportTimeout = 500 * time.Millisecond
+const (
+	exportTimeout   = 2 * time.Second
+	shutdownTimeout = 3 * time.Second
+)
 
 type BuildInfo struct {
 	Version           string
@@ -269,6 +272,10 @@ func telemetryExporterSettings(info BuildInfo) exporterSettings {
 
 func disabledManager() *Manager {
 	return &Manager{}
+}
+
+func ShutdownTimeout() time.Duration {
+	return shutdownTimeout
 }
 
 func (cfg SetupConfig) envLookup() func(string) string {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	otellog "go.opentelemetry.io/otel/log"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
@@ -174,6 +175,20 @@ func TestTelemetryExporterSettingsUseEmbeddedURLPath(t *testing.T) {
 	}
 	if got, want := settings.Timeout, exportTimeout; got != want {
 		t.Fatalf("settings.Timeout = %v, want %v", got, want)
+	}
+}
+
+func TestShutdownTimeoutExceedsExportTimeout(t *testing.T) {
+	t.Parallel()
+
+	if got, want := exportTimeout, 2*time.Second; got != want {
+		t.Fatalf("exportTimeout = %v, want %v", got, want)
+	}
+	if got, want := ShutdownTimeout(), 3*time.Second; got != want {
+		t.Fatalf("ShutdownTimeout() = %v, want %v", got, want)
+	}
+	if ShutdownTimeout() <= exportTimeout {
+		t.Fatalf("ShutdownTimeout() = %v, want greater than exportTimeout %v", ShutdownTimeout(), exportTimeout)
 	}
 }
 


### PR DESCRIPTION
## Summary
Increase the OpenTelemetry timeout budget used by the PostHog log export path so short CLI commands stop tripping the previous `context deadline exceeded` shutdown warning under normal conditions.

Closes #197.

## Changes
- raise the OTLP log exporter timeout from `500ms` to `2s`
- centralize the telemetry shutdown timeout as `3s` and use it from the CLI entrypoint
- add a focused test to guard the timeout relationship against regressions

## Validation
- `go test ./...`
- `go run -ldflags "-X github.com/nicobistolfi/vigilante/internal/build.TelemetryEndpoint=us.i.posthog.com -X github.com/nicobistolfi/vigilante/internal/build.TelemetryToken=test-token -X github.com/nicobistolfi/vigilante/internal/build.TelemetryURLPath=/i/v1/logs" ./cmd/vigilante status`
