### PR TITLE
Keep CLI telemetry failures from overshadowing successful commands

### DIFF
--- a/cmd/vigilante/main.go
+++ b/cmd/vigilante/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/nicobistolfi/vigilante/internal/app"
@@ -11,13 +10,21 @@ import (
 	"github.com/nicobistolfi/vigilante/internal/telemetry"
 )
 
-func main() {
-	os.Exit(run())
+type telemetrySession interface {
+	StartCommand(context.Context, []string) (context.Context, func(int))
+	Shutdown(context.Context) error
 }
 
-func run() int {
-	ctx := context.Background()
-	manager, err := telemetry.Setup(ctx, telemetry.SetupConfig{
+var cliArgs = func() []string {
+	return os.Args[1:]
+}
+
+var runCLI = func(ctx context.Context, args []string) int {
+	return app.New().Run(ctx, args)
+}
+
+var setupTelemetry = func(ctx context.Context) (telemetrySession, error) {
+	return telemetry.Setup(ctx, telemetry.SetupConfig{
 		BuildInfo: telemetry.BuildInfo{
 			Version:           build.Version,
 			Distro:            build.Distro,
@@ -28,20 +35,27 @@ func run() int {
 		StateRoot: state.NewStore().Root(),
 		Stderr:    os.Stderr,
 	})
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "warning: telemetry disabled:", err)
+}
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	ctx := context.Background()
+	args := cliArgs()
+	manager, err := setupTelemetry(ctx)
+	if err != nil || manager == nil {
 		manager = &telemetry.Manager{}
 	}
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), telemetry.ShutdownTimeout())
 	defer cancel()
 	defer func() {
-		if err := manager.Shutdown(shutdownCtx); err != nil {
-			fmt.Fprintln(os.Stderr, "warning: telemetry shutdown failed:", err)
-		}
+		_ = manager.Shutdown(shutdownCtx)
 	}()
 
-	commandCtx, finish := manager.StartCommand(ctx, os.Args[1:])
-	exitCode := app.New().Run(commandCtx, os.Args[1:])
+	commandCtx, finish := manager.StartCommand(ctx, args)
+	exitCode := runCLI(commandCtx, args)
 	finish(exitCode)
 	return exitCode
 }

--- a/cmd/vigilante/main_test.go
+++ b/cmd/vigilante/main_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestRunIgnoresTelemetrySetupFailure(t *testing.T) {
+	originalArgs := cliArgs
+	originalRunCLI := runCLI
+	originalSetupTelemetry := setupTelemetry
+	t.Cleanup(func() {
+		cliArgs = originalArgs
+		runCLI = originalRunCLI
+		setupTelemetry = originalSetupTelemetry
+	})
+
+	cliArgs = func() []string { return []string{"status"} }
+	runCLI = func(_ context.Context, args []string) int {
+		if len(args) != 1 || args[0] != "status" {
+			t.Fatalf("runCLI args = %v, want [status]", args)
+		}
+		return 0
+	}
+	setupTelemetry = func(context.Context) (telemetrySession, error) {
+		return nil, errors.New("collector unavailable")
+	}
+
+	if got := run(); got != 0 {
+		t.Fatalf("run() = %d, want 0", got)
+	}
+}
+
+func TestRunIgnoresTelemetryShutdownFailure(t *testing.T) {
+	originalArgs := cliArgs
+	originalRunCLI := runCLI
+	originalSetupTelemetry := setupTelemetry
+	t.Cleanup(func() {
+		cliArgs = originalArgs
+		runCLI = originalRunCLI
+		setupTelemetry = originalSetupTelemetry
+	})
+
+	session := &stubTelemetrySession{shutdownErr: errors.New("flush timeout")}
+	cliArgs = func() []string { return []string{"status"} }
+	runCLI = func(ctx context.Context, args []string) int {
+		if ctx != context.Background() {
+			t.Fatalf("runCLI ctx changed unexpectedly")
+		}
+		if len(args) != 1 || args[0] != "status" {
+			t.Fatalf("runCLI args = %v, want [status]", args)
+		}
+		return 0
+	}
+	setupTelemetry = func(context.Context) (telemetrySession, error) {
+		return session, nil
+	}
+
+	if got := run(); got != 0 {
+		t.Fatalf("run() = %d, want 0", got)
+	}
+	if !session.shutdownCalled {
+		t.Fatal("expected telemetry shutdown to be attempted")
+	}
+	if session.finishedExitCode != 0 {
+		t.Fatalf("finish exit code = %d, want 0", session.finishedExitCode)
+	}
+}
+
+func TestRunPreservesCommandFailureWhenTelemetryFails(t *testing.T) {
+	originalArgs := cliArgs
+	originalRunCLI := runCLI
+	originalSetupTelemetry := setupTelemetry
+	t.Cleanup(func() {
+		cliArgs = originalArgs
+		runCLI = originalRunCLI
+		setupTelemetry = originalSetupTelemetry
+	})
+
+	session := &stubTelemetrySession{shutdownErr: errors.New("flush timeout")}
+	cliArgs = func() []string { return []string{"watch", "/tmp/repo"} }
+	runCLI = func(_ context.Context, args []string) int {
+		if len(args) != 2 || args[0] != "watch" || args[1] != "/tmp/repo" {
+			t.Fatalf("runCLI args = %v, want [watch /tmp/repo]", args)
+		}
+		return 7
+	}
+	setupTelemetry = func(context.Context) (telemetrySession, error) {
+		return session, nil
+	}
+
+	if got := run(); got != 7 {
+		t.Fatalf("run() = %d, want 7", got)
+	}
+	if session.finishedExitCode != 7 {
+		t.Fatalf("finish exit code = %d, want 7", session.finishedExitCode)
+	}
+}
+
+type stubTelemetrySession struct {
+	shutdownErr      error
+	shutdownCalled   bool
+	finishedExitCode int
+}
+
+func (s *stubTelemetrySession) StartCommand(ctx context.Context, _ []string) (context.Context, func(int)) {
+	return ctx, func(exitCode int) {
+		s.finishedExitCode = exitCode
+	}
+}
+
+func (s *stubTelemetrySession) Shutdown(context.Context) error {
+	s.shutdownCalled = true
+	return s.shutdownErr
+}


### PR DESCRIPTION
## Summary
- make CLI telemetry setup and shutdown fully best-effort in the entrypoint
- stop emitting end-of-process telemetry warnings that can make successful commands look failed
- add entrypoint tests covering telemetry setup failure fallback, shutdown failure suppression, and command failure propagation

Closes #196.

## Validation
- `go test ./cmd/vigilante ./internal/telemetry ./internal/app`
- `go test ./...`
