### PR TITLE
Refresh live GitHub quota before honoring paused daemon state

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1172,24 +1172,35 @@ func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Sessi
 
 func (a *App) enforceGitHubRateLimit(ctx context.Context, sessions []state.Session) ([]state.Session, bool, error) {
 	now := a.clock()
-	if snapshot, active, resumed := a.currentGitHubRateLimitState(now); active {
-		a.state.AppendDaemonLog("github rate limit pause active core_remaining=%d reset_at=%s", snapshot.Core.Remaining, snapshot.Core.ResetAt.Format(time.RFC3339))
-		return a.notifyGitHubLowQuotaSessions(ctx, sessions, snapshot), true, nil
-	} else if resumed {
+	cachedSnapshot, cachedActive, resumed := a.currentGitHubRateLimitState(now)
+	if resumed {
 		a.state.AppendDaemonLog("github rate limit pause expired; refreshing snapshot")
 	}
 
 	snapshot, err := ghcli.GetRateLimitSnapshot(ctx, a.env.Runner)
 	if err != nil {
 		a.state.AppendDaemonLog("github rate limit fetch failed err=%v", err)
+		if cachedActive {
+			a.state.AppendDaemonLog("github rate limit pause active core_remaining=%d reset_at=%s", cachedSnapshot.Core.Remaining, cachedSnapshot.Core.ResetAt.Format(time.RFC3339))
+			return a.notifyGitHubLowQuotaSessions(ctx, sessions, cachedSnapshot), true, nil
+		}
 		return a.clearExpiredGitHubResumeState(sessions, now), false, nil
 	}
 	if snapshot.Core.Remaining >= githubCoreLowQuotaThreshold {
+		if cachedActive {
+			a.clearGitHubRateLimitState(false)
+			a.state.AppendDaemonLog("github rate limit pause cleared by live snapshot core_remaining=%d reset_at=%s", snapshot.Core.Remaining, snapshot.Core.ResetAt.Format(time.RFC3339))
+		}
 		return a.clearExpiredGitHubResumeState(sessions, now), false, nil
 	}
 
-	a.setGitHubRateLimitState(snapshot)
-	a.state.AppendDaemonLog("github rate limit pause entered core_remaining=%d reset_at=%s", snapshot.Core.Remaining, snapshot.Core.ResetAt.Format(time.RFC3339))
+	if cachedActive {
+		a.refreshGitHubRateLimitState(snapshot)
+		a.state.AppendDaemonLog("github rate limit pause active core_remaining=%d reset_at=%s", snapshot.Core.Remaining, snapshot.Core.ResetAt.Format(time.RFC3339))
+	} else {
+		a.setGitHubRateLimitState(snapshot)
+		a.state.AppendDaemonLog("github rate limit pause entered core_remaining=%d reset_at=%s", snapshot.Core.Remaining, snapshot.Core.ResetAt.Format(time.RFC3339))
+	}
 	return a.notifyGitHubLowQuotaSessions(ctx, sessions, snapshot), true, nil
 }
 
@@ -1219,6 +1230,28 @@ func (a *App) setGitHubRateLimitState(snapshot ghcli.RateLimitSnapshot) {
 	}
 	a.githubRateLimitMu.Unlock()
 	a.emitGitHubRateLimitEvent("paused", snapshot)
+}
+
+func (a *App) refreshGitHubRateLimitState(snapshot ghcli.RateLimitSnapshot) {
+	a.githubRateLimitMu.Lock()
+	a.githubRateLimitState = githubRateLimitState{
+		Active:   true,
+		ResetAt:  snapshot.Core.ResetAt,
+		Snapshot: snapshot,
+	}
+	a.githubRateLimitMu.Unlock()
+}
+
+func (a *App) clearGitHubRateLimitState(emit bool) {
+	a.githubRateLimitMu.Lock()
+	snapshot := a.githubRateLimitState.Snapshot
+	wasActive := a.githubRateLimitState.Active
+	a.githubRateLimitState = githubRateLimitState{}
+	a.githubRateLimitMu.Unlock()
+
+	if emit && wasActive {
+		a.emitGitHubRateLimitEvent("resumed", snapshot)
+	}
 }
 
 func (a *App) notifyGitHubLowQuotaSessions(ctx context.Context, sessions []state.Session, snapshot ghcli.RateLimitSnapshot) []state.Session {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -3893,6 +3893,58 @@ func TestScanOnceResumesAfterGitHubRateLimitResetWindowPasses(t *testing.T) {
 	}
 }
 
+func TestScanOnceClearsStaleGitHubRateLimitPauseWhenLiveQuotaRecovered(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	now := time.Date(2026, 3, 21, 21, 51, 38, 0, time.FixedZone("PDT", -7*60*60))
+	cachedResetAt := time.Date(2026, 3, 21, 22, 42, 41, 0, time.FixedZone("PDT", -7*60*60))
+	liveResetAt := now.Add(52 * time.Minute)
+	app := New()
+	app.clock = func() time.Time { return now }
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.githubRateLimitState = githubRateLimitState{
+		Active:  true,
+		ResetAt: cachedResetAt,
+		Snapshot: ghcli.RateLimitSnapshot{
+			Core: ghcli.RateLimitResource{Limit: 5000, Remaining: 0, ResetAt: cachedResetAt},
+		},
+	}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"gh": "/usr/bin/gh"},
+		Outputs: map[string]string{
+			"gh api /rate_limit": fmt.Sprintf(`{"resources":{"core":{"limit":5000,"remaining":4991,"reset":%d},"rate":{"limit":5000,"remaining":4991,"reset":%d},"graphql":{"limit":5000,"remaining":4989,"reset":%d},"search":{"limit":30,"remaining":30,"reset":%d}}}`,
+				liveResetAt.Unix(),
+				liveResetAt.Unix(),
+				liveResetAt.Unix(),
+				now.Add(time.Minute).Unix(),
+			),
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(stdout.String(), "scan paused: GitHub REST core quota is below the low-quota threshold") {
+		t.Fatalf("expected live quota recovery to skip pause, got: %s", stdout.String())
+	}
+	if app.githubRateLimitState.Active {
+		t.Fatalf("expected stale in-memory rate-limit pause to clear after live quota recovery")
+	}
+}
+
 func TestScanOnceClearsExpiredSessionResumeAfterWhenQuotaRecovered(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))


### PR DESCRIPTION
## Summary
- refresh the GitHub rate-limit snapshot on each scan instead of letting cached daemon pause state short-circuit the scan loop
- keep using the cached pause snapshot only as a fallback when the live rate-limit query fails
- add a regression test for the stale cached core_remaining=0 case where the live GitHub quota has already recovered

## Root cause
The daemon cached an in-memory GitHub low-quota pause and treated it as authoritative on later scans. If that cached state drifted from the live GitHub quota, the daemon could keep pausing scans even though vigilante status showed healthy quota from a fresh rate-limit call.

## Validation
- go test ./internal/app ./internal/github
