### PR TITLE
Implement PostHog analytics events for Vigilante usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ Once a folder is registered, `vigilante` should:
 
 In the current implementation, that worker loop already covers repository onboarding, issue intake, isolated worktrees, provider orchestration, repo-aware execution skills, local session recovery, and part of the pull request maintenance path. CI/CD promotion and richer deployment control are planned next-stage capabilities.
 
+## Telemetry
+
+Vigilante emits anonymous telemetry with two different purposes:
+
+- PostHog analytics events track product usage, such as command starts and completions, using bounded properties like command name, feature area, result, platform, and distro.
+- OTLP logs remain the operational debugging stream when log export is configured.
+
+Analytics events intentionally avoid raw repository contents, issue text, file paths, and other free-form command arguments. Operators can disable both streams with `DO_NOT_TRACK=1` or `MYTOOL_NO_ANALYTICS=1`.
+
 ## Core Workflow
 
 For each watched repository:

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,14 +1,19 @@
 package telemetry
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -34,22 +39,45 @@ type BuildInfo struct {
 }
 
 type SetupConfig struct {
-	BuildInfo   BuildInfo
-	StateRoot   string
-	Stderr      io.Writer
-	EnvLookup   func(string) string
-	NewExporter func(context.Context, BuildInfo) (sdklog.Exporter, error)
+	BuildInfo            BuildInfo
+	StateRoot            string
+	Stderr               io.Writer
+	EnvLookup            func(string) string
+	NewExporter          func(context.Context, BuildInfo) (sdklog.Exporter, error)
+	NewAnalyticsExporter func(BuildInfo, string) (analyticsExporter, error)
 }
 
 type Manager struct {
-	provider *sdklog.LoggerProvider
-	logger   otellog.Logger
-	version  string
-	distro   string
+	provider  *sdklog.LoggerProvider
+	logger    otellog.Logger
+	analytics analyticsExporter
+	mu        sync.Mutex
+	events    []analyticsEvent
+	version   string
+	distro    string
+	anonID    string
 }
 
 type localState struct {
 	AnonymousID string `json:"anonymous_id"`
+}
+
+type analyticsEvent struct {
+	Type       string         `json:"type"`
+	UUID       string         `json:"uuid"`
+	Timestamp  time.Time      `json:"timestamp"`
+	DistinctID string         `json:"distinct_id"`
+	Event      string         `json:"event"`
+	Properties map[string]any `json:"properties"`
+}
+
+type analyticsBatch struct {
+	APIKey   string            `json:"api_key"`
+	Messages []json.RawMessage `json:"batch"`
+}
+
+type analyticsExporter interface {
+	Export(context.Context, []analyticsEvent) error
 }
 
 func Setup(ctx context.Context, cfg SetupConfig) (*Manager, error) {
@@ -81,74 +109,124 @@ func Setup(ctx context.Context, cfg SetupConfig) (*Manager, error) {
 		return nil, err
 	}
 
-	exporterFactory := cfg.NewExporter
-	if exporterFactory == nil {
-		exporterFactory = newHTTPExporter
+	var (
+		provider *sdklog.LoggerProvider
+		logger   otellog.Logger
+	)
+	if telemetryLogsEnabled(cfg.BuildInfo) {
+		exporterFactory := cfg.NewExporter
+		if exporterFactory == nil {
+			exporterFactory = newHTTPExporter
+		}
+		exp, err := exporterFactory(ctx, cfg.BuildInfo)
+		if err != nil {
+			return nil, err
+		}
+
+		provider = sdklog.NewLoggerProvider(
+			sdklog.WithProcessor(
+				sdklog.NewBatchProcessor(
+					exp,
+					sdklog.WithExportInterval(100*time.Millisecond),
+					sdklog.WithExportTimeout(exportTimeout),
+				),
+			),
+			sdklog.WithResource(res),
+		)
+		logger = provider.Logger("github.com/nicobistolfi/vigilante/internal/telemetry")
 	}
-	exp, err := exporterFactory(ctx, cfg.BuildInfo)
+
+	analyticsFactory := cfg.NewAnalyticsExporter
+	if analyticsFactory == nil {
+		analyticsFactory = newHTTPAnalyticsExporter
+	}
+	analytics, err := analyticsFactory(cfg.BuildInfo, state.AnonymousID)
 	if err != nil {
 		return nil, err
 	}
 
-	provider := sdklog.NewLoggerProvider(
-		sdklog.WithProcessor(
-			sdklog.NewBatchProcessor(
-				exp,
-				sdklog.WithExportInterval(100*time.Millisecond),
-				sdklog.WithExportTimeout(exportTimeout),
-			),
-		),
-		sdklog.WithResource(res),
-	)
-
 	return &Manager{
-		provider: provider,
-		logger:   provider.Logger("github.com/nicobistolfi/vigilante/internal/telemetry"),
-		version:  defaultString(cfg.BuildInfo.Version, "dev"),
-		distro:   defaultString(cfg.BuildInfo.Distro, "direct"),
+		provider:  provider,
+		logger:    logger,
+		analytics: analytics,
+		version:   defaultString(cfg.BuildInfo.Version, "dev"),
+		distro:    defaultString(cfg.BuildInfo.Distro, "direct"),
+		anonID:    state.AnonymousID,
 	}, nil
 }
 
 func (m *Manager) Shutdown(ctx context.Context) error {
-	if m == nil || m.provider == nil {
+	if m == nil {
 		return nil
 	}
-	return m.provider.Shutdown(ctx)
+
+	var shutdownErr error
+	if m.provider != nil {
+		shutdownErr = errors.Join(shutdownErr, m.provider.Shutdown(ctx))
+	}
+	if m.analytics != nil {
+		m.mu.Lock()
+		events := append([]analyticsEvent(nil), m.events...)
+		m.events = nil
+		m.mu.Unlock()
+		shutdownErr = errors.Join(shutdownErr, m.analytics.Export(ctx, events))
+	}
+	return shutdownErr
 }
 
 func (m *Manager) StartCommand(ctx context.Context, args []string) (context.Context, func(int)) {
-	if m == nil || m.provider == nil {
+	if m == nil || (m.provider == nil && m.analytics == nil) {
 		return ctx, func(int) {}
 	}
 
 	commandName := CommandName(args)
-	startedAt := time.Now()
+	startedAt := time.Now().UTC()
+	m.enqueueAnalytics(analyticsEvent{
+		Type:       "capture",
+		UUID:       uuid.NewString(),
+		Timestamp:  startedAt,
+		DistinctID: m.anonID,
+		Event:      "cli_command_started",
+		Properties: m.commandProperties(commandName),
+	})
 
 	return ctx, func(exitCode int) {
-		record := otellog.Record{}
-		record.SetEventName("cli.command")
-		record.SetTimestamp(startedAt)
-		record.SetObservedTimestamp(time.Now())
-		record.SetBody(otellog.StringValue("command completed"))
-		record.AddAttributes(
-			otellog.KeyValueFromAttribute(attribute.Int("command.exit_code", exitCode)),
-			otellog.KeyValueFromAttribute(attribute.String("command.name", commandName)),
-			otellog.KeyValueFromAttribute(attribute.Int64("command.duration_ms", time.Since(startedAt).Milliseconds())),
-			otellog.KeyValueFromAttribute(attribute.String("platform.os", runtime.GOOS)),
-			otellog.KeyValueFromAttribute(attribute.String("platform.arch", runtime.GOARCH)),
-			otellog.KeyValueFromAttribute(attribute.String("app.version", m.version)),
-			otellog.KeyValueFromAttribute(attribute.String("distro", m.distro)),
-		)
-		if exitCode != 0 {
-			record.SetBody(otellog.StringValue("command failed"))
-			record.SetSeverity(otellog.SeverityError)
-			record.SetSeverityText("ERROR")
-		} else {
+		finishedAt := time.Now().UTC()
+		durationMs := finishedAt.Sub(startedAt).Milliseconds()
+		if m.provider != nil {
+			record := otellog.Record{}
+			record.SetEventName("cli.command")
+			record.SetTimestamp(startedAt)
+			record.SetObservedTimestamp(finishedAt)
 			record.SetBody(otellog.StringValue("command completed"))
-			record.SetSeverity(otellog.SeverityInfo)
-			record.SetSeverityText("INFO")
+			record.AddAttributes(
+				otellog.KeyValueFromAttribute(attribute.Int("command.exit_code", exitCode)),
+				otellog.KeyValueFromAttribute(attribute.String("command.name", commandName)),
+				otellog.KeyValueFromAttribute(attribute.Int64("command.duration_ms", durationMs)),
+				otellog.KeyValueFromAttribute(attribute.String("platform.os", runtime.GOOS)),
+				otellog.KeyValueFromAttribute(attribute.String("platform.arch", runtime.GOARCH)),
+				otellog.KeyValueFromAttribute(attribute.String("app.version", m.version)),
+				otellog.KeyValueFromAttribute(attribute.String("distro", m.distro)),
+			)
+			if exitCode != 0 {
+				record.SetBody(otellog.StringValue("command failed"))
+				record.SetSeverity(otellog.SeverityError)
+				record.SetSeverityText("ERROR")
+			} else {
+				record.SetBody(otellog.StringValue("command completed"))
+				record.SetSeverity(otellog.SeverityInfo)
+				record.SetSeverityText("INFO")
+			}
+			m.logger.Emit(ctx, record)
 		}
-		m.logger.Emit(ctx, record)
+		m.enqueueAnalytics(analyticsEvent{
+			Type:       "capture",
+			UUID:       uuid.NewString(),
+			Timestamp:  finishedAt,
+			DistinctID: m.anonID,
+			Event:      "cli_command_completed",
+			Properties: m.commandCompletedProperties(commandName, exitCode, durationMs),
+		})
 	}
 }
 
@@ -188,9 +266,7 @@ func telemetryDisabled(info BuildInfo, lookup func(string) string) bool {
 	if strings.EqualFold(lookup("CI"), "true") {
 		return true
 	}
-	return strings.TrimSpace(info.TelemetryEndpoint) == "" ||
-		strings.TrimSpace(info.TelemetryToken) == "" ||
-		telemetryURLPath(info) == ""
+	return !telemetryAnalyticsEnabled(info)
 }
 
 func ensureLocalState(root string) (localState, bool, error) {
@@ -248,6 +324,20 @@ func newHTTPExporter(ctx context.Context, info BuildInfo) (sdklog.Exporter, erro
 	return otlploghttp.New(exportCtx, opts...)
 }
 
+func newHTTPAnalyticsExporter(info BuildInfo, _ string) (analyticsExporter, error) {
+	baseURL, err := telemetryBaseURL(info)
+	if err != nil {
+		return nil, err
+	}
+	return &httpAnalyticsExporter{
+		baseURL: baseURL,
+		apiKey:  strings.TrimSpace(info.TelemetryToken),
+		client: &http.Client{
+			Timeout: exportTimeout,
+		},
+	}, nil
+}
+
 func defaultString(value string, fallback string) string {
 	if strings.TrimSpace(value) == "" {
 		return fallback
@@ -259,6 +349,28 @@ func telemetryURLPath(info BuildInfo) string {
 	return strings.TrimSpace(info.TelemetryURLPath)
 }
 
+func telemetryBaseURL(info BuildInfo) (string, error) {
+	endpoint := strings.TrimSpace(info.TelemetryEndpoint)
+	if endpoint == "" {
+		return "", errors.New("telemetry endpoint is empty")
+	}
+	if !strings.Contains(endpoint, "://") {
+		endpoint = "https://" + endpoint
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return "", err
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("invalid telemetry endpoint %q", info.TelemetryEndpoint)
+	}
+	parsed.Path = ""
+	parsed.RawPath = ""
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
 func telemetryExporterSettings(info BuildInfo) exporterSettings {
 	return exporterSettings{
 		Endpoint: strings.TrimSpace(info.TelemetryEndpoint),
@@ -268,6 +380,15 @@ func telemetryExporterSettings(info BuildInfo) exporterSettings {
 		Timeout: exportTimeout,
 		URLPath: telemetryURLPath(info),
 	}
+}
+
+func telemetryAnalyticsEnabled(info BuildInfo) bool {
+	return strings.TrimSpace(info.TelemetryEndpoint) != "" &&
+		strings.TrimSpace(info.TelemetryToken) != ""
+}
+
+func telemetryLogsEnabled(info BuildInfo) bool {
+	return telemetryAnalyticsEnabled(info) && telemetryURLPath(info) != ""
 }
 
 func disabledManager() *Manager {
@@ -290,4 +411,125 @@ func (cfg SetupConfig) stderr() io.Writer {
 		return cfg.Stderr
 	}
 	return io.Discard
+}
+
+func (m *Manager) enqueueAnalytics(event analyticsEvent) {
+	if m == nil || m.analytics == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, event)
+}
+
+func (m *Manager) commandProperties(commandName string) map[string]any {
+	commandGroup := commandGroup(commandName)
+	return map[string]any{
+		"$lib":          "vigilante-cli",
+		"$lib_version":  m.version,
+		"app_version":   m.version,
+		"command_name":  commandName,
+		"command_group": commandGroup,
+		"distro":        m.distro,
+		"feature_area":  commandFeatureArea(commandGroup),
+		"invocation":    "cli",
+		"platform_arch": runtime.GOARCH,
+		"platform_os":   runtime.GOOS,
+	}
+}
+
+func (m *Manager) commandCompletedProperties(commandName string, exitCode int, durationMs int64) map[string]any {
+	properties := m.commandProperties(commandName)
+	properties["duration_ms"] = durationMs
+	properties["exit_code"] = exitCode
+	properties["result"] = commandResult(exitCode)
+	properties["success"] = exitCode == 0
+	return properties
+}
+
+func commandGroup(commandName string) string {
+	parts := strings.Fields(commandName)
+	if len(parts) == 0 {
+		return "root"
+	}
+	return parts[0]
+}
+
+func commandFeatureArea(commandGroup string) string {
+	switch commandGroup {
+	case "setup":
+		return "setup"
+	case "watch", "unwatch", "list":
+		return "watch_management"
+	case "status", "service":
+		return "service_management"
+	case "daemon":
+		return "daemon"
+	case "cleanup":
+		return "cleanup"
+	case "resume", "redispatch":
+		return "issue_session"
+	case "completion", "help", "root":
+		return "operator_cli"
+	default:
+		return "operator_cli"
+	}
+}
+
+func commandResult(exitCode int) string {
+	if exitCode == 0 {
+		return "success"
+	}
+	return "failure"
+}
+
+type httpAnalyticsExporter struct {
+	baseURL string
+	apiKey  string
+	client  *http.Client
+}
+
+func (e *httpAnalyticsExporter) Export(ctx context.Context, events []analyticsEvent) error {
+	if len(events) == 0 {
+		return nil
+	}
+
+	messages := make([]json.RawMessage, 0, len(events))
+	for _, event := range events {
+		encoded, err := json.Marshal(event)
+		if err != nil {
+			return err
+		}
+		messages = append(messages, encoded)
+	}
+
+	payload, err := json.Marshal(analyticsBatch{
+		APIKey:   e.apiKey,
+		Messages: messages,
+	})
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, e.baseURL+"/batch/", bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		return fmt.Errorf("analytics export failed with status %s", resp.Status)
+	}
+	return fmt.Errorf("analytics export failed with status %s: %s", resp.Status, strings.TrimSpace(string(body)))
 }

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -3,8 +3,12 @@ package telemetry
 import (
 	"bytes"
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -31,6 +35,9 @@ func TestSetupCreatesAnonymousStateAndFirstRunNotice(t *testing.T) {
 		EnvLookup: func(string) string { return "" },
 		NewExporter: func(context.Context, BuildInfo) (sdklog.Exporter, error) {
 			return noopExporter{}, nil
+		},
+		NewAnalyticsExporter: func(BuildInfo, string) (analyticsExporter, error) {
+			return &captureAnalyticsExporter{}, nil
 		},
 	}
 
@@ -93,7 +100,7 @@ func TestSetupDisabledByConsentFlags(t *testing.T) {
 	}
 }
 
-func TestSetupDisabledWithoutTelemetryURLPath(t *testing.T) {
+func TestSetupEnablesAnalyticsWithoutTelemetryURLPath(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -106,15 +113,18 @@ func TestSetupDisabledWithoutTelemetryURLPath(t *testing.T) {
 		},
 		StateRoot: root,
 		EnvLookup: func(string) string { return "" },
+		NewAnalyticsExporter: func(BuildInfo, string) (analyticsExporter, error) {
+			return &captureAnalyticsExporter{}, nil
+		},
 	})
 	if err != nil {
 		t.Fatalf("Setup() error = %v", err)
 	}
 	if manager == nil {
-		t.Fatal("expected disabled manager instance")
+		t.Fatal("expected manager instance")
 	}
-	if _, err := os.Stat(filepath.Join(root, "state.json")); !os.IsNotExist(err) {
-		t.Fatalf("expected no state file when telemetry config is incomplete, got err=%v", err)
+	if _, err := os.Stat(filepath.Join(root, "state.json")); err != nil {
+		t.Fatalf("expected state file when analytics is enabled, got err=%v", err)
 	}
 }
 
@@ -178,6 +188,26 @@ func TestTelemetryExporterSettingsUseEmbeddedURLPath(t *testing.T) {
 	}
 }
 
+func TestTelemetryBaseURL(t *testing.T) {
+	t.Parallel()
+
+	got, err := telemetryBaseURL(BuildInfo{TelemetryEndpoint: " us.i.posthog.com "})
+	if err != nil {
+		t.Fatalf("telemetryBaseURL() error = %v", err)
+	}
+	if want := "https://us.i.posthog.com"; got != want {
+		t.Fatalf("telemetryBaseURL() = %q, want %q", got, want)
+	}
+
+	got, err = telemetryBaseURL(BuildInfo{TelemetryEndpoint: "https://eu.i.posthog.com/ingest"})
+	if err != nil {
+		t.Fatalf("telemetryBaseURL() error = %v", err)
+	}
+	if want := "https://eu.i.posthog.com"; got != want {
+		t.Fatalf("telemetryBaseURL() = %q, want %q", got, want)
+	}
+}
+
 func TestShutdownTimeoutExceedsExportTimeout(t *testing.T) {
 	t.Parallel()
 
@@ -197,6 +227,7 @@ func TestStartCommandEmitsLogRecord(t *testing.T) {
 
 	root := t.TempDir()
 	exporter := &captureExporter{}
+	analytics := &captureAnalyticsExporter{}
 	manager, err := Setup(context.Background(), SetupConfig{
 		BuildInfo: BuildInfo{
 			Version:           "1.2.3",
@@ -209,6 +240,9 @@ func TestStartCommandEmitsLogRecord(t *testing.T) {
 		EnvLookup: func(string) string { return "" },
 		NewExporter: func(context.Context, BuildInfo) (sdklog.Exporter, error) {
 			return exporter, nil
+		},
+		NewAnalyticsExporter: func(BuildInfo, string) (analyticsExporter, error) {
+			return analytics, nil
 		},
 	})
 	if err != nil {
@@ -251,6 +285,119 @@ func TestStartCommandEmitsLogRecord(t *testing.T) {
 	if got := attrs["command.duration_ms"].AsInt64(); got < 0 {
 		t.Fatalf("command.duration_ms = %d, want non-negative", got)
 	}
+
+	events := analytics.Events()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 analytics events, got %d", len(events))
+	}
+	if got, want := events[0].Event, "cli_command_started"; got != want {
+		t.Fatalf("events[0].Event = %q, want %q", got, want)
+	}
+	if got, want := events[1].Event, "cli_command_completed"; got != want {
+		t.Fatalf("events[1].Event = %q, want %q", got, want)
+	}
+	if got, want := events[0].Properties["command_name"], "watch"; got != want {
+		t.Fatalf("started command_name = %v, want %q", got, want)
+	}
+	if got, want := events[0].Properties["feature_area"], "watch_management"; got != want {
+		t.Fatalf("started feature_area = %v, want %q", got, want)
+	}
+	if _, ok := events[0].Properties["path"]; ok {
+		t.Fatal("expected analytics payload to omit raw command arguments")
+	}
+	if got, want := events[1].Properties["result"], "failure"; got != want {
+		t.Fatalf("completed result = %v, want %q", got, want)
+	}
+	if got, want := events[1].Properties["exit_code"], 7; got != want {
+		t.Fatalf("completed exit_code = %v, want %d", got, want)
+	}
+	if got, ok := events[1].Properties["duration_ms"].(int64); !ok || got < 0 {
+		t.Fatalf("completed duration_ms = %v, want non-negative int64", events[1].Properties["duration_ms"])
+	}
+}
+
+func TestStartCommandAnalyticsTaxonomyForGroupedCommands(t *testing.T) {
+	t.Parallel()
+
+	manager := &Manager{
+		analytics: &captureAnalyticsExporter{},
+		version:   "1.2.3",
+		distro:    "direct",
+		anonID:    "anon-123",
+	}
+
+	_, finish := manager.StartCommand(context.Background(), []string{"service", "restart"})
+	finish(0)
+	if err := manager.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+
+	events := manager.analytics.(*captureAnalyticsExporter).Events()
+	if len(events) != 2 {
+		t.Fatalf("expected 2 analytics events, got %d", len(events))
+	}
+	if got, want := events[0].Properties["command_name"], "service restart"; got != want {
+		t.Fatalf("command_name = %v, want %q", got, want)
+	}
+	if got, want := events[0].Properties["command_group"], "service"; got != want {
+		t.Fatalf("command_group = %v, want %q", got, want)
+	}
+	if got, want := events[0].Properties["feature_area"], "service_management"; got != want {
+		t.Fatalf("feature_area = %v, want %q", got, want)
+	}
+	if got, want := events[1].Properties["result"], "success"; got != want {
+		t.Fatalf("result = %v, want %q", got, want)
+	}
+}
+
+func TestHTTPAnalyticsExporterUsesBatchEndpoint(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu        sync.Mutex
+		gotPath   string
+		gotBody   string
+		gotMethod string
+	)
+	server := newTestServer(t, func(body string, method string, path string) {
+		mu.Lock()
+		defer mu.Unlock()
+		gotBody = body
+		gotMethod = method
+		gotPath = path
+	})
+
+	exporter, err := newHTTPAnalyticsExporter(BuildInfo{
+		TelemetryEndpoint: server.URL,
+		TelemetryToken:    "project-key",
+	}, "anon-123")
+	if err != nil {
+		t.Fatalf("newHTTPAnalyticsExporter() error = %v", err)
+	}
+	if err := exporter.Export(context.Background(), []analyticsEvent{{
+		Type:       "capture",
+		UUID:       "event-1",
+		Timestamp:  time.Unix(0, 0).UTC(),
+		DistinctID: "anon-123",
+		Event:      "cli_command_started",
+		Properties: map[string]any{"command_name": "watch"},
+	}}); err != nil {
+		t.Fatalf("Export() error = %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got, want := gotMethod, "POST"; got != want {
+		t.Fatalf("method = %q, want %q", got, want)
+	}
+	if got, want := gotPath, "/batch/"; got != want {
+		t.Fatalf("path = %q, want %q", got, want)
+	}
+	for _, want := range []string{`"api_key":"project-key"`, `"event":"cli_command_started"`, `"distinct_id":"anon-123"`, `"batch":[`} {
+		if !strings.Contains(gotBody, want) {
+			t.Fatalf("expected batch request body to contain %q, got %q", want, gotBody)
+		}
+	}
 }
 
 type noopExporter struct{}
@@ -287,4 +434,41 @@ func (e *captureExporter) Records() []sdklog.Record {
 	out := make([]sdklog.Record, len(e.records))
 	copy(out, e.records)
 	return out
+}
+
+type captureAnalyticsExporter struct {
+	mu     sync.Mutex
+	events []analyticsEvent
+}
+
+func (e *captureAnalyticsExporter) Events() []analyticsEvent {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	out := make([]analyticsEvent, len(e.events))
+	copy(out, e.events)
+	return out
+}
+
+func (e *captureAnalyticsExporter) Export(_ context.Context, events []analyticsEvent) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.events = append(e.events, events...)
+	return nil
+}
+
+func newTestServer(t *testing.T, capture func(body string, method string, path string)) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("ReadAll() error = %v", err)
+		}
+		capture(string(body), r.Method, r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+	return server
 }


### PR DESCRIPTION
## Summary
- add a PostHog-native analytics batch exporter alongside the existing OTLP log exporter
- emit privacy-bounded `cli_command_started` and `cli_command_completed` events for Vigilante CLI usage
- document the analytics-vs-logs split and cover the new telemetry behavior with targeted tests

## Validation
- `go test ./internal/telemetry`
- `go test ./...`

Closes #199
