### PR TITLE
Expand anonymous analytics into daemon workflows

### DIFF
--- a/cmd/vigilante/main.go
+++ b/cmd/vigilante/main.go
@@ -48,6 +48,9 @@ func run() int {
 	if err != nil || manager == nil {
 		manager = &telemetry.Manager{}
 	}
+	if telemetryManager, ok := manager.(*telemetry.Manager); ok {
+		telemetry.SetDefault(telemetryManager)
+	}
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), telemetry.ShutdownTimeout())
 	defer cancel()
 	defer func() {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -25,6 +25,7 @@ import (
 	"github.com/nicobistolfi/vigilante/internal/service"
 	"github.com/nicobistolfi/vigilante/internal/skill"
 	"github.com/nicobistolfi/vigilante/internal/state"
+	"github.com/nicobistolfi/vigilante/internal/telemetry"
 	"github.com/nicobistolfi/vigilante/internal/worktree"
 )
 
@@ -112,6 +113,67 @@ func New() *App {
 			},
 		},
 	}
+}
+
+func (a *App) emitSessionTransition(previous state.SessionStatus, session state.Session, source string) {
+	if previous == session.Status {
+		return
+	}
+	properties := map[string]any{
+		"feature_area":     "issue_session",
+		"invocation":       "daemon",
+		"previous_status":  string(previous),
+		"status":           string(session.Status),
+		"provider":         strings.TrimSpace(session.Provider),
+		"blocked_stage":    strings.TrimSpace(session.BlockedStage),
+		"blocked_kind":     strings.TrimSpace(session.BlockedReason.Kind),
+		"source":           strings.TrimSpace(source),
+		"has_pull_request": session.PullRequestNumber > 0,
+	}
+	switch session.Status {
+	case state.SessionStatusRunning:
+		properties["transition"] = "started"
+	case state.SessionStatusBlocked:
+		properties["transition"] = "blocked"
+	case state.SessionStatusResuming:
+		properties["transition"] = "resuming"
+	case state.SessionStatusSuccess:
+		properties["transition"] = "succeeded"
+	case state.SessionStatusFailed:
+		properties["transition"] = "failed"
+	}
+	telemetry.CaptureWorkflowEvent("issue_session_transition", properties)
+}
+
+func (a *App) emitCommentEvent(commentType string, source string) {
+	telemetry.CaptureWorkflowEvent("github_issue_comment_emitted", map[string]any{
+		"feature_area": "github_issue_comments",
+		"invocation":   "daemon",
+		"comment_type": strings.TrimSpace(commentType),
+		"source":       strings.TrimSpace(source),
+	})
+}
+
+func (a *App) emitLabelSyncEvent(added []string, removed []string) {
+	if len(added) == 0 && len(removed) == 0 {
+		return
+	}
+	telemetry.CaptureWorkflowEvent("github_issue_labels_synced", map[string]any{
+		"feature_area":   "github_issue_labels",
+		"invocation":     "daemon",
+		"added_labels":   append([]string(nil), added...),
+		"removed_labels": append([]string(nil), removed...),
+		"add_count":      len(added),
+		"remove_count":   len(removed),
+	})
+}
+
+func (a *App) commentOnIssue(ctx context.Context, repo string, issue int, body string, commentType string, source string) error {
+	if err := ghcli.CommentOnIssue(ctx, a.env.Runner, repo, issue, body); err != nil {
+		return err
+	}
+	a.emitCommentEvent(commentType, source)
+	return nil
 }
 
 func (a *App) Run(ctx context.Context, args []string) int {
@@ -627,11 +689,38 @@ func (a *App) List(blockedOnly bool, runningOnly bool) error {
 	return enc.Encode(targets)
 }
 
-func (a *App) DaemonRun(ctx context.Context, interval time.Duration, once bool) error {
+func (a *App) DaemonRun(ctx context.Context, interval time.Duration, once bool) (runErr error) {
 	if interval <= 0 {
 		return errors.New("interval must be positive")
 	}
+	startedAt := time.Now().UTC()
 	a.state.AppendDaemonLog("daemon run start once=%t interval=%s", once, interval)
+	telemetry.CaptureWorkflowEvent("daemon_execution_started", map[string]any{
+		"feature_area":     "daemon",
+		"invocation":       "daemon",
+		"mode":             daemonMode(once),
+		"interval_seconds": int(interval / time.Second),
+	})
+	defer func() {
+		result := "success"
+		if runErr != nil {
+			result = "failure"
+		}
+		if ctx.Err() != nil && !errors.Is(ctx.Err(), context.Canceled) {
+			result = "failure"
+		}
+		if ctx.Err() != nil && errors.Is(ctx.Err(), context.Canceled) {
+			result = "canceled"
+		}
+		telemetry.CaptureWorkflowEvent("daemon_execution_completed", map[string]any{
+			"feature_area":     "daemon",
+			"invocation":       "daemon",
+			"mode":             daemonMode(once),
+			"interval_seconds": int(interval / time.Second),
+			"duration_ms":      time.Since(startedAt).Milliseconds(),
+			"result":           result,
+		})
+	}()
 
 	if once {
 		if err := a.ScanOnce(ctx); err != nil {
@@ -656,6 +745,13 @@ func (a *App) DaemonRun(ctx context.Context, interval time.Duration, once bool) 
 		case <-ticker.C:
 		}
 	}
+}
+
+func daemonMode(once bool) string {
+	if once {
+		return "once"
+	}
+	return "continuous"
 }
 
 func (a *App) ScanOnce(ctx context.Context) error {
@@ -761,6 +857,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 					if err := a.state.SaveSessions(sessions); err != nil {
 						return err
 					}
+					a.emitSessionTransition(previous.Status, session, "dispatch")
 					a.syncSessionIssueLabelsBestEffort(ctx, session, nil)
 					fmt.Fprintf(a.stdout, "repo: %s blocked issue #%d: %s\n", target.Repo, next.Number, summarizeText(err.Error()))
 					continue
@@ -782,6 +879,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 						if err := a.state.SaveSessions(sessions); err != nil {
 							return err
 						}
+						a.emitSessionTransition("", session, "dispatch")
 						fmt.Fprintf(a.stdout, "repo: %s blocked issue #%d: %s\n", target.Repo, next.Number, summarizeText(session.LastError))
 						continue
 					}
@@ -810,6 +908,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 				if err := a.state.SaveSessions(sessions); err != nil {
 					return err
 				}
+				a.emitSessionTransition("", session, "dispatch")
 				a.syncSessionIssueLabelsBestEffort(ctx, session, nil)
 				startedCount++
 				fmt.Fprintf(a.stdout, "repo: %s started issue #%d in %s\n", target.Repo, next.Number, wt.Path)
@@ -858,12 +957,14 @@ func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Sessi
 			continue
 		}
 		if pr != nil {
+			previousStatus := session.Status
 			session.Status = state.SessionStatusSuccess
 			session.ProcessID = 0
 			session.LastHeartbeatAt = ""
 			updatePullRequestTrackingFromLookup(session, *pr)
 			session.LastError = ""
 			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			a.emitSessionTransition(previousStatus, *session, "stalled_recovery")
 			a.state.AppendDaemonLog("stalled session recovered to pr maintenance repo=%s issue=%d branch=%s reason=%q pr=%d", session.Repo, session.IssueNumber, session.Branch, reason, pr.Number)
 			body := ghcli.FormatProgressComment(ghcli.ProgressComment{
 				Stage:      "Implementation In Progress",
@@ -877,7 +978,7 @@ func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Sessi
 				},
 				Tagline: "Fall seven times, stand up eight.",
 			})
-			if err := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); err != nil {
+			if err := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "progress", "stalled_recovery"); err != nil {
 				session.LastError = err.Error()
 				session.UpdatedAt = a.clock().Format(time.RFC3339)
 				a.state.AppendDaemonLog("stalled session recovery comment failed repo=%s issue=%d branch=%s err=%v", session.Repo, session.IssueNumber, session.Branch, err)
@@ -903,7 +1004,7 @@ func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Sessi
 				},
 				Tagline: "The gem cannot be polished without friction.",
 			})
-			if commentErr := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); commentErr != nil {
+			if commentErr := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "blocked", "stalled_recovery"); commentErr != nil {
 				session.LastError = commentErr.Error()
 				session.UpdatedAt = a.clock().Format(time.RFC3339)
 				a.state.AppendDaemonLog("stalled session cleanup comment failed repo=%s issue=%d branch=%s err=%v", session.Repo, session.IssueNumber, session.Branch, commentErr)
@@ -913,6 +1014,7 @@ func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Sessi
 		}
 
 		now := a.clock().Format(time.RFC3339)
+		previousStatus := session.Status
 		session.Status = state.SessionStatusFailed
 		session.ProcessID = 0
 		session.LastHeartbeatAt = ""
@@ -920,6 +1022,7 @@ func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Sessi
 		session.EndedAt = now
 		session.UpdatedAt = now
 		session.LastError = fmt.Sprintf("stalled session recovered: %s", reason)
+		a.emitSessionTransition(previousStatus, *session, "stalled_recovery")
 		a.state.AppendDaemonLog("stalled session recovered for redispatch repo=%s issue=%d branch=%s reason=%q", session.Repo, session.IssueNumber, session.Branch, reason)
 		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
 			Stage:      "Implementation In Progress",
@@ -933,7 +1036,7 @@ func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Sessi
 			},
 			Tagline: "A smooth sea never made a skilled sailor.",
 		})
-		if err := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); err != nil {
+		if err := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "progress", "stalled_recovery"); err != nil {
 			session.LastError = err.Error()
 			session.UpdatedAt = a.clock().Format(time.RFC3339)
 			a.state.AppendDaemonLog("stalled session redispatch comment failed repo=%s issue=%d branch=%s err=%v", session.Repo, session.IssueNumber, session.Branch, err)
@@ -977,7 +1080,9 @@ func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session
 				a.state.AppendDaemonLog("pr maintenance failed repo=%s issue=%d pr=%d branch=%s err=%v", session.Repo, session.IssueNumber, pr.Number, session.Branch, err)
 				if shouldCommentMaintenanceFailure(*session, err) {
 					blocked := classifyBlockedReason("pr_maintenance", "git fetch origin main", err)
+					previousStatus := session.Status
 					markSessionBlocked(session, "pr_maintenance", blocked, a.clock())
+					a.emitSessionTransition(previousStatus, *session, "pr_maintenance")
 					body := ghcli.FormatProgressComment(ghcli.ProgressComment{
 						Stage:      "Blocked",
 						Emoji:      "🧱",
@@ -990,7 +1095,7 @@ func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session
 						},
 						Tagline: "Difficulties strengthen the mind, as labor does the body.",
 					})
-					if commentErr := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); commentErr != nil {
+					if commentErr := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "blocked", "pr_maintenance"); commentErr != nil {
 						a.state.AppendDaemonLog("pr maintenance failure comment failed repo=%s issue=%d pr=%d err=%v", session.Repo, session.IssueNumber, pr.Number, commentErr)
 					}
 					session.LastMaintenanceError = err.Error()
@@ -1062,6 +1167,9 @@ func (a *App) launchIssueSession(ctx context.Context, target state.WatchTarget, 
 		}
 		if previous, _ := findSession(sessions, target.Repo, issue.Number); shouldCommentStartupFailure(result) {
 			a.commentDispatchFailure(ctx, previous, &result, "issue_startup")
+		}
+		if previous, ok := findSession(sessions, target.Repo, issue.Number); ok {
+			a.emitSessionTransition(previous.Status, result, "issue_execution")
 		}
 		sessions = upsertSession(sessions, result)
 		if err := a.state.SaveSessions(sessions); err != nil {
@@ -1159,7 +1267,7 @@ func (a *App) maintainOpenPullRequest(ctx context.Context, session *state.Sessio
 		},
 		Tagline: "Success is where preparation and opportunity meet.",
 	})
-	return ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body)
+	return a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "validation", "pr_maintenance")
 }
 
 func (a *App) dispatchConflictResolution(ctx context.Context, session *state.Session, pr ghcli.PullRequest) error {
@@ -1191,7 +1299,7 @@ func (a *App) dispatchConflictResolution(ctx context.Context, session *state.Ses
 		},
 		Tagline: "Keep the spec intact while the history moves.",
 	})
-	if commentErr := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); commentErr != nil {
+	if commentErr := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "progress", "conflict_resolution"); commentErr != nil {
 		a.state.AppendDaemonLog("pr conflict comment failed repo=%s issue=%d pr=%d err=%v", session.Repo, session.IssueNumber, pr.Number, commentErr)
 	}
 
@@ -1439,7 +1547,7 @@ func (a *App) processGitHubCleanupRequests(ctx context.Context, sessions []state
 				},
 				Tagline: "Trust, but verify.",
 			})
-			if err := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); err != nil {
+			if err := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "cleanup", "github_comment"); err != nil {
 				a.state.AppendDaemonLog("cleanup no-op comment failed repo=%s issue=%d comment=%d err=%v", session.Repo, session.IssueNumber, comment.ID, err)
 				session.LastError = err.Error()
 				session.UpdatedAt = a.clock().Format(time.RFC3339)
@@ -1449,7 +1557,7 @@ func (a *App) processGitHubCleanupRequests(ctx context.Context, sessions []state
 
 		cleanupErr := a.cleanupRunningSession(ctx, session, "comment")
 		body := cleanupResultComment(*session, cleanupErr)
-		if err := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); err != nil {
+		if err := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "cleanup", "github_comment"); err != nil {
 			a.state.AppendDaemonLog("cleanup result comment failed repo=%s issue=%d comment=%d err=%v", session.Repo, session.IssueNumber, comment.ID, err)
 			session.LastError = err.Error()
 			session.UpdatedAt = a.clock().Format(time.RFC3339)
@@ -1482,6 +1590,7 @@ func (a *App) processGitHubResumeRequests(ctx context.Context, sessions []state.
 						labelRemovalFailed = true
 						break
 					}
+					a.emitLabelSyncEvent(nil, []string{label})
 				}
 			}
 			if labelRemovalFailed {
@@ -1742,6 +1851,7 @@ func (a *App) RedispatchSession(ctx context.Context, repoSlug string, issue int,
 	if err := a.state.SaveSessions(sessions); err != nil {
 		return err
 	}
+	a.emitSessionTransition("", session, source)
 	a.syncSessionIssueLabelsBestEffort(ctx, session, nil)
 
 	if source == "cli" {
@@ -1802,6 +1912,7 @@ func (a *App) cleanupRunningSession(ctx context.Context, session *state.Session,
 	if session.Status != state.SessionStatusRunning {
 		return nil
 	}
+	previousStatus := session.Status
 
 	a.cancelRunningSession(session.Repo, session.IssueNumber)
 
@@ -1817,11 +1928,13 @@ func (a *App) cleanupRunningSession(ctx context.Context, session *state.Session,
 	if err != nil {
 		session.CleanupError = err.Error()
 		session.LastError = fmt.Sprintf("cleanup requested via %s; artifact cleanup failed: %s", source, err)
+		a.emitSessionTransition(previousStatus, *session, "cleanup_"+source)
 		a.state.AppendDaemonLog("running session cleanup failed repo=%s issue=%d source=%s branch=%s worktree=%s err=%v", session.Repo, session.IssueNumber, source, session.Branch, session.WorktreePath, err)
 		return nil
 	}
 	session.CleanupCompletedAt = now
 	session.CleanupError = ""
+	a.emitSessionTransition(previousStatus, *session, "cleanup_"+source)
 	a.state.AppendDaemonLog("running session cleanup complete repo=%s issue=%d source=%s branch=%s worktree=%s", session.Repo, session.IssueNumber, source, session.Branch, session.WorktreePath)
 	return nil
 }
@@ -1888,9 +2001,11 @@ func (a *App) resumeBlockedSession(ctx context.Context, session *state.Session, 
 		return nil
 	}
 	previousStage := session.BlockedStage
+	previousStatus := session.Status
 	session.Status = state.SessionStatusResuming
 	session.LastResumeSource = source
 	session.UpdatedAt = a.clock().Format(time.RFC3339)
+	a.emitSessionTransition(previousStatus, *session, source)
 
 	if err := a.preflightResume(ctx, *session); err != nil {
 		blocked := classifyBlockedReason(session.BlockedStage, session.BlockedReason.Operation, err)
@@ -1926,7 +2041,9 @@ func (a *App) resumeBlockedSession(ctx context.Context, session *state.Session, 
 	}
 
 	previousKind := session.BlockedReason.Kind
+	previousStatus = session.Status
 	clearBlockedState(session, a.clock(), source)
+	a.emitSessionTransition(previousStatus, *session, source)
 	if source == "cli" {
 		a.commentOnIssueBestEffort(ctx, session.Repo, session.IssueNumber, localResumeSuccessComment(*session, previousStage, previousKind), "local resume result")
 		return nil
@@ -1943,7 +2060,7 @@ func (a *App) resumeBlockedSession(ctx context.Context, session *state.Session, 
 		},
 		Tagline: "Back on the wire.",
 	})
-	return ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body)
+	return a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "resume", source)
 }
 
 func (a *App) preflightResume(ctx context.Context, session state.Session) error {
@@ -2087,7 +2204,7 @@ func (a *App) cleanupInactiveBlockedSessions(ctx context.Context, sessions []sta
 		a.state.AppendDaemonLog("blocked session inactivity timeout reached repo=%s issue=%d branch=%s timeout=%s", session.Repo, session.IssueNumber, session.Branch, timeout)
 		cleanupErr := a.cleanupBlockedSessionForInactivity(ctx, session, timeout)
 		body := inactiveBlockedCleanupComment(*session, timeout, cleanupErr)
-		if err := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); err != nil {
+		if err := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "cleanup", "blocked_inactivity_timeout"); err != nil {
 			session.LastError = err.Error()
 			session.UpdatedAt = a.clock().Format(time.RFC3339)
 			a.state.AppendDaemonLog("blocked session inactivity comment failed repo=%s issue=%d branch=%s err=%v", session.Repo, session.IssueNumber, session.Branch, err)
@@ -2125,6 +2242,7 @@ func (a *App) blockedSessionExceededInactivityTimeout(ctx context.Context, sessi
 func (a *App) cleanupBlockedSessionForInactivity(ctx context.Context, session *state.Session, timeout time.Duration) error {
 	now := a.clock().Format(time.RFC3339)
 	session.LastCleanupSource = "blocked_inactivity_timeout"
+	previousStatus := session.Status
 	if err := worktree.CleanupIssueArtifacts(ctx, a.env.Runner, session.RepoPath, session.WorktreePath, session.Branch); err != nil {
 		session.CleanupError = err.Error()
 		session.LastError = fmt.Sprintf("blocked session exceeded inactivity timeout (%s) but cleanup failed: %s", timeout, err)
@@ -2147,6 +2265,7 @@ func (a *App) cleanupBlockedSessionForInactivity(ctx context.Context, session *s
 	session.EndedAt = now
 	session.UpdatedAt = now
 	session.LastError = fmt.Sprintf("blocked session cleaned up after %s of inactivity", timeout)
+	a.emitSessionTransition(previousStatus, *session, "blocked_inactivity_timeout")
 	a.state.AppendDaemonLog("blocked session inactivity cleanup complete repo=%s issue=%d branch=%s timeout=%s", session.Repo, session.IssueNumber, session.Branch, timeout)
 	return nil
 }
@@ -2506,9 +2625,11 @@ func blockedIssueSessionForDispatchFailure(target state.WatchTarget, issue ghcli
 }
 
 func (a *App) recordSessionFailure(session *state.Session, stage string, operation string, err error) {
+	previous := session.Status
 	markSessionBlocked(session, stage, classifyBlockedReason(stage, operation, err), a.clock())
 	session.LastError = err.Error()
 	session.UpdatedAt = a.clock().Format(time.RFC3339)
+	a.emitSessionTransition(previous, *session, stage)
 }
 
 func classifyBlockedReason(stage string, operation string, err error) state.BlockedReason {
@@ -2587,7 +2708,12 @@ func (a *App) syncIssueManagedLabels(ctx context.Context, repo string, issueNumb
 	if err != nil {
 		return err
 	}
-	return ghcli.SyncIssueLabels(ctx, a.env.Runner, repo, issueNumber, details.Labels, desired, managedIssueLabels)
+	toAdd, toRemove := ghcli.PlanIssueLabelSync(details.Labels, desired, managedIssueLabels)
+	if err := ghcli.SyncIssueLabels(ctx, a.env.Runner, repo, issueNumber, details.Labels, desired, managedIssueLabels); err != nil {
+		return err
+	}
+	a.emitLabelSyncEvent(toAdd, toRemove)
+	return nil
 }
 
 func (a *App) ensureRepositoryLabelsProvisioned(ctx context.Context, repo string) error {
@@ -2926,7 +3052,7 @@ func localResumeNoopComment() string {
 }
 
 func (a *App) commentOnIssueBestEffort(ctx context.Context, repo string, issue int, body string, purpose string) {
-	if err := ghcli.CommentOnIssue(ctx, a.env.Runner, repo, issue, body); err != nil {
+	if err := a.commentOnIssue(ctx, repo, issue, body, "progress", purpose); err != nil {
 		a.state.AppendDaemonLog("%s comment failed repo=%s issue=%d err=%v", purpose, repo, issue, err)
 	}
 }
@@ -2970,7 +3096,7 @@ func (a *App) commentDispatchFailure(ctx context.Context, previous state.Session
 		WorktreePath: session.WorktreePath,
 		NextStep:     dispatchFailureNextStep(*session, stage),
 	})
-	if err := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); err != nil {
+	if err := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "dispatch_failure", stage); err != nil {
 		a.state.AppendDaemonLog("dispatch/startup failure comment failed repo=%s issue=%d stage=%s err=%v", session.Repo, session.IssueNumber, stage, err)
 		return
 	}
@@ -3018,7 +3144,7 @@ func (a *App) commentResumeFailure(ctx context.Context, session *state.Session, 
 		},
 		Tagline: "No mystery errors left behind.",
 	})
-	if err := ghcli.CommentOnIssue(ctx, a.env.Runner, session.Repo, session.IssueNumber, body); err != nil {
+	if err := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "resume_failure", previousStage); err != nil {
 		return err
 	}
 	session.LastResumeFailureFingerprint = fingerprint

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -3,8 +3,12 @@ package app
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,8 +20,70 @@ import (
 	"github.com/nicobistolfi/vigilante/internal/repo"
 	"github.com/nicobistolfi/vigilante/internal/skill"
 	"github.com/nicobistolfi/vigilante/internal/state"
+	"github.com/nicobistolfi/vigilante/internal/telemetry"
 	"github.com/nicobistolfi/vigilante/internal/testutil"
 )
+
+type analyticsBatchCapture struct {
+	events []capturedAnalyticsEvent
+}
+
+type capturedAnalyticsEvent struct {
+	Event      string         `json:"event"`
+	Properties map[string]any `json:"properties"`
+}
+
+func setupTelemetryCapture(t *testing.T) (*analyticsBatchCapture, func() error) {
+	t.Helper()
+
+	capture := &analyticsBatchCapture{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read telemetry request: %v", err)
+		}
+		var payload struct {
+			Messages []json.RawMessage `json:"batch"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("parse telemetry batch: %v", err)
+		}
+		capture.events = capture.events[:0]
+		for _, raw := range payload.Messages {
+			var event capturedAnalyticsEvent
+			if err := json.Unmarshal(raw, &event); err != nil {
+				t.Fatalf("parse telemetry event: %v", err)
+			}
+			capture.events = append(capture.events, event)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	manager, err := telemetry.Setup(context.Background(), telemetry.SetupConfig{
+		BuildInfo: telemetry.BuildInfo{
+			Version:           "1.2.3",
+			Distro:            "direct",
+			TelemetryEndpoint: server.URL,
+			TelemetryToken:    "token",
+		},
+		StateRoot: t.TempDir(),
+		EnvLookup: func(string) string { return "" },
+	})
+	if err != nil {
+		t.Fatalf("setup telemetry: %v", err)
+	}
+	telemetry.SetDefault(manager)
+	t.Cleanup(func() {
+		telemetry.SetDefault(nil)
+	})
+	return capture, func() error {
+		err := manager.Shutdown(context.Background())
+		telemetry.SetDefault(nil)
+		return err
+	}
+}
 
 func TestRunSupportsTopLevelHelpFlags(t *testing.T) {
 	for _, arg := range []string{"--help", "-h"} {
@@ -116,6 +182,7 @@ func TestDesiredSessionLabels(t *testing.T) {
 }
 
 func TestSyncIssueManagedLabelsQueued(t *testing.T) {
+	capture, shutdownTelemetry := setupTelemetryCapture(t)
 	app := New()
 	app.stdout = testutil.IODiscard{}
 	app.stderr = testutil.IODiscard{}
@@ -129,6 +196,103 @@ func TestSyncIssueManagedLabelsQueued(t *testing.T) {
 
 	if err := app.syncIssueManagedLabels(context.Background(), "owner/repo", 7, []string{labelQueued}); err != nil {
 		t.Fatal(err)
+	}
+	if err := shutdownTelemetry(); err != nil {
+		t.Fatal(err)
+	}
+	if len(capture.events) != 1 {
+		t.Fatalf("expected 1 telemetry event, got %d", len(capture.events))
+	}
+	if got, want := capture.events[0].Event, "github_issue_labels_synced"; got != want {
+		t.Fatalf("event = %q, want %q", got, want)
+	}
+	if got, want := capture.events[0].Properties["add_count"], float64(1); got != want {
+		t.Fatalf("add_count = %v, want %v", got, want)
+	}
+	if got, want := capture.events[0].Properties["remove_count"], float64(1); got != want {
+		t.Fatalf("remove_count = %v, want %v", got, want)
+	}
+}
+
+func TestSyncIssueManagedLabelsNoopDoesNotEmitTelemetry(t *testing.T) {
+	capture, shutdownTelemetry := setupTelemetryCapture(t)
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:blocked"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
+			"gh api repos/owner/repo/issues/7":            `{"labels":[{"name":"vigilante:queued"}]}`,
+		},
+	}
+
+	if err := app.syncIssueManagedLabels(context.Background(), "owner/repo", 7, []string{labelQueued}); err != nil {
+		t.Fatal(err)
+	}
+	if err := shutdownTelemetry(); err != nil {
+		t.Fatal(err)
+	}
+	if len(capture.events) != 0 {
+		t.Fatalf("expected no telemetry events, got %#v", capture.events)
+	}
+}
+
+func TestCommentOnIssueEmitsTypedTelemetry(t *testing.T) {
+	capture, shutdownTelemetry := setupTelemetryCapture(t)
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh issue comment --repo owner/repo 7 --body body": "ok",
+		},
+	}
+
+	if err := app.commentOnIssue(context.Background(), "owner/repo", 7, "body", "dispatch_failure", "dispatch"); err != nil {
+		t.Fatal(err)
+	}
+	if err := shutdownTelemetry(); err != nil {
+		t.Fatal(err)
+	}
+	if len(capture.events) != 1 {
+		t.Fatalf("expected 1 telemetry event, got %d", len(capture.events))
+	}
+	if got, want := capture.events[0].Event, "github_issue_comment_emitted"; got != want {
+		t.Fatalf("event = %q, want %q", got, want)
+	}
+	if got, want := capture.events[0].Properties["comment_type"], "dispatch_failure"; got != want {
+		t.Fatalf("comment_type = %v, want %q", got, want)
+	}
+}
+
+func TestRecordSessionFailureEmitsSessionTransitionTelemetry(t *testing.T) {
+	capture, shutdownTelemetry := setupTelemetryCapture(t)
+	app := New()
+	session := &state.Session{
+		Repo:        "owner/repo",
+		IssueNumber: 7,
+		Provider:    "codex",
+		Status:      state.SessionStatusRunning,
+	}
+
+	app.recordSessionFailure(session, "issue_execution", "git worktree add", errors.New("boom"))
+	if err := shutdownTelemetry(); err != nil {
+		t.Fatal(err)
+	}
+	if len(capture.events) != 1 {
+		t.Fatalf("expected 1 telemetry event, got %d", len(capture.events))
+	}
+	if got, want := capture.events[0].Event, "issue_session_transition"; got != want {
+		t.Fatalf("event = %q, want %q", got, want)
+	}
+	if got, want := capture.events[0].Properties["previous_status"], "running"; got != want {
+		t.Fatalf("previous_status = %v, want %q", got, want)
+	}
+	if got, want := capture.events[0].Properties["status"], "blocked"; got != want {
+		t.Fatalf("status = %v, want %q", got, want)
+	}
+	if got, want := capture.events[0].Properties["transition"], "blocked"; got != want {
+		t.Fatalf("transition = %v, want %q", got, want)
 	}
 }
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -319,6 +319,23 @@ func CreateRepositoryLabel(ctx context.Context, runner environment.Runner, repo 
 }
 
 func SyncIssueLabels(ctx context.Context, runner environment.Runner, repo string, number int, current []Label, desired []string, managed []string) error {
+	toAdd, toRemove := PlanIssueLabelSync(current, desired, managed)
+	if len(toAdd) == 0 && len(toRemove) == 0 {
+		return nil
+	}
+
+	args := []string{"issue", "edit", "--repo", repo, fmt.Sprintf("%d", number)}
+	for _, label := range toAdd {
+		args = append(args, "--add-label", label)
+	}
+	for _, label := range toRemove {
+		args = append(args, "--remove-label", label)
+	}
+	_, err := runner.Run(ctx, "", "gh", args...)
+	return err
+}
+
+func PlanIssueLabelSync(current []Label, desired []string, managed []string) ([]string, []string) {
 	managedSet := make(map[string]struct{}, len(managed))
 	for _, label := range managed {
 		label = strings.TrimSpace(label)
@@ -346,7 +363,7 @@ func SyncIssueLabels(ctx context.Context, runner environment.Runner, repo string
 		desiredSet[label] = struct{}{}
 	}
 
-	var toAdd []string
+	toAdd := make([]string, 0, len(desiredSet))
 	for label := range desiredSet {
 		if _, ok := currentSet[label]; ok {
 			continue
@@ -354,7 +371,7 @@ func SyncIssueLabels(ctx context.Context, runner environment.Runner, repo string
 		toAdd = append(toAdd, label)
 	}
 
-	var toRemove []string
+	toRemove := make([]string, 0, len(managedSet))
 	for label := range managedSet {
 		if _, ok := currentSet[label]; !ok {
 			continue
@@ -367,19 +384,7 @@ func SyncIssueLabels(ctx context.Context, runner environment.Runner, repo string
 
 	sort.Strings(toAdd)
 	sort.Strings(toRemove)
-	if len(toAdd) == 0 && len(toRemove) == 0 {
-		return nil
-	}
-
-	args := []string{"issue", "edit", "--repo", repo, fmt.Sprintf("%d", number)}
-	for _, label := range toAdd {
-		args = append(args, "--add-label", label)
-	}
-	for _, label := range toRemove {
-		args = append(args, "--remove-label", label)
-	}
-	_, err := runner.Run(ctx, "", "gh", args...)
-	return err
+	return toAdd, toRemove
 }
 
 func HasAnyLabel(labels []Label, wanted ...string) bool {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -58,6 +58,11 @@ type Manager struct {
 	anonID    string
 }
 
+var (
+	defaultManagerMu sync.RWMutex
+	defaultManager   *Manager
+)
+
 type localState struct {
 	AnonymousID string `json:"anonymous_id"`
 }
@@ -395,6 +400,12 @@ func disabledManager() *Manager {
 	return &Manager{}
 }
 
+func SetDefault(manager *Manager) {
+	defaultManagerMu.Lock()
+	defer defaultManagerMu.Unlock()
+	defaultManager = manager
+}
+
 func ShutdownTimeout() time.Duration {
 	return shutdownTimeout
 }
@@ -422,6 +433,32 @@ func (m *Manager) enqueueAnalytics(event analyticsEvent) {
 	m.events = append(m.events, event)
 }
 
+func CaptureWorkflowEvent(event string, properties map[string]any) {
+	defaultManagerMu.RLock()
+	manager := defaultManager
+	defaultManagerMu.RUnlock()
+	if manager == nil {
+		return
+	}
+	manager.CaptureWorkflowEvent(event, properties)
+}
+
+func (m *Manager) CaptureWorkflowEvent(event string, properties map[string]any) {
+	if m == nil || strings.TrimSpace(event) == "" {
+		return
+	}
+
+	startedAt := time.Now().UTC()
+	m.enqueueAnalytics(analyticsEvent{
+		Type:       "capture",
+		UUID:       uuid.NewString(),
+		Timestamp:  startedAt,
+		DistinctID: m.anonID,
+		Event:      strings.TrimSpace(event),
+		Properties: m.workflowProperties(properties),
+	})
+}
+
 func (m *Manager) commandProperties(commandName string) map[string]any {
 	commandGroup := commandGroup(commandName)
 	return map[string]any{
@@ -445,6 +482,25 @@ func (m *Manager) commandCompletedProperties(commandName string, exitCode int, d
 	properties["result"] = commandResult(exitCode)
 	properties["success"] = exitCode == 0
 	return properties
+}
+
+func (m *Manager) workflowProperties(properties map[string]any) map[string]any {
+	out := map[string]any{
+		"$lib":          "vigilante-cli",
+		"$lib_version":  m.version,
+		"app_version":   m.version,
+		"distro":        m.distro,
+		"platform_arch": runtime.GOARCH,
+		"platform_os":   runtime.GOOS,
+	}
+	for key, value := range properties {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out[key] = value
+	}
+	return out
 }
 
 func commandGroup(commandName string) string {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -347,6 +348,53 @@ func TestStartCommandAnalyticsTaxonomyForGroupedCommands(t *testing.T) {
 	}
 	if got, want := events[1].Properties["result"], "success"; got != want {
 		t.Fatalf("result = %v, want %q", got, want)
+	}
+}
+
+func TestCaptureWorkflowEventUsesDefaultManagerAndBoundedProperties(t *testing.T) {
+	t.Parallel()
+
+	analytics := &captureAnalyticsExporter{}
+	manager := &Manager{
+		analytics: analytics,
+		version:   "1.2.3",
+		distro:    "direct",
+		anonID:    "anon-123",
+	}
+
+	SetDefault(manager)
+	t.Cleanup(func() {
+		SetDefault(nil)
+	})
+
+	CaptureWorkflowEvent("issue_session_transition", map[string]any{
+		"feature_area": "issue_session",
+		"status":       "blocked",
+		"source":       "dispatch",
+	})
+
+	if err := manager.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+
+	events := analytics.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 analytics event, got %d", len(events))
+	}
+	if got, want := events[0].Event, "issue_session_transition"; got != want {
+		t.Fatalf("event = %q, want %q", got, want)
+	}
+	if got, want := events[0].Properties["feature_area"], "issue_session"; got != want {
+		t.Fatalf("feature_area = %v, want %q", got, want)
+	}
+	if got, want := events[0].Properties["status"], "blocked"; got != want {
+		t.Fatalf("status = %v, want %q", got, want)
+	}
+	if got, want := events[0].Properties["app_version"], "1.2.3"; got != want {
+		t.Fatalf("app_version = %v, want %q", got, want)
+	}
+	if got, want := events[0].Properties["platform_os"], runtime.GOOS; got != want {
+		t.Fatalf("platform_os = %v, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a shared anonymous workflow-event capture path on top of the existing telemetry manager
- emit bounded analytics for daemon execution, session transitions, typed GitHub issue comments, and effective label changes
- add coverage proving no-op label syncs stay silent and the new workflow events exclude free-form content

## Validation
- go test ./...

Closes #218
