### PR TITLE
Make merge-conflict resolution commit-aware and issue-spec preserving

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1097,32 +1097,28 @@ func (a *App) maintainOpenPullRequest(ctx context.Context, session *state.Sessio
 		return errors.New("worktree is not clean before PR maintenance")
 	}
 
-	rebaseOutput, err := a.env.Runner.Run(ctx, session.WorktreePath, "git", "rebase", "origin/main")
+	details, err := ghcli.GetPullRequestDetails(ctx, a.env.Runner, session.Repo, pr.Number)
+	if err != nil {
+		return err
+	}
+	if pullRequestNeedsConflictResolution(*details) {
+		return a.dispatchConflictResolution(ctx, session, *details)
+	}
+
+	baseBranch := strings.TrimSpace(session.BaseBranch)
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
+	baseRef := "origin/" + baseBranch
+	rebaseOutput, err := a.env.Runner.Run(ctx, session.WorktreePath, "git", "rebase", baseRef)
 	rebased := rebaseChangedHistory(rebaseOutput)
 	if err != nil {
 		if !isRebaseConflict(rebaseOutput, err) {
 			return err
 		}
-		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
-			Stage:      "Implementation In Progress",
-			Emoji:      "⚔️",
-			Percent:    75,
-			ETAMinutes: 12,
-			Items: []string{
-				fmt.Sprintf("Rebase conflicts appeared while updating PR #%d onto the latest `origin/main`.", pr.Number),
-				fmt.Sprintf("Worktree: `%s`.", session.WorktreePath),
-				"Next step: launch the dedicated conflict-resolution skill and continue from the rebased branch.",
-			},
-			Tagline: "Smooth roads never make skillful drivers.",
-		})
-		if commentErr := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); commentErr != nil {
-			a.state.AppendDaemonLog("pr conflict comment failed repo=%s issue=%d pr=%d err=%v", session.Repo, session.IssueNumber, pr.Number, commentErr)
-		}
-		target := state.WatchTarget{Path: session.RepoPath, Repo: session.Repo, Branch: "main"}
-		if conflictErr := issuerunner.RunConflictResolutionSession(ctx, a.env, a.state, target, *session, pr); conflictErr != nil {
-			return conflictErr
-		}
-		rebased = true
+		details.MergeStateStatus = fallbackText(details.MergeStateStatus, "DIRTY")
+		details.Mergeable = fallbackText(details.Mergeable, "CONFLICTING")
+		return a.dispatchConflictResolution(ctx, session, *details)
 	}
 
 	session.LastMaintainedAt = a.clock().Format(time.RFC3339)
@@ -1151,6 +1147,51 @@ func (a *App) maintainOpenPullRequest(ctx context.Context, session *state.Sessio
 		Tagline: "Success is where preparation and opportunity meet.",
 	})
 	return ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body)
+}
+
+func (a *App) dispatchConflictResolution(ctx context.Context, session *state.Session, pr ghcli.PullRequest) error {
+	issueDetails, err := ghcli.GetIssueDetails(ctx, a.env.Runner, session.Repo, session.IssueNumber)
+	if err != nil {
+		return err
+	}
+	session.IssueBody = strings.TrimSpace(issueDetails.Body)
+	if strings.TrimSpace(issueDetails.Title) != "" {
+		session.IssueTitle = issueDetails.Title
+	}
+	if strings.TrimSpace(issueDetails.URL) != "" {
+		session.IssueURL = issueDetails.URL
+	}
+
+	baseBranch := strings.TrimSpace(session.BaseBranch)
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
+	body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Conflict Resolution Started",
+		Emoji:      "⚔️",
+		Percent:    78,
+		ETAMinutes: 12,
+		Items: []string{
+			fmt.Sprintf("Vigilante routed PR #%d into the dedicated conflict-resolution workflow.", pr.Number),
+			fmt.Sprintf("GitHub state: mergeable=%s, mergeStateStatus=%s. Base branch: `origin/%s`.", fallbackText(pr.Mergeable, "UNKNOWN"), fallbackText(pr.MergeStateStatus, "UNKNOWN"), baseBranch),
+			"Next step: resolve the rebase commit by commit while preserving the original issue specification and branch intent.",
+		},
+		Tagline: "Keep the spec intact while the history moves.",
+	})
+	if commentErr := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); commentErr != nil {
+		a.state.AppendDaemonLog("pr conflict comment failed repo=%s issue=%d pr=%d err=%v", session.Repo, session.IssueNumber, pr.Number, commentErr)
+	}
+
+	target := state.WatchTarget{Path: session.RepoPath, Repo: session.Repo, Branch: baseBranch}
+	if conflictErr := issuerunner.RunConflictResolutionSession(ctx, a.env, a.state, target, *session, pr); conflictErr != nil {
+		return conflictErr
+	}
+
+	now := a.clock().Format(time.RFC3339)
+	session.LastMaintainedAt = now
+	session.UpdatedAt = now
+	session.LastMaintenanceError = fmt.Sprintf("conflict resolution dispatched for PR #%d; waiting for updated branch state", pr.Number)
+	return nil
 }
 
 func (a *App) maintainPullRequestChecks(ctx context.Context, session *state.Session, pr ghcli.PullRequest) error {
@@ -2215,6 +2256,13 @@ func automergeWaitReason(pr ghcli.PullRequest) string {
 	default:
 		return fmt.Sprintf("automerge waiting for GitHub mergeability on PR #%d: state %s", pr.Number, strings.ToLower(pr.MergeStateStatus))
 	}
+}
+
+func pullRequestNeedsConflictResolution(pr ghcli.PullRequest) bool {
+	if strings.EqualFold(strings.TrimSpace(pr.Mergeable), "CONFLICTING") {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(pr.MergeStateStatus), "DIRTY")
 }
 
 func requiredChecksState(checks []ghcli.StatusCheckRoll) string {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -139,7 +139,7 @@ func TestSyncSessionIssueLabelsUsesPullRequestReviewState(t *testing.T) {
 	app.env.Runner = testutil.FakeRunner{
 		Outputs: map[string]string{
 			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:blocked"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"resume"}]`,
-			"gh pr view --repo owner/repo 17 --json number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup": `{"number":17,"url":"https://github.com/owner/repo/pull/17","state":"OPEN","mergedAt":null,"labels":[],"isDraft":false,"mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[{"context":"test","state":"COMPLETED","conclusion":"SUCCESS"}]}`,
+			"gh pr view --repo owner/repo 17 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup": `{"number":17,"title":"Demo PR","body":"PR body","url":"https://github.com/owner/repo/pull/17","state":"OPEN","mergedAt":null,"labels":[],"isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[{"context":"test","state":"COMPLETED","conclusion":"SUCCESS"}]}`,
 			"gh api repos/owner/repo/issues/7": `{"labels":[{"name":"vigilante:ready-for-review"},{"name":"vigilante:needs-review"}]}`,
 			"gh issue edit --repo owner/repo 7 --add-label vigilante:awaiting-user-validation --remove-label vigilante:needs-review --remove-label vigilante:ready-for-review": "ok",
 		},
@@ -3885,6 +3885,7 @@ func TestScanOnceMaintainsOpenPullRequest(t *testing.T) {
 			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
 			"git fetch origin main":  "ok",
 			"git status --porcelain": "",
+			"gh pr view --repo owner/repo 31 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("", "MERGEABLE", "CLEAN", "APPROVED", "COMPLETED", "SUCCESS"),
 			"git rebase origin/main": "Successfully rebased and updated refs/heads/vigilante/issue-1.\n",
 			"go test ./...":          "ok",
 			"git push --force-with-lease origin HEAD:vigilante/issue-1": "ok",
@@ -3952,9 +3953,9 @@ func TestScanOnceAutoSquashMergesLabeledPullRequestAfterChecksPass(t *testing.T)
 		"git fetch origin main":  "ok",
 		"git status --porcelain": "",
 		"git rebase origin/main": "Current branch vigilante/issue-1 is up to date.\n",
-		"gh pr view --repo owner/repo 31 --json number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("automerge", "CLEAN", "APPROVED", "COMPLETED", "SUCCESS"),
-		"gh pr merge --repo owner/repo 31 --squash --delete-branch":                                                                         "ok",
-		"gh api user --jq .login": "nicobistolfi\n",
+		"gh pr view --repo owner/repo 31 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("automerge", "MERGEABLE", "CLEAN", "APPROVED", "COMPLETED", "SUCCESS"),
+		"gh pr merge --repo owner/repo 31 --squash --delete-branch": "ok",
+		"gh api user --jq .login":                                   "nicobistolfi\n",
 		"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
 	})
 
@@ -3981,7 +3982,7 @@ func TestScanOnceAutomergeWaitsForPendingChecks(t *testing.T) {
 		"git fetch origin main":  "ok",
 		"git status --porcelain": "",
 		"git rebase origin/main": "Current branch vigilante/issue-1 is up to date.\n",
-		"gh pr view --repo owner/repo 31 --json number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("automerge", "BLOCKED", "APPROVED", "PENDING", ""),
+		"gh pr view --repo owner/repo 31 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("automerge", "MERGEABLE", "BLOCKED", "APPROVED", "PENDING", ""),
 		"gh api user --jq .login": "nicobistolfi\n",
 		"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
 	})
@@ -4006,7 +4007,7 @@ func TestScanOnceFailingChecksTriggerCIRemediation(t *testing.T) {
 		"git fetch origin main":  "ok",
 		"git status --porcelain": "",
 		"git rebase origin/main": "Current branch vigilante/issue-1 is up to date.\n",
-		"gh pr view --repo owner/repo 31 --json number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("", "BLOCKED", "APPROVED", "COMPLETED", "FAILURE"),
+		"gh pr view --repo owner/repo 31 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("", "MERGEABLE", "BLOCKED", "APPROVED", "COMPLETED", "FAILURE"),
 		"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
 			Stage:      "CI Remediation Started",
 			Emoji:      "🛠️",
@@ -4058,7 +4059,7 @@ func TestScanOnceRepeatedIdenticalFailingChecksBlockForManualReview(t *testing.T
 		"git fetch origin main":  "ok",
 		"git status --porcelain": "",
 		"git rebase origin/main": "Current branch vigilante/issue-1 is up to date.\n",
-		"gh pr view --repo owner/repo 31 --json number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("", "BLOCKED", "APPROVED", "COMPLETED", "FAILURE"),
+		"gh pr view --repo owner/repo 31 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("", "MERGEABLE", "BLOCKED", "APPROVED", "COMPLETED", "FAILURE"),
 		"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
 			Stage:      "CI Needs Manual Review",
 			Emoji:      "🧱",
@@ -4108,7 +4109,7 @@ func TestScanOnceAutomergeWaitsForMergeabilityConstraints(t *testing.T) {
 		"git fetch origin main":  "ok",
 		"git status --porcelain": "",
 		"git rebase origin/main": "Current branch vigilante/issue-1 is up to date.\n",
-		"gh pr view --repo owner/repo 31 --json number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("automerge", "BLOCKED", "REVIEW_REQUIRED", "COMPLETED", "SUCCESS"),
+		"gh pr view --repo owner/repo 31 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("automerge", "MERGEABLE", "BLOCKED", "REVIEW_REQUIRED", "COMPLETED", "SUCCESS"),
 		"gh api user --jq .login": "nicobistolfi\n",
 		"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
 	})
@@ -4133,7 +4134,7 @@ func TestScanOnceDoesNotAutomergeUnlabeledPullRequest(t *testing.T) {
 		"git fetch origin main":  "ok",
 		"git status --porcelain": "",
 		"git rebase origin/main": "Current branch vigilante/issue-1 is up to date.\n",
-		"gh pr view --repo owner/repo 31 --json number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("", "CLEAN", "APPROVED", "COMPLETED", "SUCCESS"),
+		"gh pr view --repo owner/repo 31 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("", "MERGEABLE", "CLEAN", "APPROVED", "COMPLETED", "SUCCESS"),
 		"gh api user --jq .login": "nicobistolfi\n",
 		"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
 	})
@@ -4189,12 +4190,12 @@ func newPullRequestMaintenanceTestApp(t *testing.T, outputs map[string]string) (
 	return app, &stdout
 }
 
-func automergePRDetailsJSON(label string, mergeState string, reviewDecision string, checkState string, conclusion string) string {
+func automergePRDetailsJSON(label string, mergeable string, mergeState string, reviewDecision string, checkState string, conclusion string) string {
 	labelJSON := "[]"
 	if label != "" {
 		labelJSON = fmt.Sprintf(`[{"name":"%s"}]`, label)
 	}
-	return fmt.Sprintf(`{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null,"labels":%s,"isDraft":false,"mergeStateStatus":"%s","reviewDecision":"%s","statusCheckRollup":[{"context":"test","state":"%s","conclusion":"%s"}]}`, labelJSON, mergeState, reviewDecision, checkState, conclusion)
+	return fmt.Sprintf(`{"number":31,"title":"Test PR","body":"Test PR body","url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null,"labels":%s,"isDraft":false,"mergeable":"%s","mergeStateStatus":"%s","reviewDecision":"%s","statusCheckRollup":[{"context":"test","state":"%s","conclusion":"%s"}]}`, labelJSON, mergeable, mergeState, reviewDecision, checkState, conclusion)
 }
 
 func TestScanOnceSkipsWhenAnotherProcessHoldsScanLock(t *testing.T) {
@@ -4420,7 +4421,7 @@ func TestScanOnceRecoversStalledSessionIntoPRMaintenance(t *testing.T) {
 			"git fetch origin main":  "ok",
 			"git status --porcelain": "",
 			"git rebase origin/main": "Current branch vigilante/issue-1 is up to date.\n",
-			"gh pr view --repo owner/repo 31 --json number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("", "CLEAN", "APPROVED", "COMPLETED", "SUCCESS"),
+			"gh pr view --repo owner/repo 31 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("", "MERGEABLE", "CLEAN", "APPROVED", "COMPLETED", "SUCCESS"),
 			"gh api user --jq .login": "nicobistolfi\n",
 			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
 		},
@@ -4467,6 +4468,57 @@ func TestScanOnceRecoversStalledSessionIntoPRMaintenance(t *testing.T) {
 	}
 	if sessions[0].PullRequestNumber != 31 || sessions[0].LastMaintainedAt == "" {
 		t.Fatalf("expected PR maintenance tracking after recovery: %#v", sessions[0])
+	}
+}
+
+func TestScanOnceRoutesDirtyPullRequestToConflictResolution(t *testing.T) {
+	app, _ := newPullRequestMaintenanceTestApp(t, map[string]string{
+		"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
+		"git fetch origin main":  "ok",
+		"git status --porcelain": "",
+		"gh pr view --repo owner/repo 31 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup": automergePRDetailsJSON("", "CONFLICTING", "DIRTY", "APPROVED", "COMPLETED", "SUCCESS"),
+		"gh api repos/owner/repo/issues/1": `{"title":"first","body":"Keep the original form state behavior intact.","html_url":"https://github.com/owner/repo/issues/1","labels":[]}`,
+		"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+			Stage:      "Conflict Resolution Started",
+			Emoji:      "⚔️",
+			Percent:    78,
+			ETAMinutes: 12,
+			Items: []string{
+				"Vigilante routed PR #31 into the dedicated conflict-resolution workflow.",
+				"GitHub state: mergeable=CONFLICTING, mergeStateStatus=DIRTY. Base branch: `origin/main`.",
+				"Next step: resolve the rebase commit by commit while preserving the original issue specification and branch intent.",
+			},
+			Tagline: "Keep the spec intact while the history moves.",
+		}): "ok",
+		"codex --version": "codex 0.114.0",
+		conflictResolutionPromptCommand(filepath.Join("/tmp/repo", ".worktrees", "vigilante", "issue-1"), "owner/repo", "/tmp/repo", state.Session{
+			IssueNumber:  1,
+			IssueTitle:   "first",
+			IssueBody:    "Keep the original form state behavior intact.",
+			IssueURL:     "https://github.com/owner/repo/issues/1",
+			BaseBranch:   "main",
+			WorktreePath: filepath.Join("/tmp/repo", ".worktrees", "vigilante", "issue-1"),
+			Branch:       "vigilante/issue-1",
+			Provider:     "codex",
+		}, ghcli.PullRequest{Number: 31, Title: "Test PR", Body: "Test PR body", URL: "https://github.com/owner/repo/pull/31", Mergeable: "CONFLICTING", MergeStateStatus: "DIRTY"}): "resolved and pushed",
+		"gh api user --jq .login": "nicobistolfi\n",
+		"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+	})
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	app.waitForSessions()
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions[0].LastMaintenanceError != "conflict resolution dispatched for PR #31; waiting for updated branch state" {
+		t.Fatalf("expected conflict-resolution wait state, got: %#v", sessions[0])
+	}
+	if sessions[0].LastMaintainedAt == "" {
+		t.Fatalf("expected maintenance timestamp after conflict dispatch: %#v", sessions[0])
 	}
 }
 
@@ -4606,5 +4658,13 @@ func ciRemediationPromptCommand(worktreePath string, repo string, repoPath strin
 		session,
 		pr,
 		checks,
+	))
+}
+
+func conflictResolutionPromptCommand(worktreePath string, repo string, repoPath string, session state.Session, pr ghcli.PullRequest) string {
+	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildConflictResolutionPrompt(
+		state.WatchTarget{Path: repoPath, Repo: repo, Branch: session.BaseBranch},
+		session,
+		pr,
 	))
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -26,11 +26,14 @@ type Label struct {
 
 type PullRequest struct {
 	Number            int               `json:"number"`
+	Title             string            `json:"title"`
+	Body              string            `json:"body"`
 	URL               string            `json:"url"`
 	State             string            `json:"state"`
 	MergedAt          *time.Time        `json:"mergedAt"`
 	Labels            []Label           `json:"labels"`
 	IsDraft           bool              `json:"isDraft"`
+	Mergeable         string            `json:"mergeable"`
 	MergeStateStatus  string            `json:"mergeStateStatus"`
 	ReviewDecision    string            `json:"reviewDecision"`
 	StatusCheckRollup []StatusCheckRoll `json:"statusCheckRollup"`
@@ -53,6 +56,9 @@ type IssueComment struct {
 }
 
 type IssueDetails struct {
+	Title  string  `json:"title"`
+	Body   string  `json:"body"`
+	URL    string  `json:"html_url"`
 	Labels []Label `json:"labels"`
 }
 
@@ -456,7 +462,7 @@ func GetPullRequestDetails(ctx context.Context, runner environment.Runner, repo 
 		repo,
 		fmt.Sprintf("%d", number),
 		"--json",
-		"number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup",
+		"number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup",
 	)
 	if err != nil {
 		return nil, err

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -315,7 +315,7 @@ func TestFindPullRequestForBranch(t *testing.T) {
 func TestGetPullRequestDetails(t *testing.T) {
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{
-			"gh pr view --repo owner/repo 17 --json number,url,state,mergedAt,labels,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup": `{"number":17,"url":"https://github.com/owner/repo/pull/17","state":"OPEN","mergedAt":null,"labels":[{"name":"automerge"}],"isDraft":false,"mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[{"context":"test","state":"COMPLETED","conclusion":"SUCCESS"}]}`,
+			"gh pr view --repo owner/repo 17 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup": `{"number":17,"title":"Feature","body":"PR body","url":"https://github.com/owner/repo/pull/17","state":"OPEN","mergedAt":null,"labels":[{"name":"automerge"}],"isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[{"context":"test","state":"COMPLETED","conclusion":"SUCCESS"}]}`,
 		},
 	}
 
@@ -323,7 +323,7 @@ func TestGetPullRequestDetails(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if pr.Number != 17 || pr.MergeStateStatus != "CLEAN" || pr.ReviewDecision != "APPROVED" {
+	if pr.Number != 17 || pr.Title != "Feature" || pr.Mergeable != "MERGEABLE" || pr.MergeStateStatus != "CLEAN" || pr.ReviewDecision != "APPROVED" {
 		t.Fatalf("unexpected pull request details: %#v", pr)
 	}
 	if len(pr.Labels) != 1 || pr.Labels[0].Name != "automerge" {

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -183,7 +183,7 @@ func TestRunConflictResolutionSessionFailureCommentsOnIssue(t *testing.T) {
 			}): "ok",
 		},
 		Errors: map[string]error{
-			"codex exec --cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox Use the `vigilante-conflict-resolution` skill for this task.\nRepository: owner/repo\nLocal repository path: /tmp/repo\nIssue: #7 - Demo\nIssue URL: https://github.com/owner/repo/issues/7\nPull Request: #17\nPull Request URL: https://github.com/owner/repo/pull/17\nWorktree path: /tmp/worktree\nBranch: vigilante/issue-7\nBase branch: origin/main\nResolve the current rebase conflicts in the assigned worktree, use `gh issue comment` for progress and failures, rerun `go test ./...` after conflict resolution if the rebase succeeds, and push the updated branch when finished.\nKeep the changes minimal and focused on getting the PR back to a merge-ready state.": errors.New("codex exec [--cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox prompt]: exit status 1"),
+			conflictResolutionPromptCommand("/tmp/worktree", "owner/repo", "/tmp/repo", state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, IssueTitle: "Demo", IssueBody: "Preserve the requested behavior.", IssueURL: "https://github.com/owner/repo/issues/7", BaseBranch: "main", WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7"}, ghcli.PullRequest{Number: 17, Title: "Demo PR", Body: "PR body", URL: "https://github.com/owner/repo/pull/17", Mergeable: "CONFLICTING", MergeStateStatus: "DIRTY"}): errors.New("codex exec [--cd /tmp/worktree --dangerously-bypass-approvals-and-sandbox prompt]: exit status 1"),
 		},
 	}
 	env := &environment.Environment{OS: "darwin", Runner: runner}
@@ -196,9 +196,9 @@ func TestRunConflictResolutionSessionFailureCommentsOnIssue(t *testing.T) {
 		context.Background(),
 		env,
 		store,
-		state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"},
-		state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, IssueTitle: "Demo", IssueURL: "https://github.com/owner/repo/issues/7", WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7"},
-		ghcli.PullRequest{Number: 17, URL: "https://github.com/owner/repo/pull/17"},
+		state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"},
+		state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, IssueTitle: "Demo", IssueBody: "Preserve the requested behavior.", IssueURL: "https://github.com/owner/repo/issues/7", BaseBranch: "main", WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7"},
+		ghcli.PullRequest{Number: 17, Title: "Demo PR", Body: "PR body", URL: "https://github.com/owner/repo/pull/17", Mergeable: "CONFLICTING", MergeStateStatus: "DIRTY"},
 	)
 	if err == nil {
 		t.Fatal("expected error")
@@ -668,6 +668,14 @@ func issuePromptCommandForSession(worktreePath string, repo string, repoPath str
 		state.WatchTarget{Path: repoPath, Repo: repo},
 		ghcli.Issue{Number: issueNumber, Title: title, URL: issueURL},
 		session,
+	))
+}
+
+func conflictResolutionPromptCommand(worktreePath string, repo string, repoPath string, session state.Session, pr ghcli.PullRequest) string {
+	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildConflictResolutionPrompt(
+		state.WatchTarget{Path: repoPath, Repo: repo, Branch: session.BaseBranch},
+		session,
+		pr,
 	))
 }
 

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -426,19 +426,37 @@ func BuildConflictResolutionPromptForRuntime(runtime string, target state.WatchT
 	} else {
 		lines = append(lines, fmt.Sprintf("Use the `%s` skill for this task.", VigilanteConflictResolution))
 	}
+	baseBranch := strings.TrimSpace(session.BaseBranch)
+	if baseBranch == "" {
+		baseBranch = strings.TrimSpace(target.Branch)
+	}
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
+	baseRef := "origin/" + baseBranch
 	lines = append(lines,
 		fmt.Sprintf("Repository: %s", target.Repo),
 		fmt.Sprintf("Local repository path: %s", target.Path),
 		fmt.Sprintf("Issue: #%d - %s", session.IssueNumber, session.IssueTitle),
 		fmt.Sprintf("Issue URL: %s", session.IssueURL),
+		fmt.Sprintf("Issue specification: %s", fallbackPromptText(session.IssueBody, "(issue body unavailable; preserve the stated issue title and existing branch intent)")),
 		fmt.Sprintf("Pull Request: #%d", pr.Number),
 		fmt.Sprintf("Pull Request URL: %s", pr.URL),
+		fmt.Sprintf("Pull Request title: %s", fallbackPromptText(pr.Title, "(pull request title unavailable)")),
+		fmt.Sprintf("Pull Request body: %s", fallbackPromptText(pr.Body, "(pull request body unavailable)")),
 		fmt.Sprintf("Worktree path: %s", session.WorktreePath),
 		fmt.Sprintf("Branch: %s", session.Branch),
-		"Base branch: origin/main",
-		"Resolve the current rebase conflicts in the assigned worktree, use `gh issue comment` for progress and failures, rerun `go test ./...` after conflict resolution if the rebase succeeds, and push the updated branch when finished.",
-		"Keep the changes minimal and focused on getting the PR back to a merge-ready state.",
+		fmt.Sprintf("Base branch: %s", baseRef),
+		fmt.Sprintf("GitHub mergeability: mergeable=%s mergeStateStatus=%s", fallbackPromptText(pr.Mergeable, "UNKNOWN"), fallbackPromptText(pr.MergeStateStatus, "UNKNOWN")),
+		"Conflict-resolution workflow: rebase the branch onto the latest base branch if that has not already started; if a rebase is already in progress, continue it from the current stopped commit.",
+		"Work through the rebase commit by commit. Preserve the meaning of each existing issue-branch commit and keep the original issue specification authoritative.",
+		"Do not silently discard commits or issue-specific behavior just to get a clean merge. Prefer the smallest safe conflict fix.",
+		"Use `gh issue comment` for progress and failures, rerun `go test ./...` after conflict resolution succeeds, and push the updated branch when finished.",
+		"If you cannot preserve the issue intent safely, leave a concise GitHub blocker comment and exit with a non-zero status.",
 	)
+	if strings.TrimSpace(session.BranchDiffSummary) != "" {
+		lines = append(lines, fmt.Sprintf("Existing branch summary: %s", session.BranchDiffSummary))
+	}
 	return strings.Join(lines, "\n")
 }
 

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -444,10 +444,10 @@ func TestBuildIssuePreflightPromptForReusedRemoteBranch(t *testing.T) {
 
 func TestBuildConflictResolutionPrompt(t *testing.T) {
 	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
-	session := state.Session{IssueNumber: 12, IssueTitle: "Fix bug", IssueURL: "https://example.com/issues/12", WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12"}
-	pr := ghcli.PullRequest{Number: 88, URL: "https://example.com/pull/88"}
+	session := state.Session{IssueNumber: 12, IssueTitle: "Fix bug", IssueBody: "Preserve the original validation behavior.", IssueURL: "https://example.com/issues/12", BaseBranch: "main", WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", BranchDiffSummary: "Keep the error-state form inputs intact."}
+	pr := ghcli.PullRequest{Number: 88, URL: "https://example.com/pull/88", Title: "Fix bug", Body: "This PR keeps the original UX behavior.", Mergeable: "CONFLICTING", MergeStateStatus: "DIRTY"}
 	prompt := BuildConflictResolutionPrompt(target, session, pr)
-	for _, text := range []string{"Use the `vigilante-conflict-resolution` skill", "Pull Request: #88", "Base branch: origin/main", "go test ./...", "merge-ready state"} {
+	for _, text := range []string{"Use the `vigilante-conflict-resolution` skill", "Issue specification: Preserve the original validation behavior.", "Pull Request title: Fix bug", "GitHub mergeability: mergeable=CONFLICTING mergeStateStatus=DIRTY", "Work through the rebase commit by commit.", "go test ./...", "Existing branch summary: Keep the error-state form inputs intact."} {
 		if !strings.Contains(prompt, text) {
 			t.Fatalf("prompt missing %q: %s", text, prompt)
 		}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -59,6 +59,7 @@ type Session struct {
 	Provider                       string        `json:"provider,omitempty"`
 	IssueNumber                    int           `json:"issue_number"`
 	IssueTitle                     string        `json:"issue_title,omitempty"`
+	IssueBody                      string        `json:"issue_body,omitempty"`
 	IssueURL                       string        `json:"issue_url,omitempty"`
 	BaseBranch                     string        `json:"base_branch,omitempty"`
 	Branch                         string        `json:"branch"`

--- a/skills/vigilante-conflict-resolution/SKILL.md
+++ b/skills/vigilante-conflict-resolution/SKILL.md
@@ -9,10 +9,10 @@ description: Resolve rebase and merge conflicts for an already-open Vigilante pu
 Use this skill after Vigilante has already opened a pull request and a follow-up rebase onto `origin/main` hits conflicts. Work only inside the assigned worktree, resolve the conflicts with the smallest safe change, rerun validation, push the updated branch, and keep the linked GitHub issue informed.
 
 ## Workflow
-1. Inspect the current rebase state in the assigned worktree.
+1. Inspect the current rebase state in the assigned worktree and start the rebase onto the provided base branch if it has not already begun.
 2. Read repository instructions that affect the touched files before editing.
 3. Comment on the issue when conflict resolution begins and again for meaningful milestones or failures.
-4. Resolve only the conflicts needed to complete the rebase cleanly.
+4. Resolve only the conflicts needed to complete the rebase cleanly, commit by commit, while preserving the original issue specification and branch intent.
 5. Rerun the requested validation after the rebase succeeds.
 6. Push the updated branch back to GitHub.
 7. Report the final result clearly on the issue, including any remaining blocker if the conflicts cannot be resolved safely.
@@ -20,5 +20,6 @@ Use this skill after Vigilante has already opened a pull request and a follow-up
 ## Guardrails
 - Stay inside the provided worktree.
 - Do not broaden the change beyond the conflicting files unless required to restore build or test health.
+- Keep the original issue behavior authoritative; do not drop commits or rewrite away issue scope just to remove conflicts.
 - Do not claim the branch is merge-ready unless the requested validation actually passed.
 - Report blockers immediately with `gh issue comment`.


### PR DESCRIPTION
## Summary
- route GitHub-reported merge-conflicted PRs into the dedicated conflict-resolution workflow during PR maintenance
- pass original issue spec, PR context, mergeability state, and commit-aware preservation guidance into the conflict-resolution prompt
- cover the new routing and prompt context with PR-maintenance, runner, skill, and GitHub client tests

Closes #208.

## Validation
- `go test ./internal/app ./internal/github ./internal/runner ./internal/skill`
- `go test ./...`
