### PR TITLE
Make GitHub pause recovery deterministic

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1180,10 +1180,10 @@ func (a *App) enforceGitHubRateLimit(ctx context.Context, sessions []state.Sessi
 	snapshot, err := ghcli.GetRateLimitSnapshot(ctx, a.env.Runner)
 	if err != nil {
 		a.state.AppendDaemonLog("github rate limit fetch failed err=%v", err)
-		return sessions, false, nil
+		return a.clearExpiredGitHubResumeState(sessions, now), false, nil
 	}
 	if snapshot.Core.Remaining >= githubCoreLowQuotaThreshold {
-		return sessions, false, nil
+		return a.clearExpiredGitHubResumeState(sessions, now), false, nil
 	}
 
 	a.setGitHubRateLimitState(snapshot)
@@ -1198,7 +1198,7 @@ func (a *App) currentGitHubRateLimitState(now time.Time) (ghcli.RateLimitSnapsho
 	if !a.githubRateLimitState.Active {
 		return ghcli.RateLimitSnapshot{}, false, false
 	}
-	if now.Before(a.githubRateLimitState.ResetAt) {
+	if !a.githubRateLimitState.ResetAt.IsZero() && now.Before(a.githubRateLimitState.ResetAt) {
 		return a.githubRateLimitState.Snapshot, true, false
 	}
 
@@ -1226,6 +1226,7 @@ func (a *App) notifyGitHubLowQuotaSessions(ctx context.Context, sessions []state
 		if !sessionAffectedByGitHubRateLimitPause(*session) {
 			continue
 		}
+		session.ResumeAfter = resetAt
 		if session.LastGitHubDelayResetAt == resetAt {
 			continue
 		}
@@ -1239,7 +1240,21 @@ func (a *App) notifyGitHubLowQuotaSessions(ctx context.Context, sessions []state
 		}
 		session.LastGitHubDelayResetAt = resetAt
 		session.LastGitHubDelayCommentedAt = a.clock().Format(time.RFC3339)
-		session.UpdatedAt = session.LastGitHubDelayCommentedAt
+	}
+	return sessions
+}
+
+func (a *App) clearExpiredGitHubResumeState(sessions []state.Session, now time.Time) []state.Session {
+	for i := range sessions {
+		session := &sessions[i]
+		if strings.TrimSpace(session.ResumeAfter) == "" {
+			continue
+		}
+		resumeAfter, err := time.Parse(time.RFC3339, session.ResumeAfter)
+		if err != nil || now.Before(resumeAfter) {
+			continue
+		}
+		session.ResumeAfter = ""
 	}
 	return sessions
 }
@@ -2706,7 +2721,7 @@ func isStalledSession(session state.Session, now time.Time, threshold time.Durat
 		}
 	}
 
-	lastActivity := sessionActivityTime(session)
+	lastActivity := sessionLivenessTime(session)
 	if lastActivity.IsZero() {
 		return true, "session has no recorded heartbeat"
 	}
@@ -2717,6 +2732,19 @@ func isStalledSession(session state.Session, now time.Time, threshold time.Durat
 		return true, fmt.Sprintf("process %d is not running and the session has been idle since %s", session.ProcessID, lastActivity.Format(time.RFC3339))
 	}
 	return true, fmt.Sprintf("no active process is recorded and the session has been idle since %s", lastActivity.Format(time.RFC3339))
+}
+
+func sessionLivenessTime(session state.Session) time.Time {
+	for _, raw := range []string{session.LastHeartbeatAt, session.StartedAt} {
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		parsed, err := time.Parse(time.RFC3339, raw)
+		if err == nil {
+			return parsed
+		}
+	}
+	return time.Time{}
 }
 
 func sessionActivityTime(session state.Session) time.Time {
@@ -3076,6 +3104,7 @@ func clearBlockedState(session *state.Session, now time.Time, source string) {
 	session.BlockedReason = state.BlockedReason{}
 	session.BlockedStage = ""
 	session.RetryPolicy = ""
+	session.ResumeAfter = ""
 	session.ResumeRequired = false
 	session.ResumeHint = ""
 	session.RecoveredAt = now.Format(time.RFC3339)
@@ -3367,6 +3396,7 @@ func reuseExistingIterationSession(target state.WatchTarget, issue ghcli.Issue, 
 	session.BlockedStage = ""
 	session.BlockedReason = state.BlockedReason{}
 	session.RetryPolicy = ""
+	session.ResumeAfter = ""
 	session.ResumeRequired = false
 	session.ResumeHint = ""
 	session.IterationPromptContext = strings.TrimSpace(iterationContext)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -3737,6 +3737,9 @@ func TestScanOncePausesWhenGitHubCoreRateLimitIsLowAndCommentsActiveIssues(t *te
 	if sessions[0].LastGitHubDelayResetAt != resetAt.UTC().Format(time.RFC3339) && sessions[0].LastGitHubDelayResetAt != resetAt.Format(time.RFC3339) {
 		t.Fatalf("expected dedupe reset marker, got %#v", sessions[0])
 	}
+	if sessions[0].ResumeAfter != resetAt.UTC().Format(time.RFC3339) && sessions[0].ResumeAfter != resetAt.Format(time.RFC3339) {
+		t.Fatalf("expected explicit resume_after marker, got %#v", sessions[0])
+	}
 }
 
 func TestScanOnceSuppressesDuplicateGitHubLowQuotaCommentsWithinSameResetWindow(t *testing.T) {
@@ -3830,6 +3833,78 @@ func TestScanOnceResumesAfterGitHubRateLimitResetWindowPasses(t *testing.T) {
 	}
 	if app.githubRateLimitState.Active {
 		t.Fatalf("expected in-memory rate-limit pause to clear after reset")
+	}
+}
+
+func TestScanOnceClearsExpiredSessionResumeAfterWhenQuotaRecovered(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	now := time.Date(2026, 3, 19, 23, 5, 0, 0, time.UTC)
+	resetAt := now.Add(-5 * time.Minute)
+	app := New()
+	app.clock = func() time.Time { return now }
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"gh": "/usr/bin/gh"},
+		Outputs: map[string]string{
+			"gh api /rate_limit":      `{"resources":{"core":{"limit":5000,"remaining":150,"reset":1773964751},"rate":{"limit":5000,"remaining":150,"reset":1773964751},"graphql":{"limit":5000,"remaining":4557,"reset":1773961792},"search":{"limit":30,"remaining":30,"reset":1773961093}}}`,
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:     "/tmp/repo",
+		Repo:         "owner/repo",
+		IssueNumber:  7,
+		IssueTitle:   "active work",
+		IssueURL:     "https://github.com/owner/repo/issues/7",
+		Branch:       "vigilante/issue-7",
+		WorktreePath: "/tmp/repo/.worktrees/vigilante/issue-7",
+		Status:       state.SessionStatusRunning,
+		ResumeAfter:  resetAt.Format(time.RFC3339),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions[0].ResumeAfter != "" {
+		t.Fatalf("expected expired resume_after to clear, got %#v", sessions[0])
+	}
+}
+
+func TestIsStalledSessionIgnoresUpdatedAtWithoutHeartbeat(t *testing.T) {
+	now := time.Date(2026, 3, 19, 23, 5, 0, 0, time.UTC)
+	session := state.Session{
+		WorktreePath:           t.TempDir(),
+		ProcessID:              999999,
+		StartedAt:              now.Add(-20 * time.Minute).Format(time.RFC3339),
+		UpdatedAt:              now.Add(-1 * time.Minute).Format(time.RFC3339),
+		LastGitHubDelayResetAt: now.Add(10 * time.Minute).Format(time.RFC3339),
+		ResumeAfter:            now.Add(10 * time.Minute).Format(time.RFC3339),
+	}
+
+	stalled, reason := isStalledSession(session, now, 10*time.Minute)
+	if !stalled {
+		t.Fatalf("expected session to be stale when only updated_at changed: %#v", session)
+	}
+	if !strings.Contains(reason, "idle since") {
+		t.Fatalf("expected idle-since reason, got %q", reason)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -86,6 +86,7 @@ type Session struct {
 	BlockedStage                   string        `json:"blocked_stage,omitempty"`
 	BlockedReason                  BlockedReason `json:"blocked_reason,omitempty"`
 	RetryPolicy                    string        `json:"retry_policy,omitempty"`
+	ResumeAfter                    string        `json:"resume_after,omitempty"`
 	ResumeRequired                 bool          `json:"resume_required,omitempty"`
 	ResumeHint                     string        `json:"resume_hint,omitempty"`
 	LastResumeSource               string        `json:"last_resume_source,omitempty"`


### PR DESCRIPTION
## Summary
- persist explicit `resume_after` state for sessions paused by GitHub low quota
- clear expired pause state deterministically and stop treating delay-comment bookkeeping as worker liveness
- add regression coverage for pause expiry and stale-session recovery behavior

## Validation
- `go test ./internal/app ./internal/github ./internal/state`
- `go test ./...`

Closes #264
