### PR TITLE
Add README link to closed issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 It is a Go CLI and background service that runs locally on top of the tools teams already use: `git`, `gh`, and a supported coding-agent CLI such as `codex`, `claude`, or `gemini`. The current target platforms are macOS and Ubuntu.
 
+Want to see that workflow on this repository? Browse [Vigilante's closed issues](https://github.com/aliengiraffe/vigilante/issues?q=is%3Aissue%20state%3Aclosed) for concrete examples of the project operating on its own codebase and improving itself over time.
+
 ## What Vigilante Is
 
 `vigilante` is the orchestration layer around coding agents. It is responsible for:


### PR DESCRIPTION
## Summary
- add a prominent README link to the repository's closed issues view
- explain that the link helps readers observe Vigilante improving its own codebase over time

## Validation
- inspected the README diff to verify the markdown placement and surrounding formatting
- verified the closed issues URL is present in `README.md`

Closes #236
