### PR TITLE
Fix Gemini bundled skill installation conflicts

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1098,11 +1098,13 @@ func TestSetupCreatesStateLayoutAndInstallsBundledSkillsForAllProviders(t *testi
 		filepath.Join(app.state.ClaudeHome(), "skills", skill.VigilanteIssueImplementation, "SKILL.md"),
 		filepath.Join(app.state.ClaudeHome(), "commands", skill.VigilanteIssueImplementation, "SKILL.md"),
 		filepath.Join(app.state.GeminiHome(), "skills", skill.VigilanteIssueImplementation, "SKILL.md"),
-		filepath.Join(app.state.GeminiHome(), "commands", skill.VigilanteIssueImplementation+".toml"),
 	} {
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("expected %s to exist: %v", path, err)
 		}
+	}
+	if _, err := os.Stat(filepath.Join(app.state.GeminiHome(), "commands", skill.VigilanteIssueImplementation+".toml")); !os.IsNotExist(err) {
+		t.Fatalf("expected Gemini legacy command to be removed, got: %v", err)
 	}
 }
 
@@ -1134,14 +1136,20 @@ func TestSetupWithGeminiInstallsBundledSkillsForAllProviders(t *testing.T) {
 		filepath.Join(app.state.ClaudeHome(), "skills", skill.VigilanteIssueImplementation, "SKILL.md"),
 		filepath.Join(app.state.ClaudeHome(), "commands", skill.VigilanteIssueImplementation, "SKILL.md"),
 		filepath.Join(app.state.GeminiHome(), "skills", skill.VigilanteIssueImplementation, "SKILL.md"),
-		filepath.Join(app.state.GeminiHome(), "commands", skill.VigilanteIssueImplementation+".toml"),
 		filepath.Join(app.state.GeminiHome(), "skills", skill.VigilanteIssueImplementationOnRushMonorepo, "SKILL.md"),
-		filepath.Join(app.state.GeminiHome(), "commands", skill.VigilanteIssueImplementationOnRushMonorepo+".toml"),
 		filepath.Join(app.state.GeminiHome(), "skills", skill.VigilanteConflictResolution, "SKILL.md"),
-		filepath.Join(app.state.GeminiHome(), "commands", skill.VigilanteConflictResolution+".toml"),
 	} {
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("expected %s to exist: %v", path, err)
+		}
+	}
+	for _, path := range []string{
+		filepath.Join(app.state.GeminiHome(), "commands", skill.VigilanteIssueImplementation+".toml"),
+		filepath.Join(app.state.GeminiHome(), "commands", skill.VigilanteIssueImplementationOnRushMonorepo+".toml"),
+		filepath.Join(app.state.GeminiHome(), "commands", skill.VigilanteConflictResolution+".toml"),
+	} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("expected Gemini legacy command to be removed: %s (%v)", path, err)
 		}
 	}
 }

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -72,7 +72,7 @@ func EnsureInstalled(runtime string, home string) error {
 			}
 		}
 		if strings.TrimSpace(runtime) == RuntimeGemini {
-			if err := installGeminiCommand(home, name); err != nil {
+			if err := removeGeminiLegacyCommand(home, name); err != nil {
 				return err
 			}
 		}
@@ -98,24 +98,12 @@ func installTargets(runtime string, home string, name string) ([]string, error) 
 	}
 }
 
-func installGeminiCommand(home string, name string) error {
-	body, err := skillBody(name)
-	if err != nil {
+func removeGeminiLegacyCommand(home string, name string) error {
+	commandPath := filepath.Join(home, "commands", name+".toml")
+	if err := os.Remove(commandPath); err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	commandDir := filepath.Join(home, "commands")
-	if err := os.MkdirAll(commandDir, 0o755); err != nil {
-		return err
-	}
-	commandPath := filepath.Join(commandDir, name+".toml")
-	commandBody := strings.TrimSpace(fmt.Sprintf(`
-description = "Bundled Vigilante skill: %s"
-prompt = '''
-Follow these %q skill instructions directly for this task:
-%s
-'''
-`, name, "`"+name+"`", body)) + "\n"
-	return os.WriteFile(commandPath, []byte(commandBody), 0o644)
+	return nil
 }
 
 func skillBody(name string) (string, error) {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -530,7 +530,7 @@ func TestEnsureInstalledForClaudeCreatesCommandsAndSkills(t *testing.T) {
 	}
 }
 
-func TestEnsureInstalledForGeminiCreatesCommandsAndSkills(t *testing.T) {
+func TestEnsureInstalledForGeminiCreatesSkillsAndRemovesLegacyCommands(t *testing.T) {
 	dir := t.TempDir()
 	repoRoot := t.TempDir()
 	for _, name := range VigilanteSkillNames() {
@@ -539,6 +539,13 @@ func TestEnsureInstalledForGeminiCreatesCommandsAndSkills(t *testing.T) {
 			t.Fatal(err)
 		}
 		if err := os.WriteFile(filepath.Join(skillSourceDir, "SKILL.md"), []byte("# repo skill\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		legacyCommandPath := filepath.Join(dir, "commands", name+".toml")
+		if err := os.MkdirAll(filepath.Dir(legacyCommandPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(legacyCommandPath, []byte("prompt = \"legacy\"\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -558,13 +565,13 @@ func TestEnsureInstalledForGeminiCreatesCommandsAndSkills(t *testing.T) {
 	}
 
 	for _, name := range VigilanteSkillNames() {
-		for _, path := range []string{
-			filepath.Join(dir, "skills", name, "SKILL.md"),
-			filepath.Join(dir, "commands", name+".toml"),
-		} {
-			if _, err := os.Stat(path); err != nil {
-				t.Fatalf("expected %s to exist: %v", path, err)
-			}
+		skillPath := filepath.Join(dir, "skills", name, "SKILL.md")
+		if _, err := os.Stat(skillPath); err != nil {
+			t.Fatalf("expected %s to exist: %v", skillPath, err)
+		}
+		legacyCommandPath := filepath.Join(dir, "commands", name+".toml")
+		if _, err := os.Stat(legacyCommandPath); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be removed, got: %v", legacyCommandPath, err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- treat Gemini bundled skills as the canonical slash-command source instead of also writing duplicate `commands/*.toml` files
- remove legacy Gemini command files for bundled Vigilante skills during install so repeated setup stays clean
- update Gemini regression tests to assert skills remain installed and duplicate command files are absent

## Validation
- `go test ./internal/skill ./internal/app`

Closes #277