### PR TITLE
Lower GitHub low-quota threshold to 5

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -34,7 +34,7 @@ const defaultScanInterval = 1 * time.Minute
 const defaultAssigneeFilter = "me"
 const defaultStalledSessionThreshold = 10 * time.Minute
 const defaultMaintenanceAutoRecoveryTimeout = 10 * time.Minute
-const githubCoreLowQuotaThreshold = 100
+const githubCoreLowQuotaThreshold = 5
 const unsetMaxParallel = -2147483648
 const autoRecoverySource = "auto_recovery"
 


### PR DESCRIPTION
## Summary
- lower the GitHub REST core low-quota threshold from 100 to 5
- keep scans running until the quota is actually close to exhaustion

## Testing
- go test ./internal/app -run 'TestScanOnce.*GitHub.*Quota|TestScanOnceSuppressesDuplicateGitHubLowQuotaCommentsWithinSameResetWindow'