### PR TITLE
Use only vigilante:ready-for-review for review handoff

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -75,17 +75,6 @@
       ]
     },
     {
-      "name": "vigilante:needs-review",
-      "color": "D4C5F9",
-      "group": "intervention",
-      "behavior": "informational",
-      "applied_by": "vigilante",
-      "description": "A human should review the implementation output before Vigilante continues or closes the loop.",
-      "notes": [
-        "Can coexist with vigilante:ready-for-review or vigilante:blocked depending on the workflow stage."
-      ]
-    },
-    {
       "name": "vigilante:needs-human-input",
       "color": "F7C6C7",
       "group": "intervention",

--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ Label ownership rules:
 Proposed groups:
 
 - Execution state: `vigilante:queued`, `vigilante:running`, `vigilante:blocked`, `vigilante:ready-for-review`, `vigilante:awaiting-user-validation`, `vigilante:done`
-- Human-intervention state: `vigilante:needs-review`, `vigilante:needs-human-input`, `vigilante:needs-provider-fix`, `vigilante:needs-git-fix`
+- Human-intervention state: `vigilante:needs-human-input`, `vigilante:needs-provider-fix`, `vigilante:needs-git-fix`
 - Provider routing controls: `codex`, `claude`, `gemini`
 - Explicit control labels: `vigilante:resume` and legacy `resume`
 
@@ -555,7 +555,7 @@ Recommended lifecycle:
 1. When an issue becomes eligible but has not started, add `vigilante:queued`.
 2. When execution starts, replace `vigilante:queued` with `vigilante:running`.
 3. If execution stalls on a known blocker, replace `vigilante:running` with `vigilante:blocked` and add exactly one matching `vigilante:needs-*` label when possible.
-4. When implementation is ready for a human to inspect, replace blocked or running state with `vigilante:ready-for-review`, keeping `vigilante:needs-review` when a human handoff is still pending.
+4. When implementation is ready for a human to inspect, replace blocked or running state with `vigilante:ready-for-review` as the single review-handoff label.
 5. When code review is complete but a product or operator check is still required, use `vigilante:awaiting-user-validation`.
 6. When the issue reaches a terminal successful state, clear transient labels and leave `vigilante:done`.
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2645,7 +2645,7 @@ func desiredSessionLabels(session state.Session, pr *ghcli.PullRequest) (string,
 		if pr != nil && shouldAwaitUserValidation(*pr) {
 			return labelAwaitingUserValidation, ""
 		}
-		return labelReadyForReview, labelNeedsReview
+		return labelReadyForReview, ""
 	default:
 		return "", ""
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -81,7 +81,7 @@ func TestDesiredSessionLabels(t *testing.T) {
 			name:             "success ready for review",
 			session:          state.Session{Status: state.SessionStatusSuccess},
 			wantState:        labelReadyForReview,
-			wantIntervention: labelNeedsReview,
+			wantIntervention: "",
 		},
 		{
 			name:    "success awaiting validation",
@@ -169,7 +169,6 @@ func TestSyncIssueManagedLabelsProvisionMissingRepositoryLabels(t *testing.T) {
 			"gh api --method POST repos/owner/repo/labels -f name=vigilante:ready-for-review -f color=FBCA04 -f description=Implementation is complete enough for a human to review the resulting PR or branch.":               "ok",
 			"gh api --method POST repos/owner/repo/labels -f name=vigilante:awaiting-user-validation -f color=F9D0C4 -f description=Changes are ready for product or operator validation before the issue is considered done.": "ok",
 			"gh api --method POST repos/owner/repo/labels -f name=vigilante:done -f color=5319E7 -f description=Vigilante completed its work on the issue and no further automation is expected.":                              "ok",
-			"gh api --method POST repos/owner/repo/labels -f name=vigilante:needs-review -f color=D4C5F9 -f description=A human should review the implementation output before Vigilante continues or closes the loop.":        "ok",
 			"gh api --method POST repos/owner/repo/labels -f name=vigilante:needs-human-input -f color=F7C6C7 -f description=The agent is waiting on product, operator, or repository-owner guidance.":                         "ok",
 			"gh api --method POST repos/owner/repo/labels -f name=vigilante:needs-provider-fix -f color=E99695 -f description=Execution is blocked by provider auth, quota, or runtime setup issues.":                          "ok",
 			"gh api --method POST repos/owner/repo/labels -f name=vigilante:needs-git-fix -f color=C2E0C6 -f description=Execution is blocked by repository or git state that requires human repair.":                          "ok",

--- a/internal/github/labels_manifest_test.go
+++ b/internal/github/labels_manifest_test.go
@@ -104,7 +104,6 @@ func TestIssueLabelManifestIncludesHumanReviewStates(t *testing.T) {
 	for _, name := range []string{
 		"vigilante:ready-for-review",
 		"vigilante:awaiting-user-validation",
-		"vigilante:needs-review",
 		"vigilante:needs-human-input",
 	} {
 		label, ok := labels[name]
@@ -114,6 +113,10 @@ func TestIssueLabelManifestIncludesHumanReviewStates(t *testing.T) {
 		if label.Behavior != "informational" {
 			t.Fatalf("expected %q to stay informational, got %#v", name, label)
 		}
+	}
+
+	if _, ok := labels["vigilante:needs-review"]; ok {
+		t.Fatal("expected vigilante:needs-review to be absent from the canonical label manifest")
 	}
 }
 


### PR DESCRIPTION
## Summary
- use `vigilante:ready-for-review` as the only runtime review-handoff label
- keep `vigilante:needs-review` only in the managed cleanup set so redundant legacy labels are removed during sync
- update the label manifest, README, and tests to match the simplified taxonomy

Closes #211.

## Validation
- `go test ./internal/app ./internal/github`
