### PR TITLE
Set native GitHub follow-up issue relationships

### DIFF
--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -699,6 +699,30 @@ func TestVigilanteCreateIssueSkillDocumentsNativeIssueTypeFallback(t *testing.T)
 	}
 }
 
+func TestVigilanteCreateIssueSkillDocumentsNativeIssueRelationships(t *testing.T) {
+	body, err := os.ReadFile(repoSkillPath(VigilanteCreateIssue))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	text := string(body)
+	for _, snippet := range []string{
+		"When the draft explicitly says the new issue is a follow-up, child, or sub-issue of a specific existing issue, carry that parent issue number through issue creation.",
+		"After the base issue is created, attach it as a native GitHub sub-issue of that parent with `vigilante gh api --method POST repos/{owner}/{repo}/issues/{parent_issue_number}/sub_issues -f sub_issue_id={created_issue_id}`.",
+		"Only create a native relationship when the parent mapping is explicit and low-ambiguity; incidental issue-number mentions in prose are not enough.",
+		"If native sub-issue creation fails or the repository does not support it, keep the created issue, preserve the body text reference, and make the fallback explicit in the final response.",
+		"If the native sub-issue relationship request is rejected or unsupported, do not fail the overall issue creation flow; keep the new issue and report that the relationship fell back to body-only text.",
+		"Do not infer parent/child issue links from vague wording or unrelated issue references.",
+		"explicit follow-up or child relationships are attached as native GitHub sub-issues when the parent issue is clearly identified",
+		"ambiguous issue references do not create native parent/child links",
+		"the final response says whether the native sub-issue relationship was created or whether issue creation fell back to body-only linking",
+	} {
+		if !strings.Contains(text, snippet) {
+			t.Fatalf("skill missing %q", snippet)
+		}
+	}
+}
+
 func TestVigilanteCreateIssueSkillIncludesTypeSpecificDetailGuidance(t *testing.T) {
 	body, err := os.ReadFile(repoSkillPath(VigilanteCreateIssue))
 	if err != nil {

--- a/skills/vigilante-create-issue/SKILL.md
+++ b/skills/vigilante-create-issue/SKILL.md
@@ -58,12 +58,17 @@ Produce a GitHub issue that is:
 - Prefer `vigilante gh api repos/{owner}/{repo}/issues` over `vigilante gh issue create` when opening the final issue so Vigilante can set GitHub's native issue type with the request body `type` field.
 - Map Vigilante's internal classifications explicitly to GitHub's native issue types: `feature` -> `Feature`, `bug` -> `Bug`, `task` -> `Task`.
 - Treat the native GitHub issue type as the source of truth whenever the repository supports it.
+- When the draft explicitly says the new issue is a follow-up, child, or sub-issue of a specific existing issue, carry that parent issue number through issue creation.
+- After the base issue is created, attach it as a native GitHub sub-issue of that parent with `vigilante gh api --method POST repos/{owner}/{repo}/issues/{parent_issue_number}/sub_issues -f sub_issue_id={created_issue_id}`.
+- Only create a native relationship when the parent mapping is explicit and low-ambiguity; incidental issue-number mentions in prose are not enough.
+- If native sub-issue creation fails or the repository does not support it, keep the created issue, preserve the body text reference, and make the fallback explicit in the final response.
 - Use the polished Markdown body as the issue content instead of stopping at the draft.
 - In the final response, include the created issue URL or issue number and keep the body available if useful.
 
 8. Fall back cleanly when issue creation is blocked
 - If issue creation cannot be completed because repository context is missing, `gh` auth is unavailable, network access is blocked, or sandbox restrictions prevent GitHub access, say so briefly and return the ready-to-file Markdown issue instead.
 - If the repository rejects the native `type` field because issue types are unavailable or unsupported, retry issue creation without the native type and make the fallback explicit in the final response.
+- If the native sub-issue relationship request is rejected or unsupported, do not fail the overall issue creation flow; keep the new issue and report that the relationship fell back to body-only text.
 - If the environment supports requesting escalation for GitHub/network access, do that before giving up.
 - If the user explicitly asks for a draft only, honor that request and do not create the issue.
 - Keep failure messaging short, specific, and factual.
@@ -72,6 +77,7 @@ Produce a GitHub issue that is:
 - Always classify the request as `feature`, `bug`, or `task` before finalizing the issue.
 - When creating the issue on GitHub, write that classification into GitHub's native issue type field whenever the repository supports it.
 - Do not use labels or issue-body text as the primary type representation when the native issue type is set successfully.
+- Do not infer parent/child issue links from vague wording or unrelated issue references.
 - Only include an `Issue Type: ...` line in the issue body when returning a draft without creating the issue, or when native issue types are unavailable and the fallback needs to preserve the classification explicitly.
 - When the type was inferred from an ambiguous request, note that clearly, for example `Issue Type: task (inferred)`, but only in the draft/fallback body when that line is needed.
 - For `bug` issues, prioritize current behavior, expected behavior, impact, reproduction clues, and regression risk.
@@ -182,6 +188,8 @@ Before creating the issue or returning the fallback draft, verify that:
 - the problem is understandable without extra oral context
 - the selected issue type is `feature`, `bug`, or `task`
 - the native GitHub issue type is used when the issue is created in a repository that supports it
+- explicit follow-up or child relationships are attached as native GitHub sub-issues when the parent issue is clearly identified
+- ambiguous issue references do not create native parent/child links
 - any `Issue Type:` line in the body is reserved for draft-only or explicit fallback output
 - the desired outcome is observable
 - the acceptance criteria are testable
@@ -190,4 +198,5 @@ Before creating the issue or returning the fallback draft, verify that:
 - the issue gives Vigilante enough direction to implement without guessing the basics
 - the target repository is known before attempting issue creation
 - the final response includes the created issue URL or number when creation succeeds
+- the final response says whether the native sub-issue relationship was created or whether issue creation fell back to body-only linking
 - the fallback response states briefly why issue creation was not completed when it fails


### PR DESCRIPTION
## Summary
- update the `vigilante-create-issue` skill to attach explicit follow-up issues as native GitHub sub-issues after creation
- keep issue creation non-fatal when the relationship call is unsupported or rejected, and require fallback reporting
- add guardrail tests that lock in the new relationship guidance

## Validation
- `go test ./internal/skill`

Closes #250
