### PR TITLE
Clean up issue worktrees for closed issues and PRs

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -848,6 +848,10 @@ func (a *App) ScanOnce(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		sessions, err = a.cleanupClosedIssueSessions(ctx, sessions)
+		if err != nil {
+			return err
+		}
 		sessions, err = a.maintainPullRequests(ctx, sessions)
 		if err != nil {
 			return err
@@ -1135,10 +1139,11 @@ func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session
 		updatePullRequestTrackingFromLookup(session, *pr)
 		if pr.MergedAt == nil {
 			if pr.State != "OPEN" {
-				session.MonitoringStoppedAt = a.clock().Format(time.RFC3339)
-				session.LastMaintenanceError = ""
-				session.UpdatedAt = session.MonitoringStoppedAt
-				a.state.AppendDaemonLog("monitoring stopped repo=%s issue=%d pr=%d branch=%s state=%s", session.Repo, session.IssueNumber, pr.Number, session.Branch, pr.State)
+				if err := a.cleanupSessionArtifacts(ctx, session, "pull_request_closed"); err != nil {
+					a.state.AppendDaemonLog("cleanup failed repo=%s issue=%d pr=%d branch=%s worktree=%s source=pull_request_closed state=%s err=%v", session.Repo, session.IssueNumber, pr.Number, session.Branch, session.WorktreePath, pr.State, err)
+					continue
+				}
+				a.state.AppendDaemonLog("cleanup complete repo=%s issue=%d pr=%d branch=%s worktree=%s source=pull_request_closed state=%s", session.Repo, session.IssueNumber, pr.Number, session.Branch, session.WorktreePath, pr.State)
 				a.syncSessionIssueLabelsBestEffort(ctx, *session, pr)
 				continue
 			}
@@ -1175,18 +1180,13 @@ func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session
 		}
 
 		session.PullRequestMergedAt = pr.MergedAt.UTC().Format(time.RFC3339)
-		if err := worktree.CleanupIssueArtifacts(ctx, a.env.Runner, session.RepoPath, session.WorktreePath, session.Branch); err != nil {
-			session.CleanupError = err.Error()
-			session.UpdatedAt = a.clock().Format(time.RFC3339)
-			a.state.AppendDaemonLog("cleanup failed repo=%s issue=%d branch=%s worktree=%s err=%v", session.Repo, session.IssueNumber, session.Branch, session.WorktreePath, err)
+		if err := a.cleanupSessionArtifacts(ctx, session, "pull_request_merged"); err != nil {
+			a.state.AppendDaemonLog("cleanup failed repo=%s issue=%d pr=%d branch=%s worktree=%s source=pull_request_merged merged_at=%s err=%v", session.Repo, session.IssueNumber, session.PullRequestNumber, session.Branch, session.WorktreePath, session.PullRequestMergedAt, err)
 			continue
 		}
 
-		session.CleanupCompletedAt = a.clock().Format(time.RFC3339)
-		session.CleanupError = ""
-		session.UpdatedAt = session.CleanupCompletedAt
 		a.state.AppendDaemonLog(
-			"cleanup complete repo=%s issue=%d pr=%d branch=%s worktree=%s merged_at=%s",
+			"cleanup complete repo=%s issue=%d pr=%d branch=%s worktree=%s source=pull_request_merged merged_at=%s",
 			session.Repo,
 			session.IssueNumber,
 			session.PullRequestNumber,
@@ -1198,6 +1198,52 @@ func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session
 	}
 
 	return sessions, nil
+}
+
+func (a *App) cleanupClosedIssueSessions(ctx context.Context, sessions []state.Session) ([]state.Session, error) {
+	for i := range sessions {
+		session := &sessions[i]
+		if session.Status != state.SessionStatusSuccess || session.CleanupCompletedAt != "" || session.MonitoringStoppedAt != "" {
+			continue
+		}
+
+		issue, err := ghcli.GetIssueDetails(ctx, a.env.Runner, session.Repo, session.IssueNumber)
+		if err != nil {
+			session.LastMaintenanceError = err.Error()
+			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			a.state.AppendDaemonLog("issue lookup failed repo=%s issue=%d branch=%s err=%v", session.Repo, session.IssueNumber, session.Branch, err)
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(issue.State), "closed") {
+			continue
+		}
+
+		if err := a.cleanupSessionArtifacts(ctx, session, "issue_closed"); err != nil {
+			a.state.AppendDaemonLog("cleanup failed repo=%s issue=%d branch=%s worktree=%s source=issue_closed err=%v", session.Repo, session.IssueNumber, session.Branch, session.WorktreePath, err)
+			continue
+		}
+
+		a.state.AppendDaemonLog("cleanup complete repo=%s issue=%d branch=%s worktree=%s source=issue_closed", session.Repo, session.IssueNumber, session.Branch, session.WorktreePath)
+		a.syncSessionIssueLabelsBestEffort(ctx, *session, nil)
+	}
+
+	return sessions, nil
+}
+
+func (a *App) cleanupSessionArtifacts(ctx context.Context, session *state.Session, source string) error {
+	now := a.clock().Format(time.RFC3339)
+	session.LastCleanupSource = source
+	if err := worktree.CleanupIssueArtifacts(ctx, a.env.Runner, session.RepoPath, session.WorktreePath, session.Branch); err != nil {
+		session.CleanupError = err.Error()
+		session.UpdatedAt = now
+		return err
+	}
+
+	session.CleanupCompletedAt = now
+	session.CleanupError = ""
+	session.LastMaintenanceError = ""
+	session.UpdatedAt = now
+	return nil
 }
 
 func (a *App) launchIssueSession(ctx context.Context, target state.WatchTarget, issue ghcli.Issue, session state.Session) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -4399,6 +4399,7 @@ func TestScanOnceCleansUpMergedIssueSession(t *testing.T) {
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1": `{"title":"first","body":"Issue body","html_url":"https://github.com/owner/repo/issues/1","state":"open","labels":[]}`,
 			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"MERGED","mergedAt":"2026-03-10T15:00:00Z"}]`,
 			"git worktree prune":                                         "ok",
 			"git worktree list --porcelain":                              "worktree /tmp/repo\nHEAD abcdef\nbranch refs/heads/main\n",
@@ -4469,6 +4470,7 @@ func TestScanOnceMaintainsOpenPullRequest(t *testing.T) {
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1": `{"title":"first","body":"Issue body","html_url":"https://github.com/owner/repo/issues/1","state":"open","labels":[]}`,
 			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
 			"git fetch origin main":  "ok",
 			"git status --porcelain": "",
@@ -4540,6 +4542,184 @@ func TestScanOnceMaintainsOpenPullRequest(t *testing.T) {
 	}
 	if sessions[0].LastMaintenanceError != "" {
 		t.Fatalf("unexpected maintenance error: %#v", sessions[0])
+	}
+}
+
+func TestScanOnceCleansUpClosedPullRequestSession(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	var stdout bytes.Buffer
+	app := New()
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1": `{"title":"first","body":"Issue body","html_url":"https://github.com/owner/repo/issues/1","state":"open","labels":[]}`,
+			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"CLOSED","mergedAt":null}]`,
+			"git worktree prune":                                         "ok",
+			"git worktree list --porcelain":                              "worktree /tmp/repo\nHEAD abcdef\nbranch refs/heads/main\n",
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": "ok",
+			"git branch -D vigilante/issue-1":                            "Deleted branch vigilante/issue-1\n",
+			"gh api user --jq .login":                                    "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:     "/tmp/repo",
+		Repo:         "owner/repo",
+		IssueNumber:  1,
+		Branch:       "vigilante/issue-1",
+		WorktreePath: filepath.Join("/tmp/repo", ".worktrees", "vigilante", "issue-1"),
+		Status:       state.SessionStatusSuccess,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	app.waitForSessions()
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if sessions[0].PullRequestState != "CLOSED" {
+		t.Fatalf("expected closed pull request state to be tracked: %#v", sessions[0])
+	}
+	if sessions[0].CleanupCompletedAt == "" || sessions[0].CleanupError != "" {
+		t.Fatalf("expected successful cleanup for closed pull request: %#v", sessions[0])
+	}
+	if sessions[0].MonitoringStoppedAt != "" {
+		t.Fatalf("expected closed pull request cleanup instead of monitoring stop: %#v", sessions[0])
+	}
+	if sessions[0].LastCleanupSource != "pull_request_closed" {
+		t.Fatalf("expected pull_request_closed cleanup source: %#v", sessions[0])
+	}
+}
+
+func TestScanOnceCleansUpClosedIssueSession(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	var stdout bytes.Buffer
+	app := New()
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1":                           `{"title":"first","body":"Issue body","html_url":"https://github.com/owner/repo/issues/1","state":"closed","labels":[]}`,
+			"git worktree prune":                                         "ok",
+			"git worktree list --porcelain":                              "worktree /tmp/repo\nHEAD abcdef\nbranch refs/heads/main\n",
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": "ok",
+			"git branch -D vigilante/issue-1":                            "Deleted branch vigilante/issue-1\n",
+			"gh api user --jq .login":                                    "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:     "/tmp/repo",
+		Repo:         "owner/repo",
+		IssueNumber:  1,
+		Branch:       "vigilante/issue-1",
+		WorktreePath: filepath.Join("/tmp/repo", ".worktrees", "vigilante", "issue-1"),
+		Status:       state.SessionStatusSuccess,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	app.waitForSessions()
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if sessions[0].CleanupCompletedAt == "" || sessions[0].CleanupError != "" {
+		t.Fatalf("expected successful cleanup for closed issue: %#v", sessions[0])
+	}
+	if sessions[0].LastCleanupSource != "issue_closed" {
+		t.Fatalf("expected issue_closed cleanup source: %#v", sessions[0])
+	}
+}
+
+func TestScanOnceDoesNotCleanUpOpenIssueSessionWithoutPullRequest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	var stdout bytes.Buffer
+	app := New()
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1": `{"title":"first","body":"Issue body","html_url":"https://github.com/owner/repo/issues/1","state":"open","labels":[]}`,
+			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": "[]",
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:     "/tmp/repo",
+		Repo:         "owner/repo",
+		IssueNumber:  1,
+		Branch:       "vigilante/issue-1",
+		WorktreePath: filepath.Join("/tmp/repo", ".worktrees", "vigilante", "issue-1"),
+		Status:       state.SessionStatusSuccess,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	app.waitForSessions()
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if sessions[0].CleanupCompletedAt != "" || sessions[0].CleanupError != "" {
+		t.Fatalf("expected open issue session to remain active: %#v", sessions[0])
+	}
+	if sessions[0].LastCleanupSource != "" {
+		t.Fatalf("expected no cleanup source for open issue session: %#v", sessions[0])
 	}
 }
 
@@ -4844,6 +5024,9 @@ func newPullRequestMaintenanceTestApp(t *testing.T, outputs map[string]string) (
 	app := New()
 	app.stdout = &stdout
 	app.stderr = testutil.IODiscard{}
+	outputs = mergeStringMaps(map[string]string{
+		"gh api repos/owner/repo/issues/1": `{"title":"first","body":"Issue body","html_url":"https://github.com/owner/repo/issues/1","state":"open","labels":[]}`,
+	}, outputs)
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs:   outputs,

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -59,6 +59,7 @@ type IssueDetails struct {
 	Title     string         `json:"title"`
 	Body      string         `json:"body"`
 	URL       string         `json:"html_url"`
+	State     string         `json:"state"`
 	Labels    []Label        `json:"labels"`
 	Assignees []IssueUserRef `json:"assignees"`
 }


### PR DESCRIPTION
## Summary
- clean up local issue artifacts when a tracked issue is closed
- treat closed pull requests as terminal cleanup states alongside merged pull requests
- add regression coverage for closed issues, closed PRs, merged PRs, and open sessions that must not be cleaned up

## Validation
- `go test ./...`

Closes #251
