### PR TITLE
Auto-recover stale blocked PR maintenance sessions

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -42,6 +42,18 @@
       ]
     },
     {
+      "name": "vigilante:recovering",
+      "color": "FBCA04",
+      "group": "execution-state",
+      "behavior": "informational",
+      "applied_by": "vigilante",
+      "description": "An automatic stale-session recovery attempt is actively rebuilding local execution state.",
+      "notes": [
+        "Use only while Vigilante is auto-recovering a stale maintenance session.",
+        "Clear when recovery succeeds, is skipped, or returns to a different stable state."
+      ]
+    },
+    {
       "name": "vigilante:ready-for-review",
       "color": "FBCA04",
       "group": "execution-state",

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -32,12 +32,15 @@ import (
 const defaultScanInterval = 1 * time.Minute
 const defaultAssigneeFilter = "me"
 const defaultStalledSessionThreshold = 10 * time.Minute
+const defaultMaintenanceAutoRecoveryTimeout = 10 * time.Minute
 const unsetMaxParallel = -2147483648
+const autoRecoverySource = "auto_recovery"
 
 const (
 	labelQueued                 = "vigilante:queued"
 	labelRunning                = "vigilante:running"
 	labelBlocked                = "vigilante:blocked"
+	labelRecovering             = "vigilante:recovering"
 	labelReadyForReview         = "vigilante:ready-for-review"
 	labelAwaitingUserValidation = "vigilante:awaiting-user-validation"
 	labelDone                   = "vigilante:done"
@@ -51,6 +54,7 @@ var managedIssueLabels = []string{
 	labelQueued,
 	labelRunning,
 	labelBlocked,
+	labelRecovering,
 	labelReadyForReview,
 	labelAwaitingUserValidation,
 	labelDone,
@@ -2183,6 +2187,7 @@ func (a *App) cleanupInactiveBlockedSessions(ctx context.Context, sessions []sta
 	if parsed, err := time.ParseDuration(config.BlockedSessionInactivityTimeout); err == nil && parsed > 0 {
 		timeout = parsed
 	}
+	autoRecoveryTimeout := maintenanceAutoRecoveryTimeout(config)
 
 	for i := range sessions {
 		session := &sessions[i]
@@ -2190,7 +2195,12 @@ func (a *App) cleanupInactiveBlockedSessions(ctx context.Context, sessions []sta
 			continue
 		}
 
-		inactive, err := a.blockedSessionExceededInactivityTimeout(ctx, *session, timeout)
+		evaluationTimeout := timeout
+		if shouldAutoRecoverBlockedSession(*session) {
+			evaluationTimeout = autoRecoveryTimeout
+		}
+
+		inactive, err := a.blockedSessionExceededInactivityTimeout(ctx, *session, evaluationTimeout)
 		if err != nil {
 			session.LastError = err.Error()
 			session.UpdatedAt = a.clock().Format(time.RFC3339)
@@ -2198,6 +2208,20 @@ func (a *App) cleanupInactiveBlockedSessions(ctx context.Context, sessions []sta
 			continue
 		}
 		if !inactive {
+			if shouldAutoRecoverBlockedSession(*session) {
+				a.state.AppendDaemonLog("blocked session auto recovery skipped repo=%s issue=%d branch=%s reason=recent_activity timeout=%s", session.Repo, session.IssueNumber, session.Branch, evaluationTimeout)
+			}
+			continue
+		}
+
+		if shouldAutoRecoverBlockedSession(*session) {
+			a.state.AppendDaemonLog("blocked session auto recovery starting repo=%s issue=%d branch=%s stage=%s timeout=%s", session.Repo, session.IssueNumber, session.Branch, session.BlockedStage, evaluationTimeout)
+			if err := a.autoRecoverBlockedMaintenanceSession(ctx, session, evaluationTimeout); err != nil {
+				session.LastError = err.Error()
+				session.UpdatedAt = a.clock().Format(time.RFC3339)
+				a.state.AppendDaemonLog("blocked session auto recovery failed repo=%s issue=%d branch=%s err=%v", session.Repo, session.IssueNumber, session.Branch, err)
+			}
+			a.syncSessionIssueLabelsBestEffort(ctx, *session, nil)
 			continue
 		}
 
@@ -2213,6 +2237,21 @@ func (a *App) cleanupInactiveBlockedSessions(ctx context.Context, sessions []sta
 	}
 
 	return sessions, nil
+}
+
+func maintenanceAutoRecoveryTimeout(config state.ServiceConfig) time.Duration {
+	if raw := strings.TrimSpace(os.Getenv("VIGILANTE_MAINTENANCE_AUTO_RECOVERY_TIMEOUT")); raw != "" {
+		if parsed, err := time.ParseDuration(raw); err == nil && parsed > 0 {
+			return parsed
+		}
+	}
+	raw := strings.TrimSpace(config.BlockedSessionInactivityTimeout)
+	if raw != "" && raw != state.DefaultBlockedSessionInactivityTimeout.String() {
+		if parsed, err := time.ParseDuration(raw); err == nil && parsed > 0 {
+			return parsed
+		}
+	}
+	return defaultMaintenanceAutoRecoveryTimeout
 }
 
 func (a *App) blockedSessionExceededInactivityTimeout(ctx context.Context, session state.Session, timeout time.Duration) (bool, error) {
@@ -2267,6 +2306,132 @@ func (a *App) cleanupBlockedSessionForInactivity(ctx context.Context, session *s
 	session.LastError = fmt.Sprintf("blocked session cleaned up after %s of inactivity", timeout)
 	a.emitSessionTransition(previousStatus, *session, "blocked_inactivity_timeout")
 	a.state.AppendDaemonLog("blocked session inactivity cleanup complete repo=%s issue=%d branch=%s timeout=%s", session.Repo, session.IssueNumber, session.Branch, timeout)
+	return nil
+}
+
+func shouldAutoRecoverBlockedSession(session state.Session) bool {
+	switch session.BlockedStage {
+	case "pr_maintenance", "ci_remediation", "conflict_resolution":
+	default:
+		return false
+	}
+
+	if strings.TrimSpace(session.BlockedReason.Kind) == "dirty_worktree" {
+		return true
+	}
+
+	text := strings.ToLower(strings.TrimSpace(session.BlockedReason.Summary + " " + session.BlockedReason.Detail))
+	return strings.Contains(text, "worktree is not clean")
+}
+
+func (a *App) autoRecoverBlockedMaintenanceSession(ctx context.Context, session *state.Session, timeout time.Duration) error {
+	pr, err := ghcli.FindPullRequestForBranch(ctx, a.env.Runner, session.Repo, session.Branch)
+	if err != nil {
+		return err
+	}
+	if pr == nil {
+		return errors.New("no pull request found for blocked maintenance session")
+	}
+	if pr.State != "OPEN" {
+		return fmt.Errorf("pull request #%d is not open", pr.Number)
+	}
+	updatePullRequestTrackingFromLookup(session, *pr)
+
+	previousStage := session.BlockedStage
+	previousKind := session.BlockedReason.Kind
+	previousOperation := session.BlockedReason.Operation
+	previousStatus := session.Status
+	now := a.clock()
+	session.Status = state.SessionStatusResuming
+	session.LastResumeSource = autoRecoverySource
+	session.UpdatedAt = now.Format(time.RFC3339)
+	a.emitSessionTransition(previousStatus, *session, autoRecoverySource)
+	a.syncSessionIssueLabelsBestEffort(ctx, *session, pr)
+
+	startBody := ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Auto-Recovery In Progress",
+		Emoji:      "♻️",
+		Percent:    88,
+		ETAMinutes: 8,
+		Items: []string{
+			fmt.Sprintf("The blocked `%s` session on `%s` stayed inactive longer than `%s`.", fallbackText(previousStage, "pr_maintenance"), session.Branch, timeout),
+			fmt.Sprintf("Vigilante is rebuilding the local worktree from the latest committed state of PR #%d on `%s`.", pr.Number, session.Branch),
+			"Next step: resume maintenance on the existing PR branch without opening a replacement PR.",
+		},
+		Tagline: "Reset the footing, keep the climb.",
+	})
+	if err := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, startBody, "progress", autoRecoverySource); err != nil {
+		return err
+	}
+
+	if err := worktree.RecreateBranchWorktree(ctx, a.env.Runner, session.RepoPath, session.WorktreePath, session.Branch); err != nil {
+		blocked := classifyBlockedReason(previousStage, previousOperation, err)
+		markSessionBlocked(session, fallbackText(previousStage, "pr_maintenance"), blocked, a.clock())
+		session.LastError = fmt.Sprintf("automatic recovery failed: %s", err)
+		failureBody := ghcli.FormatProgressComment(ghcli.ProgressComment{
+			Stage:      "Blocked",
+			Emoji:      "🧱",
+			Percent:    90,
+			ETAMinutes: 10,
+			Items: []string{
+				fmt.Sprintf("Vigilante tried to auto-recover `%s` on `%s` after `%s` of inactivity.", fallbackText(previousStage, "pr_maintenance"), session.Branch, timeout),
+				fmt.Sprintf("Automatic worktree reset failed: `%s`.", summarizeMaintenanceError(err)),
+				"Next step: inspect the local git state, then retry the maintenance flow manually if needed.",
+			},
+			Tagline: "The retry stopped at the gate.",
+		})
+		if commentErr := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, failureBody, "blocked", autoRecoverySource); commentErr != nil {
+			a.state.AppendDaemonLog("auto recovery failure comment failed repo=%s issue=%d pr=%d err=%v", session.Repo, session.IssueNumber, pr.Number, commentErr)
+		}
+		return err
+	}
+
+	var resumeErr error
+	switch previousStage {
+	case "conflict_resolution":
+		resumeErr = a.resumeBlockedConflictResolution(ctx, session)
+	default:
+		resumeErr = a.resumeBlockedMaintenance(ctx, session)
+	}
+	if resumeErr != nil {
+		blocked := classifyBlockedReason(previousStage, previousOperation, resumeErr)
+		markSessionBlocked(session, fallbackText(previousStage, "pr_maintenance"), blocked, a.clock())
+		session.LastError = fmt.Sprintf("automatic recovery failed: %s", resumeErr)
+		failureBody := ghcli.FormatProgressComment(ghcli.ProgressComment{
+			Stage:      "Blocked",
+			Emoji:      "🧱",
+			Percent:    92,
+			ETAMinutes: 10,
+			Items: []string{
+				fmt.Sprintf("Vigilante rebuilt the local worktree for PR #%d on `%s`.", pr.Number, session.Branch),
+				fmt.Sprintf("Automatic resume still hit `%s` while continuing `%s`.", fallbackText(session.BlockedReason.Kind, "unknown_operator_action_required"), fallbackText(previousStage, "pr_maintenance")),
+				"Next step: inspect the new blocker and use manual resume only after it is actually resolved.",
+			},
+			Tagline: "Clean slate, real blocker.",
+		})
+		if commentErr := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, failureBody, "blocked", autoRecoverySource); commentErr != nil {
+			a.state.AppendDaemonLog("auto recovery blocked comment failed repo=%s issue=%d pr=%d err=%v", session.Repo, session.IssueNumber, pr.Number, commentErr)
+		}
+		return resumeErr
+	}
+
+	clearBlockedState(session, a.clock(), autoRecoverySource)
+	body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Recovered",
+		Emoji:      "🫡",
+		Percent:    95,
+		ETAMinutes: 3,
+		Items: []string{
+			fmt.Sprintf("Vigilante auto-recovered the stale `%s` block on `%s` after `%s` of inactivity.", fallbackText(previousKind, "dirty_worktree"), session.Branch, timeout),
+			fmt.Sprintf("The local worktree was rebuilt from the latest committed state of PR #%d on the existing branch `%s`.", pr.Number, session.Branch),
+			fmt.Sprintf("Next step: `%s` resumed without creating a replacement PR.", fallbackText(previousStage, "pr_maintenance")),
+		},
+		Tagline: "Same branch, cleaner footing.",
+	})
+	if err := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "resume", autoRecoverySource); err != nil {
+		return err
+	}
+	a.state.AppendDaemonLog("blocked session auto recovery complete repo=%s issue=%d branch=%s pr=%d stage=%s", session.Repo, session.IssueNumber, session.Branch, pr.Number, previousStage)
 	return nil
 }
 
@@ -2762,6 +2927,9 @@ func sessionManagedLabels(session state.Session, pr *ghcli.PullRequest) []string
 func desiredSessionLabels(session state.Session, pr *ghcli.PullRequest) (string, string) {
 	switch session.Status {
 	case state.SessionStatusRunning, state.SessionStatusResuming:
+		if session.Status == state.SessionStatusResuming && strings.TrimSpace(session.LastResumeSource) == autoRecoverySource {
+			return labelRecovering, ""
+		}
 		return labelRunning, ""
 	case state.SessionStatusBlocked:
 		return labelBlocked, blockedInterventionLabel(session.BlockedReason)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -132,6 +132,12 @@ func TestDesiredSessionLabels(t *testing.T) {
 			wantIntervention: "",
 		},
 		{
+			name:             "auto recovering",
+			session:          state.Session{Status: state.SessionStatusResuming, LastResumeSource: autoRecoverySource},
+			wantState:        labelRecovering,
+			wantIntervention: "",
+		},
+		{
 			name:             "blocked provider",
 			session:          state.Session{Status: state.SessionStatusBlocked, BlockedReason: state.BlockedReason{Kind: "provider_auth"}},
 			wantState:        labelBlocked,
@@ -188,7 +194,7 @@ func TestSyncIssueManagedLabelsQueued(t *testing.T) {
 	app.stderr = testutil.IODiscard{}
 	app.env.Runner = testutil.FakeRunner{
 		Outputs: map[string]string{
-			"gh api repos/owner/repo/labels?per_page=100":                                                     `[{"name":"bug"},{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:blocked"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
+			"gh api repos/owner/repo/labels?per_page=100":                                                     `[{"name":"bug"},{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
 			"gh api repos/owner/repo/issues/7":                                                                `{"labels":[{"name":"bug"},{"name":"vigilante:running"}]}`,
 			"gh issue edit --repo owner/repo 7 --add-label vigilante:queued --remove-label vigilante:running": "ok",
 		},
@@ -221,7 +227,7 @@ func TestSyncIssueManagedLabelsNoopDoesNotEmitTelemetry(t *testing.T) {
 	app.stderr = testutil.IODiscard{}
 	app.env.Runner = testutil.FakeRunner{
 		Outputs: map[string]string{
-			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:blocked"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
+			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
 			"gh api repos/owner/repo/issues/7":            `{"labels":[{"name":"vigilante:queued"}]}`,
 		},
 	}
@@ -302,7 +308,7 @@ func TestSyncSessionIssueLabelsUsesPullRequestReviewState(t *testing.T) {
 	app.stderr = testutil.IODiscard{}
 	app.env.Runner = testutil.FakeRunner{
 		Outputs: map[string]string{
-			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:blocked"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
+			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
 			"gh pr view --repo owner/repo 17 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup": `{"number":17,"title":"Demo PR","body":"PR body","url":"https://github.com/owner/repo/pull/17","state":"OPEN","mergedAt":null,"labels":[],"isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[{"context":"test","state":"COMPLETED","conclusion":"SUCCESS"}]}`,
 			"gh api repos/owner/repo/issues/7": `{"labels":[{"name":"vigilante:ready-for-review"},{"name":"vigilante:needs-review"}]}`,
 			"gh issue edit --repo owner/repo 7 --add-label vigilante:awaiting-user-validation --remove-label vigilante:needs-review --remove-label vigilante:ready-for-review": "ok",
@@ -330,6 +336,7 @@ func TestSyncIssueManagedLabelsProvisionMissingRepositoryLabels(t *testing.T) {
 			"gh api --method POST repos/owner/repo/labels -f name=vigilante:queued -f color=BFDADC -f description=The issue is eligible for dispatch and waiting for a worker slot.":                                           "ok",
 			"gh api --method POST repos/owner/repo/labels -f name=vigilante:running -f color=0E8A16 -f description=A coding-agent session is currently executing for the issue.":                                               "ok",
 			"gh api --method POST repos/owner/repo/labels -f name=vigilante:blocked -f color=D93F0B -f description=Execution cannot continue until a blocker is resolved.":                                                     "ok",
+			"gh api --method POST repos/owner/repo/labels -f name=vigilante:recovering -f color=FBCA04 -f description=An automatic stale-session recovery attempt is actively rebuilding local execution state.":               "ok",
 			"gh api --method POST repos/owner/repo/labels -f name=vigilante:ready-for-review -f color=FBCA04 -f description=Implementation is complete enough for a human to review the resulting PR or branch.":               "ok",
 			"gh api --method POST repos/owner/repo/labels -f name=vigilante:awaiting-user-validation -f color=F9D0C4 -f description=Changes are ready for product or operator validation before the issue is considered done.": "ok",
 			"gh api --method POST repos/owner/repo/labels -f name=vigilante:done -f color=5319E7 -f description=Vigilante completed its work on the issue and no further automation is expected.":                              "ok",
@@ -2738,6 +2745,55 @@ func TestBlockedSessionExceededInactivityTimeoutTreatsRecentWorktreeChangeAsActi
 	}
 }
 
+func TestShouldAutoRecoverBlockedSession(t *testing.T) {
+	tests := []struct {
+		name    string
+		session state.Session
+		want    bool
+	}{
+		{
+			name: "maintenance dirty worktree",
+			session: state.Session{
+				BlockedStage:  "pr_maintenance",
+				BlockedReason: state.BlockedReason{Kind: "dirty_worktree"},
+			},
+			want: true,
+		},
+		{
+			name: "conflict resolution dirty worktree detail",
+			session: state.Session{
+				BlockedStage:  "conflict_resolution",
+				BlockedReason: state.BlockedReason{Summary: "worktree is not clean before PR maintenance"},
+			},
+			want: true,
+		},
+		{
+			name: "maintenance provider auth",
+			session: state.Session{
+				BlockedStage:  "ci_remediation",
+				BlockedReason: state.BlockedReason{Kind: "provider_auth"},
+			},
+			want: false,
+		},
+		{
+			name: "non maintenance dirty worktree",
+			session: state.Session{
+				BlockedStage:  "issue_execution",
+				BlockedReason: state.BlockedReason{Kind: "dirty_worktree"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldAutoRecoverBlockedSession(tc.session); got != tc.want {
+				t.Fatalf("unexpected result: got %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestScanOnceCleansUpBlockedSessionAfterDefaultInactivityTimeout(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
@@ -2975,6 +3031,125 @@ func TestScanOnceLeavesBlockedSessionVisibleWhenInactivityCleanupFails(t *testin
 	}
 	if sessions[0].Status != state.SessionStatusBlocked || sessions[0].CleanupError == "" || sessions[0].LastCleanupSource != "blocked_inactivity_timeout" {
 		t.Fatalf("expected failed inactivity cleanup to leave a visible blocked state: %#v", sessions[0])
+	}
+}
+
+func TestScanOnceAutoRecoversStaleBlockedMaintenanceSession(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 3, 12, 18, 0, 0, 0, time.UTC)
+	old := now.Add(-15 * time.Minute)
+	if err := os.Chtimes(worktreePath, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	startComment := ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Auto-Recovery In Progress",
+		Emoji:      "♻️",
+		Percent:    88,
+		ETAMinutes: 8,
+		Items: []string{
+			"The blocked `pr_maintenance` session on `vigilante/issue-1` stayed inactive longer than `10m0s`.",
+			"Vigilante is rebuilding the local worktree from the latest committed state of PR #31 on `vigilante/issue-1`.",
+			"Next step: resume maintenance on the existing PR branch without opening a replacement PR.",
+		},
+		Tagline: "Reset the footing, keep the climb.",
+	})
+	successComment := ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Recovered",
+		Emoji:      "🫡",
+		Percent:    95,
+		ETAMinutes: 3,
+		Items: []string{
+			"Vigilante auto-recovered the stale `dirty_worktree` block on `vigilante/issue-1` after `10m0s` of inactivity.",
+			"The local worktree was rebuilt from the latest committed state of PR #31 on the existing branch `vigilante/issue-1`.",
+			"Next step: `pr_maintenance` resumed without creating a replacement PR.",
+		},
+		Tagline: "Same branch, cleaner footing.",
+	})
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.clock = func() time.Time { return now }
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1/comments":                                                          "[]",
+			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
+			"gh issue comment --repo owner/repo 1 --body " + startComment:                                        "ok",
+			"git worktree prune":                                         "ok",
+			"git worktree remove --force " + worktreePath:                "ok",
+			"git ls-remote --exit-code --heads origin vigilante/issue-1": "abc123\trefs/heads/vigilante/issue-1",
+			"git fetch origin vigilante/issue-1:vigilante/issue-1":       "ok",
+			"git worktree list --porcelain":                              "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
+			"git worktree add " + worktreePath + " vigilante/issue-1":    "ok",
+			"git fetch origin main":                                      "ok",
+			"git status --porcelain":                                     "",
+			"git rebase origin/main":                                     "Current branch vigilante/issue-1 is up to date.\n",
+			"gh pr view --repo owner/repo 31 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup": `{"number":31,"title":"Test PR","body":"body","url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null,"labels":[],"isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[{"context":"test","state":"COMPLETED","conclusion":"SUCCESS"}]}`,
+			"gh issue comment --repo owner/repo 1 --body " + successComment:                                                                                          "ok",
+			"gh api repos/owner/repo/labels?per_page=100":                                                                                                            `[{"name":"vigilante:running"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"vigilante:queued"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
+			"gh api repos/owner/repo/issues/1":                                                                                                                       `{"labels":[{"name":"vigilante:blocked"},{"name":"vigilante:needs-git-fix"}]}`,
+			"gh issue edit --repo owner/repo 1 --add-label vigilante:recovering --remove-label vigilante:blocked --remove-label vigilante:needs-git-fix":             "ok",
+			"gh issue edit --repo owner/repo 1 --add-label vigilante:awaiting-user-validation --remove-label vigilante:recovering":                                   "ok",
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: repoPath, Repo: "owner/repo", Branch: "main", Assignee: "me"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:          repoPath,
+		Repo:              "owner/repo",
+		IssueNumber:       1,
+		IssueTitle:        "first",
+		IssueURL:          "https://github.com/owner/repo/issues/1",
+		Branch:            "vigilante/issue-1",
+		WorktreePath:      worktreePath,
+		Status:            state.SessionStatusBlocked,
+		PullRequestNumber: 31,
+		BlockedAt:         old.Format(time.RFC3339),
+		BlockedStage:      "pr_maintenance",
+		BlockedReason: state.BlockedReason{
+			Kind:      "dirty_worktree",
+			Operation: "git status --porcelain",
+			Summary:   "worktree is not clean before PR maintenance",
+			Detail:    "worktree is not clean before PR maintenance",
+		},
+		LastMaintenanceError: "worktree is not clean before PR maintenance",
+		UpdatedAt:            old.Format(time.RFC3339),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions[0].Status != state.SessionStatusSuccess {
+		t.Fatalf("expected session to recover successfully: %#v", sessions[0])
+	}
+	if sessions[0].RecoveredAt == "" || sessions[0].BlockedStage != "" || sessions[0].BlockedReason.Kind != "" {
+		t.Fatalf("expected blocked state to be cleared after auto recovery: %#v", sessions[0])
+	}
+	if sessions[0].LastResumeSource != autoRecoverySource {
+		t.Fatalf("expected auto recovery source to be recorded: %#v", sessions[0])
 	}
 }
 

--- a/internal/github/labels_manifest_test.go
+++ b/internal/github/labels_manifest_test.go
@@ -102,6 +102,7 @@ func TestIssueLabelManifestIncludesHumanReviewStates(t *testing.T) {
 	}
 
 	for _, name := range []string{
+		"vigilante:recovering",
 		"vigilante:ready-for-review",
 		"vigilante:awaiting-user-validation",
 		"vigilante:needs-human-input",

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -193,6 +193,53 @@ func CleanupIssueArtifactsForBranches(ctx context.Context, runner environment.Ru
 	return nil
 }
 
+func RecreateBranchWorktree(ctx context.Context, runner environment.Runner, repoPath string, worktreePath string, branch string) error {
+	if err := Prune(ctx, runner, repoPath); err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(worktreePath); err == nil {
+		if err := Remove(ctx, runner, repoPath, worktreePath); err != nil {
+			return err
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	if err := Prune(ctx, runner, repoPath); err != nil {
+		return err
+	}
+
+	remoteExists, err := remoteBranchExistsWithError(ctx, runner, repoPath, branch)
+	if err != nil {
+		return err
+	}
+	if remoteExists {
+		if _, err := runner.Run(ctx, repoPath, "git", "fetch", "origin", branch+":"+branch); err != nil {
+			return fmt.Errorf("prepare remote branch %q: %w", branch, err)
+		}
+	} else {
+		exists, err := branchExistsWithError(ctx, runner, repoPath, branch)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("branch %q not found locally or on origin", branch)
+		}
+	}
+
+	attached, err := branchAttachedToWorktree(ctx, runner, repoPath, branch)
+	if err != nil {
+		return err
+	}
+	if attached {
+		return fmt.Errorf("branch %q is already attached to another worktree", branch)
+	}
+
+	_, err = runner.Run(ctx, repoPath, "git", "worktree", "add", worktreePath, branch)
+	return err
+}
+
 func branchExists(ctx context.Context, runner environment.Runner, repoPath string, branch string) bool {
 	_, err := runner.Run(ctx, repoPath, "git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
 	return err == nil


### PR DESCRIPTION
## Summary
- auto-recover stale blocked PR maintenance, CI remediation, and conflict-resolution sessions when the blocker is a stale dirty worktree
- rebuild the existing PR branch worktree from committed state and resume maintenance without replacing the PR
- expose the transient `vigilante:recovering` lifecycle label and add coverage for the recovery path

## Validation
- go test ./...

Closes #226
