### PR TITLE
Configure Renovate Dependency Dashboard autoclose

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "dependencyDashboardAutoclose": true
 }


### PR DESCRIPTION
## Summary
- enable `dependencyDashboardAutoclose` in `renovate.json`
- keep `config:recommended` so the Dependency Dashboard still exists when there are pending updates
- close the dashboard issue automatically when Renovate has nothing left to track

## Validation
- `jq empty renovate.json`

Closes #228
