### PR TITLE
Add proxied CLI tool subcommands for telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,24 @@ vigilante completion bash > ~/.local/share/bash-completion/completions/vigilante
 vigilante completion fish > ~/.config/fish/completions/vigilante.fish
 ```
 
+### Tool proxy commands
+
+Vigilante can proxy a bounded set of external CLIs while emitting privacy-aware telemetry about only the tool and sanitized command shape:
+
+- `vigilante gh ...`
+- `vigilante git ...`
+- `vigilante docker ...`
+
+Examples:
+
+```sh
+vigilante gh repo view aliengiraffe/vigilante
+vigilante git status --short
+vigilante docker compose ps
+```
+
+The proxy preserves the underlying tool's stdout, stderr, and exit status. Telemetry intentionally avoids raw positional arguments, flag values, repo slugs, tokens, paths, prompts, and free-form text.
+
 ## Installation
 
 Install `vigilante` from the Homebrew tap:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -70,6 +71,7 @@ var supportedCompletionShells = []string{"bash", "fish", "zsh"}
 var errHelpHandled = errors.New("help handled")
 
 type App struct {
+	stdin  io.Reader
 	stdout io.Writer
 	stderr io.Writer
 	state  *state.Store
@@ -82,6 +84,7 @@ type App struct {
 	cancels                   map[string]context.CancelFunc
 	repoLabelProvisioningMu   sync.Mutex
 	repoLabelsProvisionedOnce map[string]bool
+	proxyExec                 func(context.Context, io.Reader, io.Writer, io.Writer, string, ...string) (int, error)
 }
 
 type stringListFlag []string
@@ -102,12 +105,14 @@ func (f *stringListFlag) Set(value string) error {
 func New() *App {
 	store := state.NewStore()
 	return &App{
+		stdin:                     os.Stdin,
 		stdout:                    os.Stdout,
 		stderr:                    os.Stderr,
 		state:                     store,
 		clock:                     time.Now().UTC,
 		cancels:                   make(map[string]context.CancelFunc),
 		repoLabelsProvisionedOnce: make(map[string]bool),
+		proxyExec:                 runProxyBinary,
 		env: &environment.Environment{
 			OS: runtime.GOOS,
 			Runner: environment.LoggingRunner{
@@ -187,6 +192,10 @@ func (a *App) Run(ctx context.Context, args []string) int {
 	}
 
 	if err := a.runCommand(ctx, args); err != nil {
+		var exitErr commandExitError
+		if errors.As(err, &exitErr) {
+			return exitErr.code
+		}
 		fmt.Fprintln(a.stderr, "error:", err)
 		return 1
 	}
@@ -198,6 +207,9 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 	if len(args) == 1 && isHelpToken(args[0]) {
 		a.printUsage(a.stdout)
 		return nil
+	}
+	if isSupportedProxyTool(args[0]) {
+		return a.runProxyCommand(ctx, args[0], args[1:])
 	}
 
 	switch args[0] {
@@ -299,6 +311,49 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 	default:
 		return fmt.Errorf("unknown command %q", args[0])
 	}
+}
+
+type commandExitError struct {
+	code int
+}
+
+func (e commandExitError) Error() string {
+	return fmt.Sprintf("command exited with status %d", e.code)
+}
+
+func isSupportedProxyTool(name string) bool {
+	switch strings.TrimSpace(name) {
+	case "gh", "git", "docker":
+		return true
+	default:
+		return false
+	}
+}
+
+func (a *App) runProxyCommand(ctx context.Context, tool string, args []string) error {
+	exitCode, err := a.proxyExec(ctx, a.stdin, a.stdout, a.stderr, tool, args...)
+	if err != nil {
+		return err
+	}
+	if exitCode != 0 {
+		return commandExitError{code: exitCode}
+	}
+	return nil
+}
+
+func runProxyBinary(ctx context.Context, stdin io.Reader, stdout io.Writer, stderr io.Writer, name string, args ...string) (int, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return exitErr.ExitCode(), nil
+		}
+		return 0, err
+	}
+	return 0, nil
 }
 
 func (a *App) runResumeCommand(ctx context.Context, args []string) error {
@@ -3559,6 +3614,7 @@ func (a *App) printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  vigilante service restart")
 	fmt.Fprintln(w, "  vigilante daemon run [--once] [--interval duration]")
 	fmt.Fprintln(w, "  vigilante completion <bash|fish|zsh>")
+	fmt.Fprintln(w, "  vigilante <gh|git|docker> ...")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Use \"vigilante <command> --help\" for command-specific usage.")
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -107,6 +107,7 @@ func TestRunSupportsTopLevelHelpFlags(t *testing.T) {
 				"vigilante status",
 				"vigilante service restart",
 				"vigilante completion <bash|fish|zsh>",
+				"vigilante <gh|git|docker> ...",
 				`Use "vigilante <command> --help" for command-specific usage.`,
 			} {
 				if !strings.Contains(stdout.String(), want) {
@@ -114,6 +115,53 @@ func TestRunSupportsTopLevelHelpFlags(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestRunProxiesSupportedToolCommands(t *testing.T) {
+	app := New()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = &stderr
+	var gotName string
+	var gotArgs []string
+	app.proxyExec = func(_ context.Context, _ io.Reader, out io.Writer, errOut io.Writer, name string, args ...string) (int, error) {
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		fmt.Fprint(out, "proxied stdout")
+		fmt.Fprint(errOut, "proxied stderr")
+		return 0, nil
+	}
+
+	exitCode := app.Run(context.Background(), []string{"gh", "repo", "view", "owner/repo"})
+	if exitCode != 0 {
+		t.Fatalf("expected success exit code, got %d", exitCode)
+	}
+	if gotName != "gh" {
+		t.Fatalf("proxy tool = %q, want %q", gotName, "gh")
+	}
+	if got, want := strings.Join(gotArgs, " "), "repo view owner/repo"; got != want {
+		t.Fatalf("proxy args = %q, want %q", got, want)
+	}
+	if got, want := stdout.String(), "proxied stdout"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	if got, want := stderr.String(), "proxied stderr"; got != want {
+		t.Fatalf("stderr = %q, want %q", got, want)
+	}
+}
+
+func TestRunReturnsUnderlyingProxyExitCode(t *testing.T) {
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.proxyExec = func(context.Context, io.Reader, io.Writer, io.Writer, string, ...string) (int, error) {
+		return 17, nil
+	}
+
+	if got := app.Run(context.Background(), []string{"git", "status"}); got != 17 {
+		t.Fatalf("Run() = %d, want %d", got, 17)
 	}
 }
 

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -175,7 +175,7 @@ func BuildIssuePromptForRuntime(runtime string, target state.WatchTarget, issue 
 		fmt.Sprintf("Issue URL: %s", issue.URL),
 		fmt.Sprintf("Worktree path: %s", session.WorktreePath),
 		fmt.Sprintf("Branch: %s", session.Branch),
-		"Use `gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch, open a pull request, and report any execution failure back to the issue.",
+		"Use `vigilante gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch with `vigilante git push`, open a pull request with `vigilante gh pr create`, and report any execution failure back to the issue.",
 		fmt.Sprintf("When you open the pull request, the final PR body must include `Closes #%d` even if you write a custom summary or the summary is otherwise minimal.", issue.Number),
 		fmt.Sprintf("For the coding-agent start comment, use `## 🕹️ Coding Agent Launched: %s` instead of a generic session-start title.", displayProviderName(session.Provider)),
 		"Use the same GitHub comment structure for every non-terminal milestone comment: a short header with the current stage and optional emoji, a 10-cell progress bar with percentage, an `ETA: ~N minutes` line, 1-3 concise bullets covering what just happened and what is next, and an optional short playful quote or tagline.",
@@ -197,7 +197,7 @@ func BuildIssuePromptForRuntime(runtime string, target state.WatchTarget, issue 
 		lines = append(lines,
 			fmt.Sprintf("Detected monorepo stack: %s", normalizedMonorepoStack(target)),
 			fmt.Sprintf("Monorepo execution context JSON: %s", monorepoExecutionContextJSON(target, selectedSkill)),
-			fmt.Sprintf("When local services are required, use the `%s` skill instead of inventing ad hoc compose logic.", DockerComposeLaunch),
+			fmt.Sprintf("When local services are required, use the `%s` skill instead of inventing ad hoc `vigilante docker compose` logic.", DockerComposeLaunch),
 		)
 	}
 	return strings.Join(lines, "\n")
@@ -450,7 +450,7 @@ func BuildConflictResolutionPromptForRuntime(runtime string, target state.WatchT
 		"Conflict-resolution workflow: rebase the branch onto the latest base branch if that has not already started; if a rebase is already in progress, continue it from the current stopped commit.",
 		"Work through the rebase commit by commit. Preserve the meaning of each existing issue-branch commit and keep the original issue specification authoritative.",
 		"Do not silently discard commits or issue-specific behavior just to get a clean merge. Prefer the smallest safe conflict fix.",
-		"Use `gh issue comment` for progress and failures, rerun `go test ./...` after conflict resolution succeeds, and push the updated branch when finished.",
+		"Use `vigilante gh issue comment` for progress and failures, rerun `go test ./...` after conflict resolution succeeds, and push the updated branch with `vigilante git push` when finished.",
 		"If you cannot preserve the issue intent safely, leave a concise GitHub blocker comment and exit with a non-zero status.",
 	)
 	if strings.TrimSpace(session.BranchDiffSummary) != "" {
@@ -493,7 +493,7 @@ func BuildCIRemediationPromptForRuntime(runtime string, target state.WatchTarget
 	}
 	lines = append(lines,
 		"Investigate the failing CI checks, reproduce the problem locally when practical, and make the minimal code or configuration fix needed to get the PR green again.",
-		"Use `gh issue comment` for progress updates and blockers, push any successful fix to the existing PR branch, and do not open a new pull request.",
+		"Use `vigilante gh issue comment` for progress updates and blockers, push any successful fix to the existing PR branch with `vigilante git push`, and do not open a new pull request.",
 		"If GitHub exposes a failing check summary or log URL during your investigation, use it. At minimum, work from the failing check identifiers listed above.",
 		"If you cannot fix the failure safely, leave a concise GitHub comment explaining the blocker and exit with a non-zero status so Vigilante can stop and hand off to a human.",
 		"Keep the changes minimal and focused on restoring CI for the existing pull request.",

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -134,7 +134,7 @@ func TestBuildIssuePrompt(t *testing.T) {
 	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
 	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
 	prompt := BuildIssuePrompt(target, issue, session)
-	for _, text := range []string{"Use the `vigilante-issue-implementation` skill", "Detected repo shape: traditional", `Repo process context JSON: {"shape":"traditional"}`, "Selected issue implementation skill: vigilante-issue-implementation", "Issue: #12 - Fix bug", "Worktree path: /tmp/worktree", "gh issue comment", "implementation plan", "open a pull request", "Closes #12", "Coding Agent Launched: Codex", "10-cell progress bar", "ETA: ~N minutes"} {
+	for _, text := range []string{"Use the `vigilante-issue-implementation` skill", "Detected repo shape: traditional", `Repo process context JSON: {"shape":"traditional"}`, "Selected issue implementation skill: vigilante-issue-implementation", "Issue: #12 - Fix bug", "Worktree path: /tmp/worktree", "vigilante gh issue comment", "vigilante git push", "vigilante gh pr create", "Closes #12", "Coding Agent Launched: Codex", "10-cell progress bar", "ETA: ~N minutes"} {
 		if !strings.Contains(prompt, text) {
 			t.Fatalf("prompt missing %q: %s", text, prompt)
 		}
@@ -704,7 +704,7 @@ func TestLocalServiceDependenciesSkillCoversStructuredOutputAndFailureModes(t *t
 	text := string(body)
 	for _, snippet := range []string{
 		"Prefer repository-provided service startup mechanisms",
-		"repository-owned `docker compose` or `docker-compose` files before generating anything new",
+		"repository-owned `vigilante docker compose` or `docker-compose` flows before generating anything new",
 		"Docker Compose is an allowed fallback, not the defining abstraction.",
 		"`status`: `ready`, `not_needed`, or `failed`",
 		"`mechanism`: `repo_native`, `repo_compose`, `repo_script`, `repo_task_runner`, or `generated_fallback`",

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -243,6 +243,13 @@ func CommandName(args []string) string {
 	if isHelpToken(args[0]) || strings.HasPrefix(args[0], "-") {
 		return "help"
 	}
+	if isProxyTool(args[0]) {
+		commandPath := proxyCommandPath(args[0], args[1:])
+		if commandPath == "" {
+			return args[0]
+		}
+		return args[0] + " " + commandPath
+	}
 
 	command := args[0]
 	if len(args) > 1 && expandsCommandGroup(command) && !strings.HasPrefix(args[1], "-") && !isHelpToken(args[1]) {
@@ -525,11 +532,115 @@ func commandFeatureArea(commandGroup string) string {
 		return "cleanup"
 	case "resume", "redispatch":
 		return "issue_session"
+	case "gh", "git", "docker":
+		return "tool_proxy"
 	case "completion", "help", "root":
 		return "operator_cli"
 	default:
 		return "operator_cli"
 	}
+}
+
+func isProxyTool(command string) bool {
+	switch strings.TrimSpace(command) {
+	case "gh", "git", "docker":
+		return true
+	default:
+		return false
+	}
+}
+
+func proxyCommandPath(tool string, args []string) string {
+	command, rest := firstProxyCommandToken(tool, args)
+	if command == "" {
+		return ""
+	}
+	if command == "help" {
+		return command
+	}
+	if subcommand, ok := nextProxySubcommand(tool, command, rest); ok {
+		return command + " " + subcommand
+	}
+	return command
+}
+
+func firstProxyCommandToken(tool string, args []string) (string, []string) {
+	for i := 0; i < len(args); i++ {
+		token := strings.TrimSpace(args[i])
+		if token == "" {
+			continue
+		}
+		if isHelpToken(token) {
+			return "help", nil
+		}
+		if strings.HasPrefix(token, "-") {
+			if proxyFlagTakesValue(tool, token) && i+1 < len(args) && !strings.HasPrefix(strings.TrimSpace(args[i+1]), "-") {
+				i++
+			}
+			continue
+		}
+		return token, args[i+1:]
+	}
+	return "", nil
+}
+
+func nextProxySubcommand(tool string, command string, args []string) (string, bool) {
+	if !proxyCommandExpands(tool, command) {
+		return "", false
+	}
+	for _, raw := range args {
+		token := strings.TrimSpace(raw)
+		if token == "" || strings.HasPrefix(token, "-") {
+			continue
+		}
+		if isHelpToken(token) {
+			return "help", true
+		}
+		return token, true
+	}
+	return "", false
+}
+
+func proxyCommandExpands(tool string, command string) bool {
+	switch tool {
+	case "gh":
+		switch command {
+		case "alias", "auth", "cache", "codespace", "config", "extension", "gist", "gpg-key", "issue", "label", "org", "pr", "project", "release", "repo", "ruleset", "run", "search", "secret", "ssh-key", "variable", "workflow":
+			return true
+		}
+	case "git":
+		switch command {
+		case "remote", "stash", "submodule", "worktree":
+			return true
+		}
+	case "docker":
+		return command == "compose"
+	}
+	return false
+}
+
+func proxyFlagTakesValue(tool string, flag string) bool {
+	if strings.Contains(flag, "=") {
+		return false
+	}
+	switch tool {
+	case "gh":
+		switch flag {
+		case "-R", "--repo", "--hostname":
+			return true
+		}
+	case "git":
+		switch flag {
+		case "-C", "-c", "--git-dir", "--work-tree", "--namespace", "--super-prefix", "--exec-path", "--config-env":
+			return true
+		}
+	case "docker":
+		switch flag {
+		case "-c", "--config", "-H", "--host", "--context", "--log-level":
+			return true
+		}
+	}
+	return false
 }
 
 func commandResult(exitCode int) string {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -142,6 +142,10 @@ func TestCommandName(t *testing.T) {
 		{name: "simple", args: []string{"watch", "/tmp/repo"}, want: "watch"},
 		{name: "grouped", args: []string{"daemon", "run", "--once"}, want: "daemon run"},
 		{name: "grouped with flag", args: []string{"service", "--help"}, want: "service"},
+		{name: "gh proxy sanitizes positional args", args: []string{"gh", "repo", "view", "owner/repo"}, want: "gh repo view"},
+		{name: "gh proxy keeps api path bounded", args: []string{"gh", "api", "repos/owner/repo/issues/1"}, want: "gh api"},
+		{name: "git proxy skips global flag values", args: []string{"git", "-C", "/tmp/repo", "status", "--short"}, want: "git status"},
+		{name: "docker proxy records compose path", args: []string{"docker", "--context", "prod", "compose", "up", "-d"}, want: "docker compose up"},
 	}
 
 	for _, tc := range cases {
@@ -152,6 +156,14 @@ func TestCommandName(t *testing.T) {
 				t.Fatalf("CommandName(%v) = %q, want %q", tc.args, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestCommandFeatureAreaUsesToolProxyForSupportedProxyCommands(t *testing.T) {
+	t.Parallel()
+
+	if got, want := commandFeatureArea(commandGroup(CommandName([]string{"gh", "repo", "view", "owner/repo"}))), "tool_proxy"; got != want {
+		t.Fatalf("feature area = %q, want %q", got, want)
 	}
 }
 

--- a/skills/vigilante-conflict-resolution/SKILL.md
+++ b/skills/vigilante-conflict-resolution/SKILL.md
@@ -22,4 +22,4 @@ Use this skill after Vigilante has already opened a pull request and a follow-up
 - Do not broaden the change beyond the conflicting files unless required to restore build or test health.
 - Keep the original issue behavior authoritative; do not drop commits or rewrite away issue scope just to remove conflicts.
 - Do not claim the branch is merge-ready unless the requested validation actually passed.
-- Report blockers immediately with `gh issue comment`.
+- Report blockers immediately with `vigilante gh issue comment`.

--- a/skills/vigilante-create-issue/SKILL.md
+++ b/skills/vigilante-create-issue/SKILL.md
@@ -54,8 +54,8 @@ Produce a GitHub issue that is:
 - Mention the key regressions or failure modes that must be prevented.
 
 7. Create the GitHub issue by default
-- When the repository is known and the user did not explicitly ask for draft-only output, use `gh issue create` to open the issue.
-- Prefer `gh api repos/{owner}/{repo}/issues` over `gh issue create` when opening the final issue so Vigilante can set GitHub's native issue type with the request body `type` field.
+- When the repository is known and the user did not explicitly ask for draft-only output, use `vigilante gh issue create` to open the issue.
+- Prefer `vigilante gh api repos/{owner}/{repo}/issues` over `vigilante gh issue create` when opening the final issue so Vigilante can set GitHub's native issue type with the request body `type` field.
 - Map Vigilante's internal classifications explicitly to GitHub's native issue types: `feature` -> `Feature`, `bug` -> `Bug`, `task` -> `Task`.
 - Treat the native GitHub issue type as the source of truth whenever the repository supports it.
 - Use the polished Markdown body as the issue content instead of stopping at the draft.

--- a/skills/vigilante-issue-implementation-on-bazel-monorepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-bazel-monorepo/SKILL.md
@@ -25,11 +25,11 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - If repository instructions conflict, follow the more specific instruction.
 
 2. Announce session start on GitHub
-- Post a comment on the issue as soon as work begins using `gh issue comment`.
+- Post a comment on the issue as soon as work begins using `vigilante gh issue comment`.
 - Include that Vigilante launched the session, the working branch, and that implementation is in progress.
 
 3. Post an implementation plan early
-- After inspecting the issue and repository constraints, post a concise implementation plan to the issue using `gh issue comment`.
+- After inspecting the issue and repository constraints, post a concise implementation plan to the issue using `vigilante gh issue comment`.
 - The plan comment should describe the intended development steps before substantial coding work begins.
 
 4. Implement inside the assigned worktree only
@@ -50,5 +50,5 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - Open a pull request targeting the repository default branch unless repository instructions say otherwise.
 
 7. Report progress and failures clearly
-- Use `gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
+- Use `vigilante gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
 - Keep comments concise, factual, and tied to real progress.

--- a/skills/vigilante-issue-implementation-on-gradle-multi-project/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-gradle-multi-project/SKILL.md
@@ -25,11 +25,11 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - If repository instructions conflict, follow the more specific instruction.
 
 2. Announce session start on GitHub
-- Post a comment on the issue as soon as work begins using `gh issue comment`.
+- Post a comment on the issue as soon as work begins using `vigilante gh issue comment`.
 - Include that Vigilante launched the session, the working branch, and that implementation is in progress.
 
 3. Post an implementation plan early
-- After inspecting the issue and repository constraints, post a concise implementation plan to the issue using `gh issue comment`.
+- After inspecting the issue and repository constraints, post a concise implementation plan to the issue using `vigilante gh issue comment`.
 - The plan comment should describe the Gradle subproject scope and validation approach before substantial coding work begins.
 
 4. Implement inside the assigned worktree only
@@ -51,5 +51,5 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - Open a pull request targeting the repository default branch unless repository instructions say otherwise.
 
 7. Report progress and failures clearly
-- Use `gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
+- Use `vigilante gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
 - Keep comments concise, factual, and tied to real progress.

--- a/skills/vigilante-issue-implementation-on-monorepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-monorepo/SKILL.md
@@ -25,11 +25,11 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - If repository instructions conflict, follow the more specific instruction.
 
 2. Announce session start on GitHub
-- Post a comment on the issue as soon as work begins using `gh issue comment`.
+- Post a comment on the issue as soon as work begins using `vigilante gh issue comment`.
 - Include that Vigilante launched the session, the working branch, and that implementation is in progress.
 
 3. Post an implementation plan early
-- After inspecting the issue and repository constraints, post a concise implementation plan to the issue using `gh issue comment`.
+- After inspecting the issue and repository constraints, post a concise implementation plan to the issue using `vigilante gh issue comment`.
 - The plan comment should describe the intended development steps before substantial coding work begins.
 
 4. Implement inside the assigned worktree only
@@ -50,5 +50,5 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - Open a pull request targeting the repository default branch unless repository instructions say otherwise.
 
 7. Report progress and failures clearly
-- Use `gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
+- Use `vigilante gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
 - Keep comments concise, factual, and tied to real progress.

--- a/skills/vigilante-issue-implementation-on-rush-monorepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-rush-monorepo/SKILL.md
@@ -25,11 +25,11 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - If repository instructions conflict, follow the more specific instruction.
 
 2. Announce session start on GitHub
-- Post a comment on the issue as soon as work begins using `gh issue comment`.
+- Post a comment on the issue as soon as work begins using `vigilante gh issue comment`.
 - Include that Vigilante launched the session, the working branch, and that implementation is in progress.
 
 3. Post an implementation plan early
-- After inspecting the issue and repository constraints, post a concise implementation plan to the issue using `gh issue comment`.
+- After inspecting the issue and repository constraints, post a concise implementation plan to the issue using `vigilante gh issue comment`.
 - The plan comment should name the likely Rush package or app scope when it is already clear, or state that scope detection is the next step.
 
 4. Implement inside the assigned worktree only
@@ -50,5 +50,5 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - Open a pull request targeting the repository default branch unless repository instructions say otherwise.
 
 7. Report progress and failures clearly
-- Use `gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
+- Use `vigilante gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
 - Keep comments concise, factual, and tied to real progress.

--- a/skills/vigilante-issue-implementation-on-turborepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-turborepo/SKILL.md
@@ -31,11 +31,11 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - If repository instructions conflict, follow the more specific instruction.
 
 2. Announce session start on GitHub
-- Post a comment on the issue as soon as work begins using `gh issue comment`.
+- Post a comment on the issue as soon as work begins using `vigilante gh issue comment`.
 - Include that Vigilante launched the session, the working branch, and that implementation is in progress.
 
 3. Post an implementation plan early
-- After inspecting the issue and repository constraints, post a concise implementation plan to the issue using `gh issue comment`.
+- After inspecting the issue and repository constraints, post a concise implementation plan to the issue using `vigilante gh issue comment`.
 - Mention the initial workspace target or the short list of candidate workspaces when that scope is already known.
 
 4. Implement inside the assigned worktree only
@@ -58,6 +58,6 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - Open a pull request targeting the repository default branch unless repository instructions say otherwise.
 
 7. Report progress and failures clearly
-- Use `gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
+- Use `vigilante gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
 - Keep comments concise, factual, and tied to real progress.
 - Include the selected workspace scope in milestone updates when that information helps reviewers follow the implementation.

--- a/skills/vigilante-issue-implementation/SKILL.md
+++ b/skills/vigilante-issue-implementation/SKILL.md
@@ -28,11 +28,11 @@ Require these inputs from Vigilante:
 - If repository instructions conflict, follow the more specific instruction.
 
 2. Announce session start on GitHub
-- Post a comment on the issue as soon as work begins using `gh issue comment`.
+- Post a comment on the issue as soon as work begins using `vigilante gh issue comment`.
 - Include that Vigilante launched the session, the working branch, and that implementation is in progress.
 
 3. Post an implementation plan early
-- After inspecting the issue and repository constraints, post a concise implementation plan to the issue using `gh issue comment`.
+- After inspecting the issue and repository constraints, post a concise implementation plan to the issue using `vigilante gh issue comment`.
 - The plan comment should describe the intended development steps before substantial code changes begin.
 - Keep the plan concrete and short so readers can understand what will happen next.
 
@@ -54,7 +54,7 @@ Service dependencies:
 
 6. Commit and push the branch
 - Commit only issue-relevant changes in the assigned branch.
-- Push the assigned branch to the remote.
+- Push the assigned branch to the remote with `vigilante git push`.
 - Do not leave completed implementation work only in the local worktree.
 
 7. Open a pull request
@@ -64,7 +64,7 @@ Service dependencies:
 - Include concise validation notes in the PR description.
 
 8. Post progress comments at meaningful milestones
-- Use `gh issue comment` for progress updates.
+- Use `vigilante gh issue comment` for progress updates.
 - Comment when investigation is complete and implementation starts.
 - Comment when major milestones are reached, such as a core fix landing or tests passing.
 - Comment when the branch has been pushed and the PR has been opened.
@@ -72,7 +72,7 @@ Service dependencies:
 - Do not spam the issue with low-signal updates.
 
 9. Handle failures and blockers explicitly
-- If tool setup fails, validation fails, or the issue is blocked, comment on the issue with the concrete problem using `gh issue comment`.
+- If tool setup fails, validation fails, or the issue is blocked, comment on the issue with the concrete problem using `vigilante gh issue comment`.
 - Include enough detail for a human maintainer to understand the current state and next step.
 - If work cannot proceed safely, stop and report the blocker instead of guessing.
 
@@ -83,7 +83,7 @@ Service dependencies:
 - If the task failed, summarize the failure clearly in the issue comment.
 
 ## GitHub Commenting Rules
-- Use `gh issue comment` for all issue updates.
+- Use `vigilante gh issue comment` for all issue updates.
 - Always comment when the session starts.
 - For the coding-agent start comment, use a distinct launch title such as `## 🕹️ Coding Agent Launched: Codex` instead of a generic `Session Start` header.
 - Always add a short implementation plan comment before substantial coding work begins.
@@ -117,5 +117,5 @@ When using this skill, the agent should leave:
 - code changes in the assigned worktree
 - a pushed branch containing those changes
 - an opened pull request for those changes
-- a clear issue comment trail produced through `gh issue comment`
+- a clear issue comment trail produced through `vigilante gh issue comment`
 - accurate success or failure reporting

--- a/skills/vigilante-local-service-dependencies/SKILL.md
+++ b/skills/vigilante-local-service-dependencies/SKILL.md
@@ -26,11 +26,11 @@ Require or infer these inputs before acting:
 ## Detection Order
 1. Search the repository for native service-management workflows first.
 - Check `README*`, `docs/`, `AGENTS.md`, `Taskfile*`, `Makefile*`, package scripts, and repo scripts for setup or startup commands.
-- Check for repository-owned `docker compose` or `docker-compose` files before generating anything new.
+- Check for repository-owned `vigilante docker compose` or `docker-compose` flows before generating anything new.
 - Prefer commands the repository already documents for development or test setup.
 
 2. Validate the native option before using it.
-- Confirm required tools exist, such as `docker`, `docker compose`, `make`, `task`, `npm`, `pnpm`, `yarn`, or project scripts.
+- Confirm required tools exist, such as `vigilante docker`, `vigilante docker compose`, `make`, `task`, `npm`, `pnpm`, `yarn`, or project scripts.
 - If a documented path is incomplete or obviously stale, say so and continue to the next viable option.
 
 3. Fall back only when necessary.


### PR DESCRIPTION
## Summary
- add `vigilante gh`, `vigilante git`, and `vigilante docker` proxy subcommands that forward stdout, stderr, and exit status to the underlying tool
- sanitize proxied command telemetry so only bounded command shape metadata is recorded
- update bundled skills and prompt guidance to route supported tool usage through Vigilante

## Validation
- `go test ./...`
- `go run ./cmd/vigilante gh repo view aliengiraffe/vigilante --json nameWithOwner --jq .nameWithOwner`

Closes #224
