### PR TITLE
Emit OTEL telemetry for downstream rate limits

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2927,7 +2927,9 @@ func (a *App) recordSessionFailure(session *state.Session, stage string, operati
 }
 
 func classifyBlockedReason(stage string, operation string, err error) state.BlockedReason {
-	return blocking.Classify(stage, operation, err.Error(), summarizeMaintenanceError(err))
+	blocked := blocking.Classify(stage, operation, err.Error(), summarizeMaintenanceError(err))
+	telemetry.CaptureDownstreamRateLimit(stage, operation, blocked, err.Error())
+	return blocked
 }
 
 func markSessionBlocked(session *state.Session, stage string, blocked state.BlockedReason, now time.Time) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1549,6 +1549,28 @@ func TestClassifyBlockedReasonDetectsProviderQuota(t *testing.T) {
 	}
 }
 
+func TestClassifyBlockedReasonEmitsGitHubRateLimitTelemetry(t *testing.T) {
+	capture, shutdownTelemetry := setupTelemetryCapture(t)
+
+	_ = classifyBlockedReason("dispatch", "gh api", errors.New("API rate limit exceeded for user ID 12345"))
+	if err := shutdownTelemetry(); err != nil {
+		t.Fatalf("shutdown telemetry: %v", err)
+	}
+
+	if len(capture.events) != 1 {
+		t.Fatalf("expected 1 telemetry event, got %d", len(capture.events))
+	}
+	if got, want := capture.events[0].Event, "downstream_service_rate_limited"; got != want {
+		t.Fatalf("event = %q, want %q", got, want)
+	}
+	if got, want := capture.events[0].Properties["service"], "github"; got != want {
+		t.Fatalf("service = %v, want %q", got, want)
+	}
+	if got, want := capture.events[0].Properties["classification"], "rate_limit"; got != want {
+		t.Fatalf("classification = %v, want %q", got, want)
+	}
+}
+
 func TestListRunningSessions(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nicobistolfi/vigilante/internal/logtime"
 	"github.com/nicobistolfi/vigilante/internal/provider"
 	"github.com/nicobistolfi/vigilante/internal/state"
+	"github.com/nicobistolfi/vigilante/internal/telemetry"
 )
 
 func RunIssueSession(ctx context.Context, env *environment.Environment, store *state.Store, target state.WatchTarget, issue ghcli.Issue, session state.Session) state.Session {
@@ -300,7 +301,10 @@ func buildResumeHint(session state.Session) string {
 }
 
 func classifyBlockedFailure(stage string, operation string, output string, err error) state.BlockedReason {
-	return blocking.Classify(stage, operation, strings.TrimSpace(output+"\n"+err.Error()), summarizeError(err))
+	diagnostic := strings.TrimSpace(output + "\n" + err.Error())
+	blocked := blocking.Classify(stage, operation, diagnostic, summarizeError(err))
+	telemetry.CaptureDownstreamRateLimit(stage, operation, blocked, diagnostic)
+	return blocked
 }
 
 func blockedPreflightMessage(blocked state.BlockedReason, providerID string) string {

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -2,7 +2,11 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +18,7 @@ import (
 	"github.com/nicobistolfi/vigilante/internal/repo"
 	"github.com/nicobistolfi/vigilante/internal/skill"
 	"github.com/nicobistolfi/vigilante/internal/state"
+	"github.com/nicobistolfi/vigilante/internal/telemetry"
 	"github.com/nicobistolfi/vigilante/internal/testutil"
 )
 
@@ -536,6 +541,82 @@ func TestClassifyBlockedFailureDetectsProviderQuota(t *testing.T) {
 	}
 	if !strings.Contains(got.Detail, "You've hit your usage limit.") {
 		t.Fatalf("expected detail to preserve provider output, got %q", got.Detail)
+	}
+}
+
+func TestClassifyBlockedFailureEmitsProviderQuotaTelemetry(t *testing.T) {
+	var events []struct {
+		Event      string         `json:"event"`
+		Properties map[string]any `json:"properties"`
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read telemetry request: %v", err)
+		}
+		var payload struct {
+			Messages []json.RawMessage `json:"batch"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("parse telemetry batch: %v", err)
+		}
+		events = events[:0]
+		for _, raw := range payload.Messages {
+			var event struct {
+				Event      string         `json:"event"`
+				Properties map[string]any `json:"properties"`
+			}
+			if err := json.Unmarshal(raw, &event); err != nil {
+				t.Fatalf("parse telemetry event: %v", err)
+			}
+			events = append(events, event)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	manager, err := telemetry.Setup(context.Background(), telemetry.SetupConfig{
+		BuildInfo: telemetry.BuildInfo{
+			Version:           "1.2.3",
+			Distro:            "direct",
+			TelemetryEndpoint: server.URL,
+			TelemetryToken:    "token",
+		},
+		StateRoot: t.TempDir(),
+		EnvLookup: func(string) string { return "" },
+	})
+	if err != nil {
+		t.Fatalf("setup telemetry: %v", err)
+	}
+	telemetry.SetDefault(manager)
+	t.Cleanup(func() {
+		telemetry.SetDefault(nil)
+	})
+
+	_ = classifyBlockedFailure("issue_execution", "codex exec", "You've hit your usage limit. Purchase more credits with token sk-live-secret.", errors.New("exit status 1"))
+	if err := manager.Shutdown(context.Background()); err != nil {
+		t.Fatalf("shutdown telemetry: %v", err)
+	}
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 telemetry event, got %d", len(events))
+	}
+	if got, want := events[0].Event, "downstream_service_rate_limited"; got != want {
+		t.Fatalf("event = %q, want %q", got, want)
+	}
+	if got, want := events[0].Properties["service"], "provider"; got != want {
+		t.Fatalf("service = %v, want %q", got, want)
+	}
+	if got, want := events[0].Properties["classification"], "quota"; got != want {
+		t.Fatalf("classification = %v, want %q", got, want)
+	}
+	encoded, err := json.Marshal(events[0])
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if strings.Contains(string(encoded), "sk-live-secret") {
+		t.Fatalf("expected bounded telemetry payload, got %s", encoded)
 	}
 }
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/nicobistolfi/vigilante/internal/state"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	otellog "go.opentelemetry.io/otel/log"
@@ -466,6 +467,75 @@ func (m *Manager) CaptureWorkflowEvent(event string, properties map[string]any) 
 	})
 }
 
+func CaptureDownstreamRateLimit(stage string, operation string, blocked state.BlockedReason, diagnostic string) {
+	defaultManagerMu.RLock()
+	manager := defaultManager
+	defaultManagerMu.RUnlock()
+	if manager == nil {
+		return
+	}
+	manager.CaptureDownstreamRateLimit(stage, operation, blocked, diagnostic)
+}
+
+func (m *Manager) CaptureDownstreamRateLimit(stage string, operation string, blocked state.BlockedReason, diagnostic string) {
+	if m == nil {
+		return
+	}
+
+	classification, retryable, ok := classifyDownstreamRateLimit(blocked, diagnostic)
+	if !ok {
+		return
+	}
+
+	service := downstreamServiceCategory(operation, blocked, diagnostic)
+	properties := map[string]any{
+		"feature_area":     "downstream_service",
+		"invocation":       "daemon",
+		"stage":            strings.TrimSpace(stage),
+		"operation":        boundedOperation(operation),
+		"service":          service,
+		"classification":   classification,
+		"retryable":        retryable,
+		"blocked_kind":     strings.TrimSpace(blocked.Kind),
+		"blocked_stage":    strings.TrimSpace(stage),
+		"result":           "failure",
+		"telemetry_signal": "downstream_rate_limit",
+	}
+
+	if m.provider != nil {
+		record := otellog.Record{}
+		now := time.Now().UTC()
+		record.SetEventName("downstream.rate_limit")
+		record.SetTimestamp(now)
+		record.SetObservedTimestamp(now)
+		record.SetBody(otellog.StringValue("downstream service rate limited"))
+		record.SetSeverity(otellog.SeverityError)
+		record.SetSeverityText("ERROR")
+		record.AddAttributes(
+			otellog.KeyValueFromAttribute(attribute.String("downstream.service", service)),
+			otellog.KeyValueFromAttribute(attribute.String("downstream.operation", boundedOperation(operation))),
+			otellog.KeyValueFromAttribute(attribute.String("downstream.classification", classification)),
+			otellog.KeyValueFromAttribute(attribute.Bool("downstream.retryable", retryable)),
+			otellog.KeyValueFromAttribute(attribute.String("session.blocked_kind", strings.TrimSpace(blocked.Kind))),
+			otellog.KeyValueFromAttribute(attribute.String("session.blocked_stage", strings.TrimSpace(stage))),
+			otellog.KeyValueFromAttribute(attribute.String("platform.os", runtime.GOOS)),
+			otellog.KeyValueFromAttribute(attribute.String("platform.arch", runtime.GOARCH)),
+			otellog.KeyValueFromAttribute(attribute.String("app.version", m.version)),
+			otellog.KeyValueFromAttribute(attribute.String("distro", m.distro)),
+		)
+		m.logger.Emit(context.Background(), record)
+	}
+
+	m.enqueueAnalytics(analyticsEvent{
+		Type:       "capture",
+		UUID:       uuid.NewString(),
+		Timestamp:  time.Now().UTC(),
+		DistinctID: m.anonID,
+		Event:      "downstream_service_rate_limited",
+		Properties: m.workflowProperties(properties),
+	})
+}
+
 func (m *Manager) commandProperties(commandName string) map[string]any {
 	commandGroup := commandGroup(commandName)
 	return map[string]any{
@@ -516,6 +586,55 @@ func commandGroup(commandName string) string {
 		return "root"
 	}
 	return parts[0]
+}
+
+func classifyDownstreamRateLimit(blocked state.BlockedReason, diagnostic string) (classification string, retryable bool, ok bool) {
+	if strings.TrimSpace(blocked.Kind) == "provider_quota" {
+		return "quota", false, true
+	}
+
+	lower := strings.ToLower(strings.TrimSpace(diagnostic))
+	switch {
+	case strings.Contains(lower, "secondary rate limit"),
+		strings.Contains(lower, "api rate limit exceeded"),
+		strings.Contains(lower, "rate limit exceeded"),
+		strings.Contains(lower, "rate limit reached"),
+		strings.Contains(lower, "too many requests"),
+		strings.Contains(lower, "http 429"),
+		strings.Contains(lower, "status 429"):
+		return "rate_limit", true, true
+	case strings.Contains(lower, "usage limit"),
+		strings.Contains(lower, "quota exceeded"),
+		(strings.Contains(lower, "credits") && strings.Contains(lower, "purchase more")):
+		return "quota", false, true
+	default:
+		return "", false, false
+	}
+}
+
+func downstreamServiceCategory(operation string, blocked state.BlockedReason, diagnostic string) string {
+	joined := strings.ToLower(strings.Join([]string{operation, blocked.Kind, diagnostic}, "\n"))
+	switch {
+	case strings.Contains(joined, "gh "), strings.Contains(joined, "github"), strings.Contains(joined, "graphql"), strings.Contains(joined, "api rate limit exceeded"):
+		return "github"
+	case strings.Contains(joined, "codex"), strings.Contains(joined, "claude"), strings.Contains(joined, "gemini"), strings.Contains(joined, "provider_"):
+		return "provider"
+	case strings.Contains(joined, "otlp"), strings.Contains(joined, "telemetry"):
+		return "telemetry_export"
+	default:
+		return "unknown"
+	}
+}
+
+func boundedOperation(operation string) string {
+	operation = strings.TrimSpace(operation)
+	if operation == "" {
+		return "unknown"
+	}
+	if len(operation) > 80 {
+		return strings.TrimSpace(operation[:80])
+	}
+	return operation
 }
 
 func commandFeatureArea(commandGroup string) string {

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -3,6 +3,7 @@ package telemetry
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nicobistolfi/vigilante/internal/state"
 	otellog "go.opentelemetry.io/otel/log"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 )
@@ -407,6 +409,156 @@ func TestCaptureWorkflowEventUsesDefaultManagerAndBoundedProperties(t *testing.T
 	}
 	if got, want := events[0].Properties["platform_os"], runtime.GOOS; got != want {
 		t.Fatalf("platform_os = %v, want %q", got, want)
+	}
+}
+
+func TestCaptureDownstreamRateLimitEmitsBoundedProviderQuotaSignal(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	exporter := &captureExporter{}
+	analytics := &captureAnalyticsExporter{}
+	manager, err := Setup(context.Background(), SetupConfig{
+		BuildInfo: BuildInfo{
+			Version:           "1.2.3",
+			Distro:            "direct",
+			TelemetryEndpoint: "otel.example.test",
+			TelemetryToken:    "token",
+			TelemetryURLPath:  "/i/v1/logs",
+		},
+		StateRoot: root,
+		EnvLookup: func(string) string { return "" },
+		NewExporter: func(context.Context, BuildInfo) (sdklog.Exporter, error) {
+			return exporter, nil
+		},
+		NewAnalyticsExporter: func(BuildInfo, string) (analyticsExporter, error) {
+			return analytics, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Setup() error = %v", err)
+	}
+
+	SetDefault(manager)
+	t.Cleanup(func() {
+		SetDefault(nil)
+	})
+
+	CaptureDownstreamRateLimit("issue_execution", "codex exec", state.BlockedReason{Kind: "provider_quota"}, "You've hit your usage limit. Purchase more credits with token sk-live-secret.")
+	if err := manager.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+
+	records := exporter.Records()
+	if len(records) != 1 {
+		t.Fatalf("expected 1 exported record, got %d", len(records))
+	}
+
+	record := records[0]
+	if got, want := record.EventName(), "downstream.rate_limit"; got != want {
+		t.Fatalf("record.EventName() = %q, want %q", got, want)
+	}
+	if got, want := record.Severity(), otellog.SeverityError; got != want {
+		t.Fatalf("record.Severity() = %v, want %v", got, want)
+	}
+	if got, want := record.Body().AsString(), "downstream service rate limited"; got != want {
+		t.Fatalf("record.Body() = %q, want %q", got, want)
+	}
+
+	attrs := map[string]otellog.Value{}
+	record.WalkAttributes(func(kv otellog.KeyValue) bool {
+		attrs[kv.Key] = kv.Value
+		return true
+	})
+	if got, want := attrs["downstream.service"].AsString(), "provider"; got != want {
+		t.Fatalf("downstream.service = %q, want %q", got, want)
+	}
+	if got, want := attrs["downstream.operation"].AsString(), "codex exec"; got != want {
+		t.Fatalf("downstream.operation = %q, want %q", got, want)
+	}
+	if got, want := attrs["downstream.classification"].AsString(), "quota"; got != want {
+		t.Fatalf("downstream.classification = %q, want %q", got, want)
+	}
+	if got, want := attrs["downstream.retryable"].AsBool(), false; got != want {
+		t.Fatalf("downstream.retryable = %v, want %v", got, want)
+	}
+
+	events := analytics.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 analytics event, got %d", len(events))
+	}
+	if got, want := events[0].Event, "downstream_service_rate_limited"; got != want {
+		t.Fatalf("events[0].Event = %q, want %q", got, want)
+	}
+	if got, want := events[0].Properties["service"], "provider"; got != want {
+		t.Fatalf("service = %v, want %q", got, want)
+	}
+	if got, want := events[0].Properties["classification"], "quota"; got != want {
+		t.Fatalf("classification = %v, want %q", got, want)
+	}
+	encoded, err := json.Marshal(events[0])
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if strings.Contains(string(encoded), "sk-live-secret") {
+		t.Fatalf("expected telemetry payload to omit raw diagnostic details, got %s", encoded)
+	}
+}
+
+func TestCaptureDownstreamRateLimitDetectsGitHubRateLimit(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	exporter := &captureExporter{}
+	manager, err := Setup(context.Background(), SetupConfig{
+		BuildInfo: BuildInfo{
+			Version:           "1.2.3",
+			Distro:            "direct",
+			TelemetryEndpoint: "otel.example.test",
+			TelemetryToken:    "token",
+			TelemetryURLPath:  "/i/v1/logs",
+		},
+		StateRoot: root,
+		EnvLookup: func(string) string { return "" },
+		NewExporter: func(context.Context, BuildInfo) (sdklog.Exporter, error) {
+			return exporter, nil
+		},
+		NewAnalyticsExporter: func(BuildInfo, string) (analyticsExporter, error) {
+			return &captureAnalyticsExporter{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Setup() error = %v", err)
+	}
+
+	SetDefault(manager)
+	t.Cleanup(func() {
+		SetDefault(nil)
+	})
+
+	CaptureDownstreamRateLimit("dispatch", "gh api", state.BlockedReason{Kind: "provider_runtime_error"}, "API rate limit exceeded for github user 12345.")
+	if err := manager.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+
+	records := exporter.Records()
+	if len(records) != 1 {
+		t.Fatalf("expected 1 exported record, got %d", len(records))
+	}
+
+	attrs := map[string]otellog.Value{}
+	records[0].WalkAttributes(func(kv otellog.KeyValue) bool {
+		attrs[kv.Key] = kv.Value
+		return true
+	})
+	if got, want := attrs["downstream.service"].AsString(), "github"; got != want {
+		t.Fatalf("downstream.service = %q, want %q", got, want)
+	}
+	if got, want := attrs["downstream.classification"].AsString(), "rate_limit"; got != want {
+		t.Fatalf("downstream.classification = %q, want %q", got, want)
+	}
+	if got, want := attrs["downstream.retryable"].AsBool(), true; got != want {
+		t.Fatalf("downstream.retryable = %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- emit a dedicated downstream rate-limit/quota telemetry signal with bounded OTEL log attributes and analytics properties
- trigger that signal from both runner-side provider failures and app-side daemon/service failures
- add focused coverage for provider quota, GitHub/API throttling, and privacy-safe payloads

## Validation
- go test ./internal/telemetry ./internal/runner ./internal/app

Closes #256
