### PR TITLE
Monitor GitHub rate limits before exhaustion

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Once a folder is registered, `vigilante` should:
 
 In the current implementation, that worker loop already covers repository onboarding, issue intake, isolated worktrees, provider orchestration, repo-aware execution skills, local session recovery, and part of the pull request maintenance path. CI/CD promotion and richer deployment control are planned next-stage capabilities.
 
+Vigilante also monitors GitHub REST API quota through `gh api /rate_limit` before GitHub-heavy orchestration work. When the REST core bucket drops below `100` remaining requests, Vigilante posts one delay notice per affected issue for that reset window, pauses additional GitHub-backed work, and resumes automatically after GitHub's reported reset time.
+
 ## Telemetry
 
 Vigilante emits anonymous telemetry with two different purposes:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -34,6 +34,7 @@ const defaultScanInterval = 1 * time.Minute
 const defaultAssigneeFilter = "me"
 const defaultStalledSessionThreshold = 10 * time.Minute
 const defaultMaintenanceAutoRecoveryTimeout = 10 * time.Minute
+const githubCoreLowQuotaThreshold = 100
 const unsetMaxParallel = -2147483648
 const autoRecoverySource = "auto_recovery"
 
@@ -86,7 +87,15 @@ type App struct {
 	cancels                   map[string]context.CancelFunc
 	repoLabelProvisioningMu   sync.Mutex
 	repoLabelsProvisionedOnce map[string]bool
+	githubRateLimitMu         sync.Mutex
+	githubRateLimitState      githubRateLimitState
 	proxyExec                 func(context.Context, io.Reader, io.Writer, io.Writer, string, ...string) (int, error)
+}
+
+type githubRateLimitState struct {
+	Active   bool
+	ResetAt  time.Time
+	Snapshot ghcli.RateLimitSnapshot
 }
 
 type stringListFlag []string
@@ -177,6 +186,22 @@ func (a *App) emitLabelSyncEvent(added []string, removed []string) {
 		"removed_labels": append([]string(nil), removed...),
 		"add_count":      len(added),
 		"remove_count":   len(removed),
+	})
+}
+
+func (a *App) emitGitHubRateLimitEvent(state string, snapshot ghcli.RateLimitSnapshot) {
+	telemetry.CaptureWorkflowEvent("github_rate_limit_state_changed", map[string]any{
+		"feature_area":   "github_rate_limit",
+		"invocation":     "daemon",
+		"state":          strings.TrimSpace(state),
+		"core_remaining": snapshot.Core.Remaining,
+		"core_limit":     snapshot.Core.Limit,
+		"core_reset_at":  snapshot.Core.ResetAt.Format(time.RFC3339),
+		"graphql_limit":  snapshot.GraphQL.Limit,
+		"graphql_remain": snapshot.GraphQL.Remaining,
+		"search_limit":   snapshot.Search.Limit,
+		"search_remain":  snapshot.Search.Remaining,
+		"healthy_cutoff": githubCoreLowQuotaThreshold,
 	})
 }
 
@@ -849,6 +874,18 @@ func (a *App) ScanOnce(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		sessions, throttled, err := a.enforceGitHubRateLimit(ctx, sessions)
+		if err != nil {
+			return err
+		}
+		if throttled {
+			if err := a.state.SaveSessions(sessions); err != nil {
+				return err
+			}
+			fmt.Fprintln(a.stdout, "scan paused: GitHub REST core quota is below the low-quota threshold")
+			a.state.AppendDaemonLog("scan paused by github rate limit")
+			return nil
+		}
 		sessions, err = a.processGitHubCleanupRequests(ctx, sessions)
 		if err != nil {
 			return err
@@ -1133,6 +1170,99 @@ func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Sessi
 	}
 
 	return sessions, nil
+}
+
+func (a *App) enforceGitHubRateLimit(ctx context.Context, sessions []state.Session) ([]state.Session, bool, error) {
+	now := a.clock()
+	if snapshot, active, resumed := a.currentGitHubRateLimitState(now); active {
+		a.state.AppendDaemonLog("github rate limit pause active core_remaining=%d reset_at=%s", snapshot.Core.Remaining, snapshot.Core.ResetAt.Format(time.RFC3339))
+		return a.notifyGitHubLowQuotaSessions(ctx, sessions, snapshot), true, nil
+	} else if resumed {
+		a.state.AppendDaemonLog("github rate limit pause expired; refreshing snapshot")
+	}
+
+	snapshot, err := ghcli.GetRateLimitSnapshot(ctx, a.env.Runner)
+	if err != nil {
+		a.state.AppendDaemonLog("github rate limit fetch failed err=%v", err)
+		return sessions, false, nil
+	}
+	if snapshot.Core.Remaining >= githubCoreLowQuotaThreshold {
+		return sessions, false, nil
+	}
+
+	a.setGitHubRateLimitState(snapshot)
+	a.state.AppendDaemonLog("github rate limit pause entered core_remaining=%d reset_at=%s", snapshot.Core.Remaining, snapshot.Core.ResetAt.Format(time.RFC3339))
+	return a.notifyGitHubLowQuotaSessions(ctx, sessions, snapshot), true, nil
+}
+
+func (a *App) currentGitHubRateLimitState(now time.Time) (ghcli.RateLimitSnapshot, bool, bool) {
+	a.githubRateLimitMu.Lock()
+	defer a.githubRateLimitMu.Unlock()
+
+	if !a.githubRateLimitState.Active {
+		return ghcli.RateLimitSnapshot{}, false, false
+	}
+	if now.Before(a.githubRateLimitState.ResetAt) {
+		return a.githubRateLimitState.Snapshot, true, false
+	}
+
+	snapshot := a.githubRateLimitState.Snapshot
+	a.githubRateLimitState = githubRateLimitState{}
+	a.emitGitHubRateLimitEvent("resumed", snapshot)
+	return ghcli.RateLimitSnapshot{}, false, true
+}
+
+func (a *App) setGitHubRateLimitState(snapshot ghcli.RateLimitSnapshot) {
+	a.githubRateLimitMu.Lock()
+	a.githubRateLimitState = githubRateLimitState{
+		Active:   true,
+		ResetAt:  snapshot.Core.ResetAt,
+		Snapshot: snapshot,
+	}
+	a.githubRateLimitMu.Unlock()
+	a.emitGitHubRateLimitEvent("paused", snapshot)
+}
+
+func (a *App) notifyGitHubLowQuotaSessions(ctx context.Context, sessions []state.Session, snapshot ghcli.RateLimitSnapshot) []state.Session {
+	resetAt := snapshot.Core.ResetAt.Format(time.RFC3339)
+	for i := range sessions {
+		session := &sessions[i]
+		if !sessionAffectedByGitHubRateLimitPause(*session) {
+			continue
+		}
+		if session.LastGitHubDelayResetAt == resetAt {
+			continue
+		}
+
+		body := ghcli.FormatGitHubRateLimitDelayComment(snapshot, githubCoreLowQuotaThreshold, a.clock())
+		if err := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "rate_limit_delay", "github_rate_limit"); err != nil {
+			a.state.AppendDaemonLog("github rate limit delay comment failed repo=%s issue=%d err=%v", session.Repo, session.IssueNumber, err)
+			session.LastError = err.Error()
+			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			continue
+		}
+		session.LastGitHubDelayResetAt = resetAt
+		session.LastGitHubDelayCommentedAt = a.clock().Format(time.RFC3339)
+		session.UpdatedAt = session.LastGitHubDelayCommentedAt
+	}
+	return sessions
+}
+
+func sessionAffectedByGitHubRateLimitPause(session state.Session) bool {
+	if session.IssueNumber <= 0 {
+		return false
+	}
+	if strings.TrimSpace(session.Repo) == "" || session.CleanupCompletedAt != "" || session.MonitoringStoppedAt != "" {
+		return false
+	}
+	switch session.Status {
+	case state.SessionStatusRunning, state.SessionStatusResuming:
+		return true
+	case state.SessionStatusSuccess:
+		return session.PullRequestNumber > 0 && !strings.EqualFold(strings.TrimSpace(session.PullRequestState), "closed") && !strings.EqualFold(strings.TrimSpace(session.PullRequestState), "merged")
+	default:
+		return false
+	}
 }
 
 func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session) ([]state.Session, error) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -3624,6 +3624,7 @@ func TestScanOnceSelectsEligibleIssueAndPersistsSession(t *testing.T) {
 	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
 
 	app := New()
+	app.clock = func() time.Time { return time.Date(2026, 3, 19, 21, 55, 0, 0, time.UTC) }
 	app.stdout = &bytes.Buffer{}
 	app.stderr = testutil.IODiscard{}
 	worktreePath := filepath.Join("/tmp/repo", ".worktrees", "vigilante", "issue-1")
@@ -3632,6 +3633,7 @@ func TestScanOnceSelectsEligibleIssueAndPersistsSession(t *testing.T) {
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: mergeStringMaps(freshBaseBranchOutputs("/tmp/repo", "main"), map[string]string{
 			"gh auth status":          "ok",
+			"gh api /rate_limit":      `{"resources":{"core":{"limit":5000,"remaining":150,"reset":1773961151},"rate":{"limit":5000,"remaining":150,"reset":1773961151},"graphql":{"limit":5000,"remaining":4557,"reset":1773961792},"search":{"limit":30,"remaining":30,"reset":1773961093}}}`,
 			"gh api user --jq .login": "nicobistolfi\n",
 			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[{"name":"to-do"}]}]`,
 			"git worktree prune": "ok",
@@ -3675,6 +3677,159 @@ func TestScanOnceSelectsEligibleIssueAndPersistsSession(t *testing.T) {
 	}
 	if len(sessions) != 1 || sessions[0].Status != state.SessionStatusSuccess {
 		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+}
+
+func TestScanOncePausesWhenGitHubCoreRateLimitIsLowAndCommentsActiveIssues(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	now := time.Date(2026, 3, 19, 21, 55, 0, 0, time.UTC)
+	resetAt := time.Unix(1773961151, 0).Local()
+	app := New()
+	app.clock = func() time.Time { return now }
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"gh": "/usr/bin/gh"},
+		Outputs: map[string]string{
+			"gh api /rate_limit": `{"resources":{"core":{"limit":5000,"remaining":95,"reset":1773961151},"rate":{"limit":5000,"remaining":95,"reset":1773961151},"graphql":{"limit":5000,"remaining":4557,"reset":1773961792},"search":{"limit":30,"remaining":30,"reset":1773961093}}}`,
+			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatGitHubRateLimitDelayComment(ghcli.RateLimitSnapshot{
+				Core:    ghcli.RateLimitResource{Limit: 5000, Remaining: 95, ResetAt: resetAt},
+				Rate:    ghcli.RateLimitResource{Limit: 5000, Remaining: 95, ResetAt: resetAt},
+				GraphQL: ghcli.RateLimitResource{Limit: 5000, Remaining: 4557, ResetAt: time.Unix(1773961792, 0).Local()},
+				Search:  ghcli.RateLimitResource{Limit: 30, Remaining: 30, ResetAt: time.Unix(1773961093, 0).Local()},
+			}, githubCoreLowQuotaThreshold, now): "ok",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:     "/tmp/repo",
+		Repo:         "owner/repo",
+		IssueNumber:  7,
+		IssueTitle:   "active work",
+		IssueURL:     "https://github.com/owner/repo/issues/7",
+		Branch:       "vigilante/issue-7",
+		WorktreePath: "/tmp/repo/.worktrees/vigilante/issue-7",
+		Status:       state.SessionStatusRunning,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := stdout.String(); !strings.Contains(got, "scan paused: GitHub REST core quota is below the low-quota threshold") {
+		t.Fatalf("unexpected stdout: %s", got)
+	}
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions[0].LastGitHubDelayResetAt != resetAt.UTC().Format(time.RFC3339) && sessions[0].LastGitHubDelayResetAt != resetAt.Format(time.RFC3339) {
+		t.Fatalf("expected dedupe reset marker, got %#v", sessions[0])
+	}
+}
+
+func TestScanOnceSuppressesDuplicateGitHubLowQuotaCommentsWithinSameResetWindow(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	now := time.Date(2026, 3, 19, 21, 55, 0, 0, time.UTC)
+	resetAt := time.Unix(1773961151, 0).Local()
+	app := New()
+	app.clock = func() time.Time { return now }
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"gh": "/usr/bin/gh"},
+		Outputs: map[string]string{
+			"gh api /rate_limit": `{"resources":{"core":{"limit":5000,"remaining":95,"reset":1773961151},"rate":{"limit":5000,"remaining":95,"reset":1773961151},"graphql":{"limit":5000,"remaining":4557,"reset":1773961792},"search":{"limit":30,"remaining":30,"reset":1773961093}}}`,
+			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatGitHubRateLimitDelayComment(ghcli.RateLimitSnapshot{
+				Core:    ghcli.RateLimitResource{Limit: 5000, Remaining: 95, ResetAt: resetAt},
+				Rate:    ghcli.RateLimitResource{Limit: 5000, Remaining: 95, ResetAt: resetAt},
+				GraphQL: ghcli.RateLimitResource{Limit: 5000, Remaining: 4557, ResetAt: time.Unix(1773961792, 0).Local()},
+				Search:  ghcli.RateLimitResource{Limit: 30, Remaining: 30, ResetAt: time.Unix(1773961093, 0).Local()},
+			}, githubCoreLowQuotaThreshold, now): "ok",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:               "/tmp/repo",
+		Repo:                   "owner/repo",
+		IssueNumber:            7,
+		IssueTitle:             "active work",
+		IssueURL:               "https://github.com/owner/repo/issues/7",
+		Branch:                 "vigilante/issue-7",
+		WorktreePath:           "/tmp/repo/.worktrees/vigilante/issue-7",
+		Status:                 state.SessionStatusRunning,
+		LastGitHubDelayResetAt: resetAt.Format(time.RFC3339),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestScanOnceResumesAfterGitHubRateLimitResetWindowPasses(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	now := time.Date(2026, 3, 19, 23, 5, 0, 0, time.UTC)
+	resetAt := time.Unix(1773961151, 0).Local()
+	app := New()
+	app.clock = func() time.Time { return now }
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.githubRateLimitState = githubRateLimitState{
+		Active:  true,
+		ResetAt: resetAt,
+		Snapshot: ghcli.RateLimitSnapshot{
+			Core: ghcli.RateLimitResource{Limit: 5000, Remaining: 95, ResetAt: resetAt},
+		},
+	}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"gh": "/usr/bin/gh"},
+		Outputs: map[string]string{
+			"gh api /rate_limit":      `{"resources":{"core":{"limit":5000,"remaining":150,"reset":1773964751},"rate":{"limit":5000,"remaining":150,"reset":1773964751},"graphql":{"limit":5000,"remaining":4557,"reset":1773961792},"search":{"limit":30,"remaining":30,"reset":1773961093}}}`,
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(stdout.String(), "scan paused: GitHub REST core quota is below the low-quota threshold") {
+		t.Fatalf("expected scan to resume after reset, got: %s", stdout.String())
+	}
+	if app.githubRateLimitState.Active {
+		t.Fatalf("expected in-memory rate-limit pause to clear after reset")
 	}
 }
 

--- a/internal/github/comment_format.go
+++ b/internal/github/comment_format.go
@@ -3,6 +3,7 @@ package ghcli
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 type ProgressComment struct {
@@ -78,6 +79,38 @@ func FormatDispatchFailureComment(comment DispatchFailureComment) string {
 	})
 }
 
+func FormatGitHubRateLimitDelayComment(snapshot RateLimitSnapshot, threshold int, now time.Time) string {
+	lines := []string{
+		"## ⏸️ GitHub Delay Window",
+		progressLine(70),
+		fmt.Sprintf("`ETA: ~%s`", formatMinutes(minutesUntil(now, snapshot.Core.ResetAt))),
+		fmt.Sprintf("- GitHub REST core quota fell below the safety threshold (`%d` remaining), so Vigilante is pausing GitHub-backed work for this issue.", threshold),
+		fmt.Sprintf("- Automatic resume is scheduled after `%s`.", formatAbsoluteTime(snapshot.Core.ResetAt)),
+		"- Vigilante will resume automatically after the GitHub-provided reset time without manual intervention.",
+		"",
+		FormatGitHubRateLimitSnapshot(snapshot),
+		"",
+		"> \"Waiting beats failing at the limit.\"",
+	}
+	return strings.Join(lines, "\n")
+}
+
+func FormatGitHubRateLimitSnapshot(snapshot RateLimitSnapshot) string {
+	rate := snapshot.Rate
+	if rate.Limit == 0 {
+		rate = snapshot.Core
+	}
+	lines := []string{
+		"gh api /rate_limit returned:",
+		"",
+		fmt.Sprintf("  - core: %d/%d used, %d remaining, resets at %s", usedRequests(snapshot.Core), snapshot.Core.Limit, snapshot.Core.Remaining, formatAbsoluteTime(snapshot.Core.ResetAt)),
+		fmt.Sprintf("  - rate (same as core): %d/%d used, %d remaining, resets at %s", usedRequests(rate), rate.Limit, rate.Remaining, formatAbsoluteTime(rate.ResetAt)),
+		fmt.Sprintf("  - graphql: %d/%d used, %d remaining, resets at %s", usedRequests(snapshot.GraphQL), snapshot.GraphQL.Limit, snapshot.GraphQL.Remaining, formatAbsoluteTime(snapshot.GraphQL.ResetAt)),
+		fmt.Sprintf("  - search: %d/%d used, %d remaining, resets at %s", usedRequests(snapshot.Search), snapshot.Search.Limit, snapshot.Search.Remaining, formatAbsoluteTime(snapshot.Search.ResetAt)),
+	}
+	return strings.Join(lines, "\n")
+}
+
 func fallbackCommentValue(value string, fallback string) string {
 	value = strings.TrimSpace(value)
 	if value == "" {
@@ -113,4 +146,37 @@ func formatMinutes(minutes int) string {
 		return "1 minute"
 	}
 	return fmt.Sprintf("%d minutes", minutes)
+}
+
+func usedRequests(resource RateLimitResource) int {
+	used := resource.Limit - resource.Remaining
+	if used < 0 {
+		return 0
+	}
+	return used
+}
+
+func formatAbsoluteTime(ts time.Time) string {
+	if ts.IsZero() {
+		return "unknown"
+	}
+	return ts.Format("2006-01-02 15:04:05 -07:00")
+}
+
+func minutesUntil(now time.Time, resetAt time.Time) int {
+	if resetAt.IsZero() {
+		return 1
+	}
+	if !resetAt.After(now) {
+		return 1
+	}
+	duration := resetAt.Sub(now)
+	minutes := int(duration / time.Minute)
+	if duration%time.Minute != 0 {
+		minutes++
+	}
+	if minutes < 1 {
+		return 1
+	}
+	return minutes
 }

--- a/internal/github/comment_format_test.go
+++ b/internal/github/comment_format_test.go
@@ -3,6 +3,7 @@ package ghcli
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestFormatProgressComment(t *testing.T) {
@@ -66,6 +67,33 @@ func TestFormatDispatchFailureComment(t *testing.T) {
 	expected := "## 🧱 Blocked\nProgress: [#---------] 15%\n`ETA: ~10 minutes`\n- Failure stage: `issue startup`. Summary: `codex CLI version 2.0.0 is incompatible with this Vigilante build`.\n- Branch: `vigilante/issue-149`. Worktree: `/tmp/repo/.worktrees/vigilante/issue-149`.\n- Next step: fix the local `codex` runtime, then run `vigilante resume --repo owner/repo --issue 149` or request resume from GitHub.\n> \"No silent stalls.\""
 	if comment != expected {
 		t.Fatalf("unexpected comment:\n%s", comment)
+	}
+}
+
+func TestFormatGitHubRateLimitDelayComment(t *testing.T) {
+	now := time.Date(2026, 3, 19, 21, 55, 0, 0, time.UTC)
+	snapshot := RateLimitSnapshot{
+		Core:    RateLimitResource{Limit: 5000, Remaining: 95, ResetAt: time.Date(2026, 3, 19, 14, 59, 11, 0, time.FixedZone("PDT", -7*60*60))},
+		Rate:    RateLimitResource{Limit: 5000, Remaining: 95, ResetAt: time.Date(2026, 3, 19, 14, 59, 11, 0, time.FixedZone("PDT", -7*60*60))},
+		GraphQL: RateLimitResource{Limit: 5000, Remaining: 4557, ResetAt: time.Date(2026, 3, 19, 15, 9, 52, 0, time.FixedZone("PDT", -7*60*60))},
+		Search:  RateLimitResource{Limit: 30, Remaining: 30, ResetAt: time.Date(2026, 3, 19, 14, 58, 13, 0, time.FixedZone("PDT", -7*60*60))},
+	}
+
+	comment := FormatGitHubRateLimitDelayComment(snapshot, 100, now)
+	for _, want := range []string{
+		"## ⏸️ GitHub Delay Window",
+		"Progress: [#######---] 70%",
+		"`ETA: ~5 minutes`",
+		"gh api /rate_limit returned:",
+		"  - core: 4905/5000 used, 95 remaining, resets at 2026-03-19 14:59:11 -07:00",
+		"  - rate (same as core): 4905/5000 used, 95 remaining, resets at 2026-03-19 14:59:11 -07:00",
+		"  - graphql: 443/5000 used, 4557 remaining, resets at 2026-03-19 15:09:52 -07:00",
+		"  - search: 0/30 used, 30 remaining, resets at 2026-03-19 14:58:13 -07:00",
+		"Automatic resume is scheduled after `2026-03-19 14:59:11 -07:00`.",
+	} {
+		if !strings.Contains(comment, want) {
+			t.Fatalf("expected comment to contain %q, got:\n%s", want, comment)
+		}
 	}
 }
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -72,6 +72,34 @@ type RepositoryLabelDetails struct {
 	Name string `json:"name"`
 }
 
+type RateLimitResource struct {
+	Limit     int
+	Remaining int
+	ResetAt   time.Time
+}
+
+type RateLimitSnapshot struct {
+	Core    RateLimitResource
+	Rate    RateLimitResource
+	GraphQL RateLimitResource
+	Search  RateLimitResource
+}
+
+type rateLimitAPIResponse struct {
+	Resources struct {
+		Core    rateLimitAPIResource `json:"core"`
+		Rate    rateLimitAPIResource `json:"rate"`
+		GraphQL rateLimitAPIResource `json:"graphql"`
+		Search  rateLimitAPIResource `json:"search"`
+	} `json:"resources"`
+}
+
+type rateLimitAPIResource struct {
+	Limit     int   `json:"limit"`
+	Remaining int   `json:"remaining"`
+	Reset     int64 `json:"reset"`
+}
+
 func ListOpenIssues(ctx context.Context, runner environment.Runner, repo string, assignee string) ([]Issue, error) {
 	resolvedAssignee, err := resolveAssignee(ctx, runner, assignee)
 	if err != nil {
@@ -192,6 +220,40 @@ func matchesLabelAllowlist(issue Issue, allowlist []string) bool {
 func CommentOnIssue(ctx context.Context, runner environment.Runner, repo string, number int, body string) error {
 	_, err := runner.Run(ctx, "", "gh", "issue", "comment", "--repo", repo, fmt.Sprintf("%d", number), "--body", body)
 	return err
+}
+
+func GetRateLimitSnapshot(ctx context.Context, runner environment.Runner) (RateLimitSnapshot, error) {
+	output, err := runner.Run(ctx, "", "gh", "api", "/rate_limit")
+	if err != nil {
+		return RateLimitSnapshot{}, err
+	}
+
+	var response rateLimitAPIResponse
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &response); err != nil {
+		return RateLimitSnapshot{}, fmt.Errorf("parse gh rate limit output: %w", err)
+	}
+
+	snapshot := RateLimitSnapshot{
+		Core:    normalizeRateLimitResource(response.Resources.Core),
+		Rate:    normalizeRateLimitResource(response.Resources.Rate),
+		GraphQL: normalizeRateLimitResource(response.Resources.GraphQL),
+		Search:  normalizeRateLimitResource(response.Resources.Search),
+	}
+	if snapshot.Rate.Limit == 0 {
+		snapshot.Rate = snapshot.Core
+	}
+	return snapshot, nil
+}
+
+func normalizeRateLimitResource(resource rateLimitAPIResource) RateLimitResource {
+	snapshot := RateLimitResource{
+		Limit:     resource.Limit,
+		Remaining: resource.Remaining,
+	}
+	if resource.Reset > 0 {
+		snapshot.ResetAt = time.Unix(resource.Reset, 0).Local()
+	}
+	return snapshot
 }
 
 func GetIssueDetails(ctx context.Context, runner environment.Runner, repo string, number int) (*IssueDetails, error) {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -180,6 +180,28 @@ func TestListOpenIssuesReturnsErrorWhenResolvingMeFails(t *testing.T) {
 	}
 }
 
+func TestGetRateLimitSnapshot(t *testing.T) {
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api /rate_limit": `{"resources":{"core":{"limit":5000,"remaining":95,"reset":1773961151},"rate":{"limit":5000,"remaining":95,"reset":1773961151},"graphql":{"limit":5000,"remaining":4557,"reset":1773961792},"search":{"limit":30,"remaining":30,"reset":1773961093}}}`,
+		},
+	}
+
+	snapshot, err := GetRateLimitSnapshot(context.Background(), runner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Core.Limit != 5000 || snapshot.Core.Remaining != 95 {
+		t.Fatalf("unexpected core snapshot: %#v", snapshot.Core)
+	}
+	if snapshot.GraphQL.Remaining != 4557 || snapshot.Search.Limit != 30 {
+		t.Fatalf("unexpected snapshot: %#v", snapshot)
+	}
+	if snapshot.Core.ResetAt.IsZero() || snapshot.Rate.ResetAt.IsZero() {
+		t.Fatalf("expected reset timestamps: %#v", snapshot)
+	}
+}
+
 func TestSyncIssueLabelsAddsAndRemovesManagedLabels(t *testing.T) {
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -95,6 +95,8 @@ type Session struct {
 	LastResumeFailureCommentedAt   string        `json:"last_resume_failure_commented_at,omitempty"`
 	LastDispatchFailureFingerprint string        `json:"last_dispatch_failure_fingerprint,omitempty"`
 	LastDispatchFailureCommentedAt string        `json:"last_dispatch_failure_commented_at,omitempty"`
+	LastGitHubDelayResetAt         string        `json:"last_github_delay_reset_at,omitempty"`
+	LastGitHubDelayCommentedAt     string        `json:"last_github_delay_commented_at,omitempty"`
 	LastIterationCommentID         int64         `json:"last_iteration_comment_id,omitempty"`
 	LastIterationCommentAt         string        `json:"last_iteration_comment_at,omitempty"`
 	IterationPromptContext         string        `json:"iteration_prompt_context,omitempty"`


### PR DESCRIPTION
## Summary
- add a shared GitHub `/rate_limit` snapshot helper and human-readable delay comment formatting
- pause GitHub-backed scan work when the REST core bucket drops below `100`, notify affected active issues once per reset window, and resume automatically after reset
- cover the new rate-limit parsing, thresholding, deduplication, resume flow, and README note with tests

## Validation
- `go test ./...`

Closes #257
