### PR TITLE
Support assignee-driven @vigilanteai iteration comments

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -31,6 +31,18 @@
       ]
     },
     {
+      "name": "vigilante:iterating",
+      "color": "1D76DB",
+      "group": "execution-state",
+      "behavior": "informational",
+      "applied_by": "vigilante",
+      "description": "An assignee-requested follow-up implementation iteration is actively in progress.",
+      "notes": [
+        "Coexists with the current execution-state label while Vigilante is handling a new assignee-driven `@vigilanteai` follow-up pass.",
+        "Clear when the active iteration returns to a stable non-iterating state."
+      ]
+    },
+    {
       "name": "vigilante:blocked",
       "color": "D93F0B",
       "group": "execution-state",

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -40,6 +40,7 @@ const autoRecoverySource = "auto_recovery"
 const (
 	labelQueued                 = "vigilante:queued"
 	labelRunning                = "vigilante:running"
+	labelIterating              = "vigilante:iterating"
 	labelBlocked                = "vigilante:blocked"
 	labelRecovering             = "vigilante:recovering"
 	labelReadyForReview         = "vigilante:ready-for-review"
@@ -54,6 +55,7 @@ const (
 var managedIssueLabels = []string{
 	labelQueued,
 	labelRunning,
+	labelIterating,
 	labelBlocked,
 	labelRecovering,
 	labelReadyForReview,
@@ -863,6 +865,12 @@ func (a *App) ScanOnce(ctx context.Context) error {
 			}
 			target.MaxParallel = configuredMaxParallel(target.MaxParallel)
 			target.Classification = repo.Classify(target.Path)
+			var started int
+			sessions, started, err = a.processGitHubIterationRequestsForTarget(ctx, *target, sessions)
+			if err != nil {
+				return err
+			}
+			startedCount += started
 			a.state.AppendDaemonLog("scan repo classified repo=%s shape=%s hints=%d/%d/%d", target.Repo, target.Classification.Shape, len(target.Classification.ProcessHints.WorkspaceConfigFiles), len(target.Classification.ProcessHints.WorkspaceManifestFiles), len(target.Classification.ProcessHints.MultiPackageRoots))
 			a.state.AppendDaemonLog("scan repo start repo=%s path=%s max_parallel=%d", target.Repo, target.Path, target.MaxParallel)
 			issues, err := ghcli.ListOpenIssues(ctx, a.env.Runner, target.Repo, target.Assignee)
@@ -2892,6 +2900,216 @@ func clearBlockedState(session *state.Session, now time.Time, source string) {
 	session.LastDispatchFailureCommentedAt = ""
 }
 
+func (a *App) processGitHubIterationRequestsForTarget(ctx context.Context, target state.WatchTarget, sessions []state.Session) ([]state.Session, int, error) {
+	started := 0
+	for i := range sessions {
+		session := &sessions[i]
+		if session.Repo != target.Repo {
+			continue
+		}
+		if !sessionSupportsIteration(*session) {
+			continue
+		}
+
+		details, err := ghcli.GetIssueDetails(ctx, a.env.Runner, session.Repo, session.IssueNumber)
+		if err != nil {
+			a.state.AppendDaemonLog("iteration issue details failed repo=%s issue=%d err=%v", session.Repo, session.IssueNumber, err)
+			session.LastError = err.Error()
+			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			continue
+		}
+
+		comments, err := ghcli.ListIssueCommentsForPolling(ctx, a.env.Runner, session.Repo, session.IssueNumber, "iteration", a.state.AppendDaemonLog)
+		if err != nil {
+			a.state.AppendDaemonLog("iteration comment lookup failed repo=%s issue=%d err=%v", session.Repo, session.IssueNumber, err)
+			session.LastError = err.Error()
+			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			continue
+		}
+
+		comment := ghcli.FindIterationComment(comments, session.LastIterationCommentID)
+		if comment == nil {
+			continue
+		}
+
+		assignees := assigneeLogins(details.Assignees)
+		if !loginMatchesAssignee(comment.User.Login, assignees) {
+			session.LastIterationCommentID = comment.ID
+			session.LastIterationCommentAt = comment.CreatedAt.UTC().Format(time.RFC3339)
+			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Iteration Ignored",
+				Emoji:      "🛂",
+				Percent:    100,
+				ETAMinutes: 1,
+				Items: []string{
+					fmt.Sprintf("Ignored the latest `@vigilanteai` iteration request from `@%s`.", fallbackText(comment.User.Login, "unknown")),
+					"Only a current issue assignee can request another implementation iteration for this issue.",
+					"Next step: ask an assignee to post the follow-up request if another pass is needed.",
+				},
+				Tagline: "Hands on the wheel, one driver at a time.",
+			})
+			if err := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "iteration_ignored", "github_comment"); err != nil {
+				a.state.AppendDaemonLog("iteration rejection comment failed repo=%s issue=%d comment=%d err=%v", session.Repo, session.IssueNumber, comment.ID, err)
+				session.LastError = err.Error()
+			}
+			continue
+		}
+
+		if err := ghcli.AddIssueCommentReaction(ctx, a.env.Runner, session.Repo, comment.ID, "eyes"); err != nil {
+			a.state.AppendDaemonLog("iteration reaction failed repo=%s issue=%d comment=%d err=%v", session.Repo, session.IssueNumber, comment.ID, err)
+		}
+
+		iterationComments := ghcli.AssigneeIterationComments(comments, assignees)
+		issue := ghcli.Issue{
+			Number: session.IssueNumber,
+			Title:  fallbackText(details.Title, session.IssueTitle),
+			URL:    fallbackText(details.URL, session.IssueURL),
+			Labels: details.Labels,
+		}
+		previous := *session
+		updated, err := a.dispatchIssueSession(ctx, target, issue, session.Provider, previous, strings.TrimSpace(details.Body), buildIterationPromptContext(iterationComments), comment)
+		if err != nil {
+			if updated.IssueNumber == 0 {
+				updated = previous
+			}
+			updated.LastIterationCommentID = comment.ID
+			updated.LastIterationCommentAt = comment.CreatedAt.UTC().Format(time.RFC3339)
+			updated.UpdatedAt = a.clock().Format(time.RFC3339)
+			a.commentDispatchFailure(ctx, previous, &updated, "iteration_dispatch")
+			sessions = upsertSession(sessions, updated)
+			a.emitSessionTransition(previous.Status, updated, "iteration_dispatch")
+			a.syncSessionIssueLabelsBestEffort(ctx, updated, nil)
+			a.state.AppendDaemonLog("iteration dispatch failed repo=%s issue=%d comment=%d err=%v", session.Repo, session.IssueNumber, comment.ID, err)
+			continue
+		}
+
+		sessions = upsertSession(sessions, updated)
+		a.emitSessionTransition(previous.Status, updated, "iteration_dispatch")
+		a.syncSessionIssueLabelsBestEffort(ctx, updated, nil)
+		a.launchIssueSession(ctx, target, issue, updated)
+		started++
+	}
+	return sessions, started, a.state.SaveSessions(sessions)
+}
+
+func sessionSupportsIteration(session state.Session) bool {
+	if session.CleanupCompletedAt != "" || session.MonitoringStoppedAt != "" {
+		return false
+	}
+	switch session.Status {
+	case state.SessionStatusRunning, state.SessionStatusResuming:
+		return false
+	case state.SessionStatusBlocked, state.SessionStatusSuccess, state.SessionStatusFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+func assigneeLogins(assignees []ghcli.IssueUserRef) []string {
+	logins := make([]string, 0, len(assignees))
+	for _, assignee := range assignees {
+		if login := strings.TrimSpace(assignee.Login); login != "" {
+			logins = append(logins, login)
+		}
+	}
+	return logins
+}
+
+func loginMatchesAssignee(login string, assignees []string) bool {
+	login = strings.TrimSpace(strings.ToLower(login))
+	if login == "" {
+		return false
+	}
+	for _, assignee := range assignees {
+		if login == strings.ToLower(strings.TrimSpace(assignee)) {
+			return true
+		}
+	}
+	return false
+}
+
+func buildIterationPromptContext(comments []ghcli.IssueComment) string {
+	if len(comments) == 0 {
+		return ""
+	}
+	var lines []string
+	latest := comments[len(comments)-1]
+	lines = append(lines,
+		"Iteration context for this pass:",
+		"The latest qualifying assignee `@vigilanteai` comment is the primary focus for this implementation pass.",
+		"",
+		"Primary focus comment:",
+		fmt.Sprintf("- Author: @%s", fallbackText(latest.User.Login, "unknown")),
+		fmt.Sprintf("- Created at: %s", latest.CreatedAt.UTC().Format(time.RFC3339)),
+		"- Body:",
+		strings.TrimSpace(latest.Body),
+	)
+	if len(comments) > 1 {
+		lines = append(lines, "", "Earlier assignee `@vigilanteai` comments for background:")
+		for i := 0; i < len(comments)-1; i++ {
+			lines = append(lines,
+				fmt.Sprintf("%d. @%s at %s", i+1, fallbackText(comments[i].User.Login, "unknown"), comments[i].CreatedAt.UTC().Format(time.RFC3339)),
+				strings.TrimSpace(comments[i].Body),
+			)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (a *App) dispatchIssueSession(ctx context.Context, target state.WatchTarget, issue ghcli.Issue, selectedProvider string, previous state.Session, issueBody string, iterationContext string, triggeringComment *ghcli.IssueComment) (state.Session, error) {
+	wt, err := worktree.CreateIssueWorktree(ctx, a.env.Runner, target, issue.Number, issue.Title)
+	if err != nil {
+		return blockedIssueSessionForDispatchFailure(target, issue, selectedProvider, err, a.clock()), err
+	}
+	a.state.AppendDaemonLog("scan repo worktree ready repo=%s issue=%d path=%s branch=%s reused_remote=%t", target.Repo, issue.Number, wt.Path, wt.Branch, wt.ReusedRemoteBranch != "")
+
+	diffSummary := ""
+	if strings.TrimSpace(wt.ReusedRemoteBranch) != "" {
+		diffSummary, err = summarizeIssueBranchDiff(ctx, a.env.Runner, target.Path, target.Branch, wt.Branch)
+		if err != nil {
+			_ = worktree.CleanupIssueArtifacts(ctx, a.env.Runner, target.Path, wt.Path, wt.Branch)
+			blocked := blockedIssueSessionForDispatchFailure(target, issue, selectedProvider, fmt.Errorf("analyze reused remote issue branch %q against %q: %w", wt.Branch, target.Branch, err), a.clock())
+			blocked.Branch = wt.Branch
+			blocked.BaseBranch = target.Branch
+			blocked.WorktreePath = wt.Path
+			blocked.ReusedRemoteBranch = wt.ReusedRemoteBranch
+			return blocked, err
+		}
+		a.state.AppendDaemonLog("scan repo reused remote issue branch repo=%s issue=%d branch=%s base=%s diff=%s", target.Repo, issue.Number, wt.Branch, target.Branch, summarizeText(diffSummary))
+	}
+
+	now := a.clock().Format(time.RFC3339)
+	session := previous
+	session.RepoPath = target.Path
+	session.Repo = target.Repo
+	session.Provider = selectedProvider
+	session.IssueNumber = issue.Number
+	session.IssueTitle = issue.Title
+	session.IssueBody = strings.TrimSpace(issueBody)
+	session.IssueURL = issue.URL
+	session.BaseBranch = target.Branch
+	session.Branch = wt.Branch
+	session.WorktreePath = wt.Path
+	session.ReusedRemoteBranch = wt.ReusedRemoteBranch
+	session.BranchDiffSummary = diffSummary
+	session.Status = state.SessionStatusRunning
+	session.ProcessID = os.Getpid()
+	session.StartedAt = now
+	session.LastHeartbeatAt = now
+	session.EndedAt = ""
+	session.UpdatedAt = now
+	session.LastError = ""
+	session.IterationPromptContext = strings.TrimSpace(iterationContext)
+	session.IterationInProgress = triggeringComment != nil
+	if triggeringComment != nil {
+		session.LastIterationCommentID = triggeringComment.ID
+		session.LastIterationCommentAt = triggeringComment.CreatedAt.UTC().Format(time.RFC3339)
+	}
+	return session, nil
+}
+
 func (a *App) syncQueuedIssueLabelsBestEffort(ctx context.Context, repo string, issueNumber int) {
 	if err := a.syncIssueManagedLabels(ctx, repo, issueNumber, []string{labelQueued}); err != nil {
 		a.state.AppendDaemonLog("issue label sync failed repo=%s issue=%d err=%v", repo, issueNumber, err)
@@ -2969,9 +3187,12 @@ func (a *App) ensureRepositoryLabelsProvisioned(ctx context.Context, repo string
 
 func sessionManagedLabels(session state.Session, pr *ghcli.PullRequest) []string {
 	stateLabel, interventionLabel := desiredSessionLabels(session, pr)
-	labels := make([]string, 0, 2)
+	labels := make([]string, 0, 3)
 	if stateLabel != "" {
 		labels = append(labels, stateLabel)
+	}
+	if session.IterationInProgress && (session.Status == state.SessionStatusRunning || session.Status == state.SessionStatusResuming || session.Status == state.SessionStatusBlocked) {
+		labels = append(labels, labelIterating)
 	}
 	if interventionLabel != "" {
 		labels = append(labels, interventionLabel)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -235,6 +235,205 @@ func TestDesiredSessionLabels(t *testing.T) {
 	}
 }
 
+func TestSessionManagedLabelsIncludesIteratingWhenActive(t *testing.T) {
+	labels := sessionManagedLabels(state.Session{
+		Status:              state.SessionStatusRunning,
+		IterationInProgress: true,
+	}, nil)
+	if len(labels) != 2 || labels[0] != labelRunning || labels[1] != labelIterating {
+		t.Fatalf("unexpected labels: %#v", labels)
+	}
+}
+
+func TestProcessGitHubIterationRequestsForTargetRejectsNonAssignee(t *testing.T) {
+	now := time.Date(2026, 3, 19, 12, 0, 0, 0, time.UTC)
+	repoPath := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", stateRoot)
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.clock = func() time.Time { return now }
+	app.state = state.NewStore()
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1":          `{"title":"first","body":"Issue body","html_url":"https://github.com/owner/repo/issues/1","labels":[{"name":"vigilante:ready-for-review"}],"assignees":[{"login":"nicobistolfi"}]}`,
+			"gh api repos/owner/repo/issues/1/comments": `[{"id":101,"body":"@vigilanteai please revise this","created_at":"2026-03-19T11:59:00Z","user":{"login":"someoneelse"}}]`,
+			"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Iteration Ignored",
+				Emoji:      "🛂",
+				Percent:    100,
+				ETAMinutes: 1,
+				Items: []string{
+					"Ignored the latest `@vigilanteai` iteration request from `@someoneelse`.",
+					"Only a current issue assignee can request another implementation iteration for this issue.",
+					"Next step: ask an assignee to post the follow-up request if another pass is needed.",
+				},
+				Tagline: "Hands on the wheel, one driver at a time.",
+			}): "ok",
+		},
+	}
+
+	sessions := []state.Session{{
+		RepoPath:     repoPath,
+		Repo:         "owner/repo",
+		Provider:     "codex",
+		IssueNumber:  1,
+		IssueTitle:   "first",
+		IssueURL:     "https://github.com/owner/repo/issues/1",
+		Status:       state.SessionStatusSuccess,
+		Branch:       "vigilante/issue-1-first",
+		WorktreePath: filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1"),
+	}}
+
+	updated, started, err := app.processGitHubIterationRequestsForTarget(context.Background(), state.WatchTarget{
+		Path:   repoPath,
+		Repo:   "owner/repo",
+		Branch: "main",
+	}, sessions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if started != 0 {
+		t.Fatalf("expected no iteration dispatches, got %d", started)
+	}
+	if updated[0].LastIterationCommentID != 101 {
+		t.Fatalf("expected rejected iteration comment to be recorded, got %#v", updated[0])
+	}
+}
+
+func TestProcessGitHubIterationRequestsForTargetDispatchesAssigneeComment(t *testing.T) {
+	now := time.Date(2026, 3, 19, 12, 0, 0, 0, time.UTC)
+	repoPath := t.TempDir()
+	stateRoot := t.TempDir()
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	t.Setenv("VIGILANTE_HOME", stateRoot)
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.clock = func() time.Time { return now }
+	app.state = state.NewStore()
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	app.repoLabelsProvisionedOnce["owner/repo"] = true
+
+	iterationContext := buildIterationPromptContext([]ghcli.IssueComment{
+		{
+			ID:        101,
+			Body:      "@vigilanteai first follow-up",
+			CreatedAt: now.Add(-2 * time.Minute),
+			User: struct {
+				Login string `json:"login"`
+			}{Login: "nicobistolfi"},
+		},
+		{
+			ID:        102,
+			Body:      "@vigilanteai tighten the validation path",
+			CreatedAt: now.Add(-1 * time.Minute),
+			User: struct {
+				Login string `json:"login"`
+			}{Login: "nicobistolfi"},
+		},
+	})
+	startSession := state.Session{
+		RepoPath:               repoPath,
+		Repo:                   "owner/repo",
+		Provider:               "codex",
+		IssueNumber:            1,
+		IssueTitle:             "first",
+		IssueURL:               "https://github.com/owner/repo/issues/1",
+		Status:                 state.SessionStatusSuccess,
+		Branch:                 "vigilante/issue-1-first",
+		WorktreePath:           worktreePath,
+		IssueBody:              "Original body",
+		IterationPromptContext: iterationContext,
+		IterationInProgress:    true,
+	}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1":          `{"title":"first","body":"Issue body","html_url":"https://github.com/owner/repo/issues/1","labels":[{"name":"vigilante:ready-for-review"}],"assignees":[{"login":"nicobistolfi"}]}`,
+			"gh api repos/owner/repo/issues/1/comments": `[{"id":101,"body":"@vigilanteai first follow-up","created_at":"2026-03-19T11:58:00Z","user":{"login":"nicobistolfi"}},{"id":102,"body":"@vigilanteai tighten the validation path","created_at":"2026-03-19T11:59:00Z","user":{"login":"nicobistolfi"}}]`,
+			"gh api --method POST -H Accept: application/vnd.github+json repos/owner/repo/issues/comments/102/reactions -f content=eyes": "ok",
+			"git worktree prune":                          "ok",
+			"git fetch origin main":                       "ok",
+			"git worktree list --porcelain":               "",
+			"git branch -f main refs/remotes/origin/main": "ok",
+			"git worktree add -b vigilante/issue-1-first " + worktreePath + " origin/main":                                                              "ok",
+			"gh issue edit --repo owner/repo 1 --add-label vigilante:iterating --add-label vigilante:running --remove-label vigilante:ready-for-review": "ok",
+			sessionStartCommentCommand("owner/repo", 1, worktreePath, state.Session{
+				Repo:                   "owner/repo",
+				IssueNumber:            1,
+				IssueTitle:             "first",
+				IssueBody:              "Issue body",
+				IssueURL:               "https://github.com/owner/repo/issues/1",
+				BaseBranch:             "main",
+				Branch:                 "vigilante/issue-1-first",
+				WorktreePath:           worktreePath,
+				Status:                 state.SessionStatusRunning,
+				Provider:               "codex",
+				IterationInProgress:    true,
+				IterationPromptContext: iterationContext,
+			}): "ok",
+			preflightPromptCommand(worktreePath, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1-first"): "ok",
+			issuePromptCommandForSession(worktreePath, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", state.Session{
+				WorktreePath:           worktreePath,
+				Branch:                 "vigilante/issue-1-first",
+				Provider:               "codex",
+				IssueBody:              "Issue body",
+				IterationPromptContext: iterationContext,
+			}): "done",
+			"gh issue edit --repo owner/repo 1 --add-label vigilante:ready-for-review --remove-label vigilante:iterating --remove-label vigilante:running": "ok",
+		},
+		Errors: map[string]error{
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1-first": errors.New("exit status 1"),
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1":       errors.New("exit status 1"),
+		},
+	}
+
+	sessions := []state.Session{startSession}
+	updated, started, err := app.processGitHubIterationRequestsForTarget(context.Background(), state.WatchTarget{
+		Path:   repoPath,
+		Repo:   "owner/repo",
+		Branch: "main",
+	}, sessions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if started != 1 {
+		t.Fatalf("expected one iteration dispatch, got %d", started)
+	}
+	app.waitForSessions()
+
+	saved, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(saved) != 1 {
+		t.Fatalf("expected one saved session, got %#v", saved)
+	}
+	if saved[0].LastIterationCommentID != 102 {
+		t.Fatalf("expected iteration comment tracking, got %#v", saved[0])
+	}
+	if saved[0].IssueBody != "Issue body" {
+		t.Fatalf("expected updated issue body, got %#v", saved[0])
+	}
+	if strings.TrimSpace(saved[0].IterationPromptContext) == "" {
+		t.Fatalf("expected iteration prompt context, got %#v", saved[0])
+	}
+	if saved[0].IterationInProgress {
+		t.Fatalf("expected iteration flag to clear after successful run, got %#v", saved[0])
+	}
+	if updated[0].Status != state.SessionStatusRunning {
+		t.Fatalf("expected in-memory session to be redispatched before completion, got %#v", updated[0])
+	}
+}
+
 func TestSyncIssueManagedLabelsQueued(t *testing.T) {
 	capture, shutdownTelemetry := setupTelemetryCapture(t)
 	app := New()
@@ -242,7 +441,7 @@ func TestSyncIssueManagedLabelsQueued(t *testing.T) {
 	app.stderr = testutil.IODiscard{}
 	app.env.Runner = testutil.FakeRunner{
 		Outputs: map[string]string{
-			"gh api repos/owner/repo/labels?per_page=100":                                                     `[{"name":"bug"},{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
+			"gh api repos/owner/repo/labels?per_page=100":                                                     `[{"name":"bug"},{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:iterating"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
 			"gh api repos/owner/repo/issues/7":                                                                `{"labels":[{"name":"bug"},{"name":"vigilante:running"}]}`,
 			"gh issue edit --repo owner/repo 7 --add-label vigilante:queued --remove-label vigilante:running": "ok",
 		},
@@ -275,7 +474,7 @@ func TestSyncIssueManagedLabelsNoopDoesNotEmitTelemetry(t *testing.T) {
 	app.stderr = testutil.IODiscard{}
 	app.env.Runner = testutil.FakeRunner{
 		Outputs: map[string]string{
-			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
+			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:iterating"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
 			"gh api repos/owner/repo/issues/7":            `{"labels":[{"name":"vigilante:queued"}]}`,
 		},
 	}
@@ -356,7 +555,7 @@ func TestSyncSessionIssueLabelsUsesPullRequestReviewState(t *testing.T) {
 	app.stderr = testutil.IODiscard{}
 	app.env.Runner = testutil.FakeRunner{
 		Outputs: map[string]string{
-			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
+			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:iterating"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
 			"gh pr view --repo owner/repo 17 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup": `{"number":17,"title":"Demo PR","body":"PR body","url":"https://github.com/owner/repo/pull/17","state":"OPEN","mergedAt":null,"labels":[],"isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[{"context":"test","state":"COMPLETED","conclusion":"SUCCESS"}]}`,
 			"gh api repos/owner/repo/issues/7": `{"labels":[{"name":"vigilante:ready-for-review"},{"name":"vigilante:needs-review"}]}`,
 			"gh issue edit --repo owner/repo 7 --add-label vigilante:awaiting-user-validation --remove-label vigilante:needs-review --remove-label vigilante:ready-for-review": "ok",
@@ -383,6 +582,7 @@ func TestSyncIssueManagedLabelsProvisionMissingRepositoryLabels(t *testing.T) {
 			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"bug"}]`,
 			"gh api --method POST repos/owner/repo/labels -f name=vigilante:queued -f color=BFDADC -f description=The issue is eligible for dispatch and waiting for a worker slot.":                                           "ok",
 			"gh api --method POST repos/owner/repo/labels -f name=vigilante:running -f color=0E8A16 -f description=A coding-agent session is currently executing for the issue.":                                               "ok",
+			"gh api --method POST repos/owner/repo/labels -f name=vigilante:iterating -f color=1D76DB -f description=An assignee-requested follow-up implementation iteration is actively in progress.":                        "ok",
 			"gh api --method POST repos/owner/repo/labels -f name=vigilante:blocked -f color=D93F0B -f description=Execution cannot continue until a blocker is resolved.":                                                     "ok",
 			"gh api --method POST repos/owner/repo/labels -f name=vigilante:recovering -f color=FBCA04 -f description=An automatic stale-session recovery attempt is actively rebuilding local execution state.":               "ok",
 			"gh api --method POST repos/owner/repo/labels -f name=vigilante:ready-for-review -f color=FBCA04 -f description=Implementation is complete enough for a human to review the resulting PR or branch.":               "ok",
@@ -5221,6 +5421,14 @@ func issuePromptCommand(worktreePath string, repo string, repoPath string, issue
 	))
 }
 
+func issuePromptCommandForSession(worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, session state.Session) string {
+	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePrompt(
+		state.WatchTarget{Path: repoPath, Repo: repo},
+		ghcli.Issue{Number: issueNumber, Title: title, URL: issueURL},
+		session,
+	))
+}
+
 func issuePromptCommandForProvider(providerID string, worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, branch string) string {
 	switch providerID {
 	case "gemini":
@@ -5241,14 +5449,6 @@ func preflightPromptCommand(worktreePath string, repo string, repoPath string, i
 
 func preflightPromptCommandForSession(worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, session state.Session) string {
 	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePreflightPrompt(
-		state.WatchTarget{Path: repoPath, Repo: repo},
-		ghcli.Issue{Number: issueNumber, Title: title, URL: issueURL},
-		session,
-	))
-}
-
-func issuePromptCommandForSession(worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, session state.Session) string {
-	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePrompt(
 		state.WatchTarget{Path: repoPath, Repo: repo},
 		ghcli.Issue{Number: issueNumber, Title: title, URL: issueURL},
 		session,

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -56,10 +56,15 @@ type IssueComment struct {
 }
 
 type IssueDetails struct {
-	Title  string  `json:"title"`
-	Body   string  `json:"body"`
-	URL    string  `json:"html_url"`
-	Labels []Label `json:"labels"`
+	Title     string         `json:"title"`
+	Body      string         `json:"body"`
+	URL       string         `json:"html_url"`
+	Labels    []Label        `json:"labels"`
+	Assignees []IssueUserRef `json:"assignees"`
+}
+
+type IssueUserRef struct {
+	Login string `json:"login"`
 }
 
 type RepositoryLabelDetails struct {
@@ -406,6 +411,64 @@ func FindCleanupComment(comments []IssueComment, claimedCommentID int64) *IssueC
 	return findCommandComment(comments, "@vigilanteai cleanup", claimedCommentID)
 }
 
+func FindIterationComment(comments []IssueComment, claimedCommentID int64) *IssueComment {
+	for i := len(comments) - 1; i >= 0; i-- {
+		if claimedCommentID != 0 && comments[i].ID == claimedCommentID {
+			continue
+		}
+		if !IsIterationComment(comments[i]) {
+			continue
+		}
+		return &comments[i]
+	}
+	return nil
+}
+
+func IsIterationComment(comment IssueComment) bool {
+	body := normalizeVigilanteComment(comment.Body)
+	if !strings.HasPrefix(body, "@vigilanteai") {
+		return false
+	}
+	if IsKnownVigilanteCommandComment(body) {
+		return false
+	}
+	return strings.TrimSpace(strings.TrimPrefix(body, "@vigilanteai")) != ""
+}
+
+func IsKnownVigilanteCommandComment(body string) bool {
+	switch normalizeVigilanteComment(body) {
+	case "@vigilanteai resume", "@vigilanteai cleanup":
+		return true
+	default:
+		return false
+	}
+}
+
+func AssigneeIterationComments(comments []IssueComment, assignees []string) []IssueComment {
+	if len(assignees) == 0 {
+		return nil
+	}
+	allowed := make(map[string]struct{}, len(assignees))
+	for _, assignee := range assignees {
+		login := strings.TrimSpace(strings.ToLower(assignee))
+		if login == "" {
+			continue
+		}
+		allowed[login] = struct{}{}
+	}
+	selected := make([]IssueComment, 0, len(comments))
+	for _, comment := range comments {
+		if !IsIterationComment(comment) {
+			continue
+		}
+		if _, ok := allowed[strings.ToLower(strings.TrimSpace(comment.User.Login))]; !ok {
+			continue
+		}
+		selected = append(selected, comment)
+	}
+	return selected
+}
+
 func LatestUserCommentTime(comments []IssueComment) time.Time {
 	for i := len(comments) - 1; i >= 0; i-- {
 		if IsUserComment(comments[i]) {
@@ -427,9 +490,10 @@ func IsUserComment(comment IssueComment) bool {
 }
 
 func findCommandComment(comments []IssueComment, command string, claimedCommentID int64) *IssueComment {
+	want := normalizeVigilanteComment(command)
 	for i := len(comments) - 1; i >= 0; i-- {
-		body := strings.TrimSpace(comments[i].Body)
-		if body != command {
+		body := normalizeVigilanteComment(comments[i].Body)
+		if body != want {
 			continue
 		}
 		if claimedCommentID != 0 && comments[i].ID == claimedCommentID {
@@ -438,6 +502,11 @@ func findCommandComment(comments []IssueComment, command string, claimedCommentI
 		return &comments[i]
 	}
 	return nil
+}
+
+func normalizeVigilanteComment(body string) string {
+	fields := strings.Fields(strings.ToLower(strings.TrimSpace(body)))
+	return strings.Join(fields, " ")
 }
 
 func FindPullRequestForBranch(ctx context.Context, runner environment.Runner, repo string, branch string) (*PullRequest, error) {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -362,6 +362,42 @@ func TestFindCleanupComment(t *testing.T) {
 	}
 }
 
+func TestFindIterationCommentSkipsKnownCommands(t *testing.T) {
+	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	comments := []IssueComment{
+		{ID: 10, Body: "@vigilanteai cleanup", CreatedAt: now.Add(-2 * time.Minute)},
+		{ID: 11, Body: "@vigilanteai please adjust the copy", CreatedAt: now.Add(-1 * time.Minute)},
+	}
+
+	comment := FindIterationComment(comments, 0)
+	if comment == nil || comment.ID != 11 {
+		t.Fatalf("expected iteration comment to be found, got: %#v", comment)
+	}
+	if comment := FindIterationComment(comments, 11); comment != nil {
+		t.Fatalf("expected claimed iteration comment to be ignored, got: %#v", comment)
+	}
+}
+
+func TestAssigneeIterationCommentsFiltersByAuthor(t *testing.T) {
+	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	comments := []IssueComment{
+		{ID: 10, Body: "@vigilanteai first pass", CreatedAt: now.Add(-3 * time.Minute), User: struct {
+			Login string `json:"login"`
+		}{Login: "nicobistolfi"}},
+		{ID: 11, Body: "@vigilanteai resume", CreatedAt: now.Add(-2 * time.Minute), User: struct {
+			Login string `json:"login"`
+		}{Login: "nicobistolfi"}},
+		{ID: 12, Body: "@vigilanteai second pass", CreatedAt: now.Add(-1 * time.Minute), User: struct {
+			Login string `json:"login"`
+		}{Login: "someoneelse"}},
+	}
+
+	filtered := AssigneeIterationComments(comments, []string{"nicobistolfi"})
+	if len(filtered) != 1 || filtered[0].ID != 10 {
+		t.Fatalf("unexpected assignee iteration comments: %#v", filtered)
+	}
+}
+
 func TestLatestUserCommentTimeIgnoresAutomationComments(t *testing.T) {
 	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
 	comments := []IssueComment{

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -24,6 +24,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 	selectedProvider, err := provider.Resolve(session.Provider)
 	if err != nil {
 		session.Status = state.SessionStatusFailed
+		session.IterationInProgress = false
 		session.LastError = err.Error()
 		session.EndedAt = time.Now().UTC().Format(time.RFC3339)
 		session.UpdatedAt = session.EndedAt
@@ -36,6 +37,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 	session.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 	if err := provider.ValidateRuntimeCompatibility(ctx, env.Runner, selectedProvider); err != nil {
 		session.Status = state.SessionStatusFailed
+		session.IterationInProgress = false
 		session.LastError = err.Error()
 		session.EndedAt = time.Now().UTC().Format(time.RFC3339)
 		session.UpdatedAt = session.EndedAt
@@ -69,6 +71,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 	appendSessionLog(logPath, "session started", session, "")
 	if err := ghcli.CommentOnIssue(ctx, env.Runner, target.Repo, issue.Number, startBody); err != nil {
 		session.Status = state.SessionStatusFailed
+		session.IterationInProgress = false
 		session.LastError = err.Error()
 		session.EndedAt = time.Now().UTC().Format(time.RFC3339)
 		session.UpdatedAt = session.EndedAt
@@ -79,6 +82,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 	preflightInvocation, err := selectedProvider.BuildIssuePreflightInvocation(provider.IssueTask{Target: target, Issue: issue, Session: session})
 	if err != nil {
 		session.Status = state.SessionStatusFailed
+		session.IterationInProgress = false
 		session.LastError = err.Error()
 		session.EndedAt = time.Now().UTC().Format(time.RFC3339)
 		session.LastHeartbeatAt = session.EndedAt
@@ -92,6 +96,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 	if err != nil {
 		if errors.Is(err, context.Canceled) || ctx.Err() != nil {
 			session.Status = state.SessionStatusFailed
+			session.IterationInProgress = false
 			session.LastError = "session canceled"
 			session.EndedAt = time.Now().UTC().Format(time.RFC3339)
 			session.LastHeartbeatAt = session.EndedAt
@@ -138,6 +143,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 	if err != nil {
 		if errors.Is(err, context.Canceled) || ctx.Err() != nil {
 			session.Status = state.SessionStatusFailed
+			session.IterationInProgress = false
 			session.LastError = "session canceled"
 			appendSessionLog(logPath, "session canceled", session, combineLogDetails(output, err.Error()))
 			return session
@@ -163,6 +169,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 	}
 
 	session.Status = state.SessionStatusSuccess
+	session.IterationInProgress = false
 	appendSessionLog(logPath, fmt.Sprintf("session succeeded duration=%s output_bytes=%d", time.Since(invocationStart).Truncate(time.Second), len(output)), session, output)
 	return session
 }

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -181,6 +181,15 @@ func BuildIssuePromptForRuntime(runtime string, target state.WatchTarget, issue 
 		"Use the same GitHub comment structure for every non-terminal milestone comment: a short header with the current stage and optional emoji, a 10-cell progress bar with percentage, an `ETA: ~N minutes` line, 1-3 concise bullets covering what just happened and what is next, and an optional short playful quote or tagline.",
 		"Use the issue as the source of truth for the requested behavior and keep the implementation minimal.",
 	)
+	if body := strings.TrimSpace(session.IssueBody); body != "" {
+		lines = append(lines,
+			"Full issue body:",
+			body,
+		)
+	}
+	if iterationContext := strings.TrimSpace(session.IterationPromptContext); iterationContext != "" {
+		lines = append(lines, iterationContext)
+	}
 	if strings.TrimSpace(session.ReusedRemoteBranch) != "" {
 		baseBranch := strings.TrimSpace(session.BaseBranch)
 		if baseBranch == "" {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -165,6 +165,31 @@ func TestBuildIssuePromptIncludesReusedRemoteBranchContext(t *testing.T) {
 	}
 }
 
+func TestBuildIssuePromptIncludesIssueBodyAndIterationContext(t *testing.T) {
+	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
+	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
+	session := state.Session{
+		WorktreePath:           "/tmp/worktree",
+		Branch:                 "vigilante/issue-12",
+		Provider:               "Codex",
+		IssueBody:              "Full issue body here.",
+		IterationPromptContext: "Iteration context for this pass:\nPrimary focus comment:\n@vigilanteai tighten the validation path",
+	}
+
+	prompt := BuildIssuePrompt(target, issue, session)
+
+	for _, text := range []string{
+		"Full issue body:",
+		"Full issue body here.",
+		"Iteration context for this pass:",
+		"@vigilanteai tighten the validation path",
+	} {
+		if !strings.Contains(prompt, text) {
+			t.Fatalf("prompt missing %q: %s", text, prompt)
+		}
+	}
+}
+
 func TestVigilanteSkillNamesIncludesLocalServiceDependencies(t *testing.T) {
 	foundLocalServices := false
 	foundComposeLaunch := false

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -95,6 +95,10 @@ type Session struct {
 	LastResumeFailureCommentedAt   string        `json:"last_resume_failure_commented_at,omitempty"`
 	LastDispatchFailureFingerprint string        `json:"last_dispatch_failure_fingerprint,omitempty"`
 	LastDispatchFailureCommentedAt string        `json:"last_dispatch_failure_commented_at,omitempty"`
+	LastIterationCommentID         int64         `json:"last_iteration_comment_id,omitempty"`
+	LastIterationCommentAt         string        `json:"last_iteration_comment_at,omitempty"`
+	IterationPromptContext         string        `json:"iteration_prompt_context,omitempty"`
+	IterationInProgress            bool          `json:"iteration_in_progress,omitempty"`
 	LastCleanupSource              string        `json:"last_cleanup_source,omitempty"`
 	LastCleanupCommentID           int64         `json:"last_cleanup_comment_id,omitempty"`
 	LastCleanupCommentAt           string        `json:"last_cleanup_comment_at,omitempty"`


### PR DESCRIPTION
## Summary
- add assignee-only freeform `@vigilanteai ...` iteration handling for active issues while preserving `resume` and `cleanup` command precedence
- add the `vigilante:iterating` managed label and propagate iteration context into issue prompts
- cover comment classification, authorization, label sync, prompt construction, and app dispatch flow with tests

## Validation
- `go test ./...`

Closes #241