### PR TITLE
Install bundled Vigilante skills for all providers during setup

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -569,7 +569,7 @@ func (a *App) SetupWithProvider(ctx context.Context, installDaemon bool, provide
 	if err := a.ensureTooling(ctx, selectedProvider); err != nil {
 		return err
 	}
-	if err := selectedProvider.EnsureRuntimeInstalled(a.state); err != nil {
+	if err := a.installBundledSkills(); err != nil {
 		return err
 	}
 	if installDaemon {
@@ -579,6 +579,22 @@ func (a *App) SetupWithProvider(ctx context.Context, installDaemon bool, provide
 	}
 	a.state.AppendDaemonLog("setup complete install_daemon=%t", installDaemon)
 	fmt.Fprintln(a.stdout, "setup complete")
+	return nil
+}
+
+func (a *App) installBundledSkills() error {
+	for _, runtimeHome := range []struct {
+		runtime string
+		home    string
+	}{
+		{runtime: skill.RuntimeCodex, home: a.state.CodexHome()},
+		{runtime: skill.RuntimeClaude, home: a.state.ClaudeHome()},
+		{runtime: skill.RuntimeGemini, home: a.state.GeminiHome()},
+	} {
+		if err := skill.EnsureInstalled(runtimeHome.runtime, runtimeHome.home); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -877,11 +877,13 @@ func TestRunDaemonCommandKeepsIntervalOverride(t *testing.T) {
 	}
 }
 
-func TestSetupCreatesStateLayoutAndSkill(t *testing.T) {
+func TestSetupCreatesStateLayoutAndInstallsBundledSkillsForAllProviders(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
 	t.Setenv("HOME", home)
 	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+	t.Setenv("CLAUDE_HOME", filepath.Join(home, ".claude"))
+	t.Setenv("GEMINI_HOME", filepath.Join(home, ".gemini"))
 
 	app := New()
 	app.stdout = testutil.IODiscard{}
@@ -903,6 +905,7 @@ func TestSetupCreatesStateLayoutAndSkill(t *testing.T) {
 		filepath.Join(app.state.Root(), "sessions.json"),
 		filepath.Join(app.state.Root(), "logs"),
 		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteIssueImplementation, "SKILL.md"),
+		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteIssueImplementation, "agents", "openai.yaml"),
 		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteIssueImplementationOnMonorepo, "SKILL.md"),
 		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteIssueImplementationOnTurborepo, "SKILL.md"),
 		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteIssueImplementationOnNx, "SKILL.md"),
@@ -910,6 +913,10 @@ func TestSetupCreatesStateLayoutAndSkill(t *testing.T) {
 		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteIssueImplementationOnRushMonorepo, "SKILL.md"),
 		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteConflictResolution, "SKILL.md"),
 		filepath.Join(app.state.CodexHome(), "skills", skill.DockerComposeLaunch, "SKILL.md"),
+		filepath.Join(app.state.ClaudeHome(), "skills", skill.VigilanteIssueImplementation, "SKILL.md"),
+		filepath.Join(app.state.ClaudeHome(), "commands", skill.VigilanteIssueImplementation, "SKILL.md"),
+		filepath.Join(app.state.GeminiHome(), "skills", skill.VigilanteIssueImplementation, "SKILL.md"),
+		filepath.Join(app.state.GeminiHome(), "commands", skill.VigilanteIssueImplementation+".toml"),
 	} {
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("expected %s to exist: %v", path, err)
@@ -917,10 +924,12 @@ func TestSetupCreatesStateLayoutAndSkill(t *testing.T) {
 	}
 }
 
-func TestSetupWithGeminiCreatesGeminiSkillAssets(t *testing.T) {
+func TestSetupWithGeminiInstallsBundledSkillsForAllProviders(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
 	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+	t.Setenv("CLAUDE_HOME", filepath.Join(home, ".claude"))
 	t.Setenv("GEMINI_HOME", filepath.Join(home, ".gemini"))
 
 	app := New()
@@ -939,6 +948,9 @@ func TestSetupWithGeminiCreatesGeminiSkillAssets(t *testing.T) {
 	}
 
 	for _, path := range []string{
+		filepath.Join(app.state.CodexHome(), "skills", skill.VigilanteIssueImplementation, "SKILL.md"),
+		filepath.Join(app.state.ClaudeHome(), "skills", skill.VigilanteIssueImplementation, "SKILL.md"),
+		filepath.Join(app.state.ClaudeHome(), "commands", skill.VigilanteIssueImplementation, "SKILL.md"),
 		filepath.Join(app.state.GeminiHome(), "skills", skill.VigilanteIssueImplementation, "SKILL.md"),
 		filepath.Join(app.state.GeminiHome(), "commands", skill.VigilanteIssueImplementation+".toml"),
 		filepath.Join(app.state.GeminiHome(), "skills", skill.VigilanteIssueImplementationOnRushMonorepo, "SKILL.md"),


### PR DESCRIPTION
## Summary
- refresh bundled Vigilante skill assets for Codex, Claude Code, and Gemini during setup
- keep provider CLI validation scoped to the selected setup provider
- add regression coverage for the multi-runtime setup behavior

## Validation
- go test ./...

Closes #247
