### PR TITLE
Fix Homebrew Caskroom Gatekeeper cleanup for macOS daemon setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,13 +350,15 @@ Expected behavior:
   - `docker-compose-launch`
 - installs or updates the daemon definition when requested
 
-On macOS, `vigilante setup -d` resolves Homebrew-style symlinks before it prepares the daemon binary. The launchd plist still uses the invoked path, but Vigilante removes `com.apple.provenance` and `com.apple.quarantine` from the resolved binary when present, ad-hoc signs that binary, and runs `spctl --assess --type execute -vv` against the resolved path before loading the service.
+On macOS, `vigilante setup -d` resolves Homebrew-style symlinks before it prepares the daemon binary. For Homebrew cask installs, Vigilante first clears `com.apple.provenance` and `com.apple.quarantine` recursively from the enclosing Caskroom version directory, then removes those same xattrs from the resolved binary when present, ad-hoc signs that binary, and runs `spctl --assess --type execute -vv` against the resolved path before loading the service.
 
 If Gatekeeper still rejects the binary, the error now reports both the assessed path and the invoked path when they differ. A useful manual recovery sequence is:
 
 ```sh
 realbin="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' /opt/homebrew/bin/vigilante)"
 xattr "$realbin"
+xattr -dr com.apple.provenance "$(dirname "$realbin")" 2>/dev/null || true
+xattr -dr com.apple.quarantine "$(dirname "$realbin")" 2>/dev/null || true
 xattr -d com.apple.provenance "$realbin" 2>/dev/null || true
 xattr -d com.apple.quarantine "$realbin" 2>/dev/null || true
 codesign --force --sign - "$realbin"
@@ -427,7 +429,7 @@ task setup-daemon
 
 On macOS, `task setup-daemon` now performs one explicit recovery attempt when an existing `com.vigilante.agent` launch agent is already present. If the first refresh fails, the task cleans up the existing launch agent, retries once, and prints a short manual `launchctl bootout ...` hint if recovery still fails.
 
-On macOS, `vigilante setup -d` also prepares the installed daemon binary before reloading the LaunchAgent by clearing an observed `com.apple.provenance` xattr, applying ad-hoc signing, and validating the binary with `spctl`. If macOS still rejects the binary, setup exits with a code-signing error instead of leaving the agent stuck in `OS_REASON_CODESIGNING`.
+On macOS, `vigilante setup -d` also prepares the installed daemon binary before reloading the LaunchAgent by clearing observed Gatekeeper xattrs from the Homebrew cask install root when applicable, clearing those xattrs from the resolved binary, applying ad-hoc signing, and validating the binary with `spctl`. If macOS still rejects the binary, setup exits with a code-signing error instead of leaving the agent stuck in `OS_REASON_CODESIGNING`.
 
 Notes:
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -342,6 +342,12 @@ func prepareMacOSDaemonBinary(ctx context.Context, runner environment.Runner, ex
 		return fmt.Errorf("resolve macOS daemon binary %q: %w", executable, err)
 	}
 
+	if caskRoot, ok := homebrewCaskInstallRoot(resolvedPath); ok {
+		if err := removeKnownMacOSAttributesRecursively(ctx, runner, caskRoot); err != nil {
+			return fmt.Errorf("remove macOS extended attributes from Homebrew cask install root %q: %w", caskRoot, err)
+		}
+	}
+
 	attrs, err := listExtendedAttributes(ctx, runner, resolvedPath)
 	if err != nil {
 		return fmt.Errorf("inspect macOS extended attributes for daemon binary %q: %w", resolvedPath, err)
@@ -365,6 +371,25 @@ func prepareMacOSDaemonBinary(ctx context.Context, runner environment.Runner, ex
 		return fmt.Errorf("macOS rejected daemon binary %s: %w", macOSBinaryContext(executable, resolvedPath, removedAttrs), err)
 	}
 
+	return nil
+}
+
+func homebrewCaskInstallRoot(path string) (string, bool) {
+	dir := filepath.Dir(path)
+	tokenDir := filepath.Dir(dir)
+	if filepath.Base(filepath.Dir(tokenDir)) != "Caskroom" {
+		return "", false
+	}
+	return dir, true
+}
+
+func removeKnownMacOSAttributesRecursively(ctx context.Context, runner environment.Runner, path string) error {
+	for _, attr := range []string{"com.apple.provenance", "com.apple.quarantine"} {
+		command := fmt.Sprintf("xattr -dr %s %s >/dev/null 2>&1 || true", shellQuote(attr), shellQuote(path))
+		if _, err := runner.Run(ctx, "", "/bin/sh", "-lc", command); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -405,6 +405,7 @@ func TestRestartReturnsUnsupportedOSError(t *testing.T) {
 func TestPrepareMacOSDaemonBinaryUsesResolvedPath(t *testing.T) {
 	dir := t.TempDir()
 	resolvedPath := filepath.Join(dir, "Caskroom", "vigilante", "1.2.3", "vigilante")
+	caskRoot := filepath.Dir(resolvedPath)
 	if err := os.MkdirAll(filepath.Dir(resolvedPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -427,6 +428,8 @@ func TestPrepareMacOSDaemonBinaryUsesResolvedPath(t *testing.T) {
 	runner := &recordingRunner{
 		FakeRunner: testutil.FakeRunner{
 			Outputs: map[string]string{
+				`/bin/sh -lc xattr -dr 'com.apple.provenance' ` + shellQuote(caskRoot) + ` >/dev/null 2>&1 || true`: "",
+				`/bin/sh -lc xattr -dr 'com.apple.quarantine' ` + shellQuote(caskRoot) + ` >/dev/null 2>&1 || true`: "",
 				testutil.Key("xattr", resolvedPath):                                         "com.apple.provenance\ncom.apple.quarantine\ncom.example.keep\n",
 				testutil.Key("xattr", "-d", "com.apple.provenance", resolvedPath):           "",
 				testutil.Key("xattr", "-d", "com.apple.quarantine", resolvedPath):           "",
@@ -441,6 +444,8 @@ func TestPrepareMacOSDaemonBinaryUsesResolvedPath(t *testing.T) {
 	}
 
 	wantCalls := []string{
+		`/bin/sh -lc xattr -dr 'com.apple.provenance' ` + shellQuote(caskRoot) + ` >/dev/null 2>&1 || true`,
+		`/bin/sh -lc xattr -dr 'com.apple.quarantine' ` + shellQuote(caskRoot) + ` >/dev/null 2>&1 || true`,
 		testutil.Key("xattr", resolvedPath),
 		testutil.Key("xattr", "-d", "com.apple.provenance", resolvedPath),
 		testutil.Key("xattr", "-d", "com.apple.quarantine", resolvedPath),
@@ -489,6 +494,7 @@ func TestPrepareMacOSDaemonBinarySkipsMissingKnownAttrs(t *testing.T) {
 func TestPrepareMacOSDaemonBinaryReportsSymlinkContextOnSpctlFailure(t *testing.T) {
 	dir := t.TempDir()
 	resolvedPath := filepath.Join(dir, "Caskroom", "vigilante", "1.2.3", "vigilante")
+	caskRoot := filepath.Dir(resolvedPath)
 	if err := os.MkdirAll(filepath.Dir(resolvedPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -511,6 +517,8 @@ func TestPrepareMacOSDaemonBinaryReportsSymlinkContextOnSpctlFailure(t *testing.
 	runner := &recordingRunner{
 		FakeRunner: testutil.FakeRunner{
 			Outputs: map[string]string{
+				`/bin/sh -lc xattr -dr 'com.apple.provenance' ` + shellQuote(caskRoot) + ` >/dev/null 2>&1 || true`: "",
+				`/bin/sh -lc xattr -dr 'com.apple.quarantine' ` + shellQuote(caskRoot) + ` >/dev/null 2>&1 || true`: "",
 				testutil.Key("xattr", resolvedPath):                              "",
 				testutil.Key("codesign", "--force", "--sign", "-", resolvedPath): "",
 			},
@@ -532,5 +540,38 @@ func TestPrepareMacOSDaemonBinaryReportsSymlinkContextOnSpctlFailure(t *testing.
 	}
 	if !strings.Contains(err.Error(), "removed_xattrs=none") {
 		t.Fatalf("error missing xattr context: %v", err)
+	}
+}
+
+func TestHomebrewCaskInstallRoot(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+		ok   bool
+	}{
+		{
+			name: "homebrew cask binary",
+			path: "/opt/homebrew/Caskroom/vigilante-nightly/0.0.0-nightly.1/vigilante",
+			want: "/opt/homebrew/Caskroom/vigilante-nightly/0.0.0-nightly.1",
+			ok:   true,
+		},
+		{
+			name: "non cask path",
+			path: "/usr/local/bin/vigilante",
+			ok:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := homebrewCaskInstallRoot(tt.path)
+			if ok != tt.ok {
+				t.Fatalf("unexpected ok=%v want %v", ok, tt.ok)
+			}
+			if got != tt.want {
+				t.Fatalf("unexpected root=%q want %q", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- clear known Gatekeeper xattrs recursively from Homebrew Caskroom installs before signing the resolved daemon binary
- keep the existing resolved-path assessment flow and actionable error context intact
- document the updated macOS recovery behavior and cover the Homebrew path with tests

## Validation
- `go test ./internal/service ./internal/app`
- `go test ./...`

Closes #239
