### PR TITLE
Fix README release workflow badge status

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/nicobistolfi/vigilante)](https://goreportcard.com/report/github.com/nicobistolfi/vigilante)
 [![Go Package Search](https://img.shields.io/badge/go-package%20search-00ADD8?logo=go&logoColor=white)](https://pkg.go.dev/search?q=github.com%2Fnicobistolfi%2Fvigilante)
 [![License](https://img.shields.io/github/license/aliengiraffe/vigilante)](https://github.com/aliengiraffe/vigilante/blob/main/LICENSE)
-[![Release Workflow](https://img.shields.io/github/actions/workflow/status/aliengiraffe/vigilante/release.yml?branch=main&label=release)](https://github.com/aliengiraffe/vigilante/actions/workflows/release.yml)
+[![Release Workflow](https://img.shields.io/github/actions/workflow/status/aliengiraffe/vigilante/release.yml?label=release)](https://github.com/aliengiraffe/vigilante/actions/workflows/release.yml)
 
 `vigilante` is a GitHub-native control plane for autonomous software delivery. It watches repositories, selects executable issues, prepares isolated implementation environments, dispatches headless coding agents, keeps GitHub updated with progress, and maintains the delivery loop around pull requests.
 


### PR DESCRIPTION
## Summary
- remove the `branch=main` filter from the README release badge URL
- let the badge report the real status of the tag-triggered release workflow

## Validation
- compared the badge response before and after the URL change
- confirmed the filtered badge returned `release: no status` while the unfiltered workflow badge returned the actual workflow state

Closes #258
