### PR TITLE
Auto-restart stale implementation sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ Notes:
 - The default is `20m`.
 - A blocked session is eligible for automatic local cleanup only after there have been no qualifying user comments on the issue, no session updates, and no worktree updates for longer than the configured timeout.
 - This inactivity cleanup is conservative: it clears local blocked-session artifacts so the issue can be redispatched later, but it does not delete remote pull requests or remote branches automatically.
+- Stale running implementation sessions use a separate recovery path: after Vigilante first confirms the run is stale, it waits 20 minutes before attempting an automatic fresh restart, persists the restart attempt count in session state, and stops after 3 automatic restarts until a human intervenes.
 
 Suggested `watchlist.json` shape:
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -33,7 +33,9 @@ import (
 const defaultScanInterval = 1 * time.Minute
 const defaultAssigneeFilter = "me"
 const defaultStalledSessionThreshold = 10 * time.Minute
+const defaultStaleAutoRestartDelay = 20 * time.Minute
 const defaultMaintenanceAutoRecoveryTimeout = 10 * time.Minute
+const staleAutoRestartAttemptLimit = 3
 const githubCoreLowQuotaThreshold = 5
 const unsetMaxParallel = -2147483648
 const autoRecoverySource = "auto_recovery"
@@ -1027,6 +1029,9 @@ func (a *App) ScanOnce(ctx context.Context) error {
 					LastHeartbeatAt:    a.clock().Format(time.RFC3339),
 					UpdatedAt:          a.clock().Format(time.RFC3339),
 				}
+				if previous, ok := findSession(sessions, target.Repo, next.Number); ok {
+					carryStaleAutoRestartState(&session, previous)
+				}
 				sessions = upsertSession(sessions, session)
 				if err := a.state.SaveSessions(sessions); err != nil {
 					return err
@@ -1058,6 +1063,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 
 func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Session) ([]state.Session, error) {
 	threshold := stalledSessionThreshold()
+	restartDelay := defaultStaleAutoRestartDelay
 
 	for i := range sessions {
 		session := &sessions[i]
@@ -1065,11 +1071,13 @@ func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Sessi
 			continue
 		}
 		if sessionProcessAlive(session.ProcessID) {
+			clearStaleAutoRestartPending(session)
 			continue
 		}
 
 		stale, reason := isStalledSession(*session, a.clock(), threshold)
 		if !stale {
+			clearStaleAutoRestartPending(session)
 			continue
 		}
 
@@ -1084,6 +1092,7 @@ func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Sessi
 			session.Status = state.SessionStatusSuccess
 			session.ProcessID = 0
 			session.LastHeartbeatAt = ""
+			clearStaleAutoRestartPending(session)
 			updatePullRequestTrackingFromLookup(session, *pr)
 			session.LastError = ""
 			session.UpdatedAt = a.clock().Format(time.RFC3339)
@@ -1107,6 +1116,52 @@ func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Sessi
 				a.state.AppendDaemonLog("stalled session recovery comment failed repo=%s issue=%d branch=%s err=%v", session.Repo, session.IssueNumber, session.Branch, err)
 			}
 			a.syncSessionIssueLabelsBestEffort(ctx, *session, pr)
+			continue
+		}
+
+		now := a.clock()
+		pendingSince, hasPending := staleAutoRestartPendingSince(*session)
+		if !hasPending {
+			session.StaleAutoRestartPendingSince = now.Format(time.RFC3339)
+			session.UpdatedAt = now.Format(time.RFC3339)
+			a.state.AppendDaemonLog("stalled session auto restart pending repo=%s issue=%d branch=%s reason=%q pending_since=%s delay=%s", session.Repo, session.IssueNumber, session.Branch, reason, session.StaleAutoRestartPendingSince, restartDelay)
+			continue
+		}
+		if now.Sub(pendingSince) < restartDelay {
+			a.state.AppendDaemonLog("stalled session auto restart waiting repo=%s issue=%d branch=%s reason=%q pending_since=%s delay=%s", session.Repo, session.IssueNumber, session.Branch, reason, pendingSince.Format(time.RFC3339), restartDelay)
+			continue
+		}
+		if session.StaleAutoRestartAttempts >= staleAutoRestartAttemptLimit {
+			nowText := now.Format(time.RFC3339)
+			previousStatus := session.Status
+			session.Status = state.SessionStatusFailed
+			session.ProcessID = 0
+			session.LastHeartbeatAt = ""
+			session.EndedAt = nowText
+			session.UpdatedAt = nowText
+			session.LastError = fmt.Sprintf("automatic stale-session restart limit reached after %d attempts; manual intervention required", staleAutoRestartAttemptLimit)
+			session.StaleAutoRestartStoppedAt = nowText
+			clearStaleAutoRestartPending(session)
+			a.emitSessionTransition(previousStatus, *session, "stalled_auto_restart_limit")
+			a.state.AppendDaemonLog("stalled session auto restart limit reached repo=%s issue=%d branch=%s attempts=%d reason=%q", session.Repo, session.IssueNumber, session.Branch, session.StaleAutoRestartAttempts, reason)
+			body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Manual Intervention Required",
+				Emoji:      "🧯",
+				Percent:    85,
+				ETAMinutes: 5,
+				Items: []string{
+					fmt.Sprintf("The local session on `%s` is still stale (%s).", session.Branch, reason),
+					fmt.Sprintf("Vigilante already used all %d automatic stale-session restart attempts for this issue.", staleAutoRestartAttemptLimit),
+					fmt.Sprintf("Next step: inspect the local state and run `vigilante redispatch --repo %s --issue %d` when it is safe to try again.", session.Repo, session.IssueNumber),
+				},
+				Tagline: "No loops without consent.",
+			})
+			if err := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "blocked", "stalled_auto_restart_limit"); err != nil {
+				session.LastError = err.Error()
+				session.UpdatedAt = a.clock().Format(time.RFC3339)
+				a.state.AppendDaemonLog("stalled session auto restart limit comment failed repo=%s issue=%d branch=%s err=%v", session.Repo, session.IssueNumber, session.Branch, err)
+			}
+			a.syncSessionIssueLabelsBestEffort(ctx, *session, nil)
 			continue
 		}
 
@@ -1136,33 +1191,37 @@ func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Sessi
 			continue
 		}
 
-		now := a.clock().Format(time.RFC3339)
+		nowText := now.Format(time.RFC3339)
 		previousStatus := session.Status
 		session.Status = state.SessionStatusFailed
 		session.ProcessID = 0
 		session.LastHeartbeatAt = ""
+		session.StaleAutoRestartAttempts++
+		session.StaleAutoRestartStoppedAt = ""
+		clearStaleAutoRestartPending(session)
+		session.CleanupCompletedAt = nowText
 		session.CleanupError = ""
-		session.EndedAt = now
-		session.UpdatedAt = now
-		session.LastError = fmt.Sprintf("stalled session recovered: %s", reason)
-		a.emitSessionTransition(previousStatus, *session, "stalled_recovery")
-		a.state.AppendDaemonLog("stalled session recovered for redispatch repo=%s issue=%d branch=%s reason=%q", session.Repo, session.IssueNumber, session.Branch, reason)
+		session.EndedAt = nowText
+		session.UpdatedAt = nowText
+		session.LastError = fmt.Sprintf("automatic stale-session restart attempt %d/%d triggered: %s", session.StaleAutoRestartAttempts, staleAutoRestartAttemptLimit, reason)
+		a.emitSessionTransition(previousStatus, *session, "stalled_auto_restart")
+		a.state.AppendDaemonLog("stalled session auto restart triggered repo=%s issue=%d branch=%s attempt=%d/%d reason=%q", session.Repo, session.IssueNumber, session.Branch, session.StaleAutoRestartAttempts, staleAutoRestartAttemptLimit, reason)
 		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
 			Stage:      "Implementation In Progress",
-			Emoji:      "🧹",
-			Percent:    15,
-			ETAMinutes: 20,
+			Emoji:      "♻️",
+			Percent:    25,
+			ETAMinutes: 15,
 			Items: []string{
 				fmt.Sprintf("The previous local session on `%s` stalled (%s).", session.Branch, reason),
-				"The abandoned worktree state was cleaned up successfully.",
-				"Next step: the issue is ready to be redispatched in a fresh worktree.",
+				fmt.Sprintf("Vigilante cleaned up the abandoned worktree and started automatic restart attempt %d/%d.", session.StaleAutoRestartAttempts, staleAutoRestartAttemptLimit),
+				"Next step: launch a fresh implementation session in a new worktree now.",
 			},
-			Tagline: "A smooth sea never made a skilled sailor.",
+			Tagline: "Try again, but keep count.",
 		})
-		if err := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "progress", "stalled_recovery"); err != nil {
+		if err := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "progress", "stalled_auto_restart"); err != nil {
 			session.LastError = err.Error()
 			session.UpdatedAt = a.clock().Format(time.RFC3339)
-			a.state.AppendDaemonLog("stalled session redispatch comment failed repo=%s issue=%d branch=%s err=%v", session.Repo, session.IssueNumber, session.Branch, err)
+			a.state.AppendDaemonLog("stalled session auto restart comment failed repo=%s issue=%d branch=%s err=%v", session.Repo, session.IssueNumber, session.Branch, err)
 		}
 		a.syncSessionIssueLabelsBestEffort(ctx, *session, nil)
 	}
@@ -2158,6 +2217,13 @@ func (a *App) RedispatchSession(ctx context.Context, repoSlug string, issue int,
 		LastHeartbeatAt: now,
 		UpdatedAt:       now,
 	}
+	if previous, ok := findSession(sessions, repoSlug, issue); ok {
+		if source == "cli" {
+			resetStaleAutoRestartState(&session)
+		} else {
+			carryStaleAutoRestartState(&session, previous)
+		}
+	}
 	sessions = upsertSession(sessions, session)
 	if err := a.state.SaveSessions(sessions); err != nil {
 		return err
@@ -2303,8 +2369,38 @@ func (a *App) resetSessionForRedispatch(ctx context.Context, session *state.Sess
 	session.CleanupError = ""
 	session.LastCleanupSource = source
 	session.LastError = fmt.Sprintf("redispatch requested via %s", source)
+	if source == "cli" {
+		resetStaleAutoRestartState(session)
+	}
 	a.state.AppendDaemonLog("redispatch cleanup complete repo=%s issue=%d source=%s branch=%s worktree=%s", session.Repo, session.IssueNumber, source, session.Branch, session.WorktreePath)
 	return nil
+}
+
+func clearStaleAutoRestartPending(session *state.Session) {
+	session.StaleAutoRestartPendingSince = ""
+}
+
+func staleAutoRestartPendingSince(session state.Session) (time.Time, bool) {
+	if strings.TrimSpace(session.StaleAutoRestartPendingSince) == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339, session.StaleAutoRestartPendingSince)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed, true
+}
+
+func carryStaleAutoRestartState(session *state.Session, previous state.Session) {
+	session.StaleAutoRestartAttempts = previous.StaleAutoRestartAttempts
+	session.StaleAutoRestartStoppedAt = ""
+	clearStaleAutoRestartPending(session)
+}
+
+func resetStaleAutoRestartState(session *state.Session) {
+	session.StaleAutoRestartAttempts = 0
+	session.StaleAutoRestartStoppedAt = ""
+	clearStaleAutoRestartPending(session)
 }
 
 func (a *App) resumeBlockedSession(ctx context.Context, session *state.Session, source string) error {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -5965,7 +5965,79 @@ func TestScanOnceReportsRepoScanFailureWhenResolvingDefaultAssigneeFails(t *test
 	}
 }
 
-func TestScanOnceRecoversStalledSessionAndRedispatchesIssue(t *testing.T) {
+func TestScanOnceMarksStaleSessionPendingAutoRestart(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	var stdout bytes.Buffer
+	app := New()
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	now := time.Date(2026, 3, 10, 15, 0, 0, 0, time.UTC)
+	app.clock = func() time.Time { return now }
+
+	worktreePath := filepath.Join(home, "repo", ".worktrees", "vigilante", "issue-1")
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": "[]",
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]}]`,
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "repo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: filepath.Join(home, "repo"), Repo: "owner/repo", Branch: "main"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:        filepath.Join(home, "repo"),
+		Repo:            "owner/repo",
+		IssueNumber:     1,
+		IssueTitle:      "first",
+		IssueURL:        "https://github.com/owner/repo/issues/1",
+		Branch:          "vigilante/issue-1",
+		WorktreePath:    worktreePath,
+		Status:          state.SessionStatusRunning,
+		ProcessID:       999999,
+		StartedAt:       now.Add(-20 * time.Minute).Format(time.RFC3339),
+		LastHeartbeatAt: now.Add(-20 * time.Minute).Format(time.RFC3339),
+		UpdatedAt:       now.Add(-20 * time.Minute).Format(time.RFC3339),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if sessions[0].Status != state.SessionStatusRunning {
+		t.Fatalf("expected running session to stay pending, got: %#v", sessions[0])
+	}
+	if sessions[0].StaleAutoRestartPendingSince != now.Format(time.RFC3339) {
+		t.Fatalf("expected pending timestamp to be recorded, got: %#v", sessions[0])
+	}
+	if sessions[0].StaleAutoRestartAttempts != 0 {
+		t.Fatalf("expected no restart attempts yet, got: %#v", sessions[0])
+	}
+	if got := stdout.String(); !strings.Contains(got, "repo: owner/repo no eligible issues (1 open)") {
+		t.Fatalf("unexpected output: %s", got)
+	}
+}
+
+func TestScanOnceAutoRestartsStaleSessionAfterDelay(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
 	t.Setenv("HOME", home)
@@ -5990,15 +6062,15 @@ func TestScanOnceRecoversStalledSessionAndRedispatchesIssue(t *testing.T) {
 			"git branch -D vigilante/issue-1":                            "Deleted branch vigilante/issue-1\n",
 			"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
 				Stage:      "Implementation In Progress",
-				Emoji:      "🧹",
-				Percent:    15,
-				ETAMinutes: 20,
+				Emoji:      "♻️",
+				Percent:    25,
+				ETAMinutes: 15,
 				Items: []string{
 					"The previous local session on `vigilante/issue-1` stalled (worktree path is missing).",
-					"The abandoned worktree state was cleaned up successfully.",
-					"Next step: the issue is ready to be redispatched in a fresh worktree.",
+					"Vigilante cleaned up the abandoned worktree and started automatic restart attempt 1/3.",
+					"Next step: launch a fresh implementation session in a new worktree now.",
 				},
-				Tagline: "A smooth sea never made a skilled sailor.",
+				Tagline: "Try again, but keep count.",
 			}): "ok",
 			"gh api user --jq .login": "nicobistolfi\n",
 			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]}]`,
@@ -6033,18 +6105,19 @@ func TestScanOnceRecoversStalledSessionAndRedispatchesIssue(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := app.state.SaveSessions([]state.Session{{
-		RepoPath:        filepath.Join(home, "repo"),
-		Repo:            "owner/repo",
-		IssueNumber:     1,
-		IssueTitle:      "first",
-		IssueURL:        "https://github.com/owner/repo/issues/1",
-		Branch:          "vigilante/issue-1",
-		WorktreePath:    worktreePath,
-		Status:          state.SessionStatusRunning,
-		ProcessID:       999999,
-		StartedAt:       now.Add(-20 * time.Minute).Format(time.RFC3339),
-		LastHeartbeatAt: now.Add(-20 * time.Minute).Format(time.RFC3339),
-		UpdatedAt:       now.Add(-20 * time.Minute).Format(time.RFC3339),
+		RepoPath:                     filepath.Join(home, "repo"),
+		Repo:                         "owner/repo",
+		IssueNumber:                  1,
+		IssueTitle:                   "first",
+		IssueURL:                     "https://github.com/owner/repo/issues/1",
+		Branch:                       "vigilante/issue-1",
+		WorktreePath:                 worktreePath,
+		Status:                       state.SessionStatusRunning,
+		ProcessID:                    999999,
+		StartedAt:                    now.Add(-20 * time.Minute).Format(time.RFC3339),
+		LastHeartbeatAt:              now.Add(-20 * time.Minute).Format(time.RFC3339),
+		UpdatedAt:                    now.Add(-20 * time.Minute).Format(time.RFC3339),
+		StaleAutoRestartPendingSince: now.Add(-20 * time.Minute).Format(time.RFC3339),
 	}}); err != nil {
 		t.Fatal(err)
 	}
@@ -6061,7 +6134,99 @@ func TestScanOnceRecoversStalledSessionAndRedispatchesIssue(t *testing.T) {
 	if len(sessions) != 1 || sessions[0].Status != state.SessionStatusSuccess {
 		t.Fatalf("unexpected sessions: %#v", sessions)
 	}
+	if sessions[0].StaleAutoRestartAttempts != 1 {
+		t.Fatalf("expected one persisted auto-restart attempt, got: %#v", sessions[0])
+	}
+	if sessions[0].StaleAutoRestartPendingSince != "" {
+		t.Fatalf("expected pending timestamp to clear after restart, got: %#v", sessions[0])
+	}
 	if got := stdout.String(); !strings.Contains(got, "repo: owner/repo started issue #1 in "+worktreePath) {
+		t.Fatalf("unexpected output: %s", got)
+	}
+}
+
+func TestScanOnceStopsAutoRestartAfterAttemptLimit(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	var stdout bytes.Buffer
+	app := New()
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	now := time.Date(2026, 3, 10, 15, 0, 0, 0, time.UTC)
+	app.clock = func() time.Time { return now }
+
+	worktreePath := filepath.Join(home, "repo", ".worktrees", "vigilante", "issue-1")
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": "[]",
+			"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Manual Intervention Required",
+				Emoji:      "🧯",
+				Percent:    85,
+				ETAMinutes: 5,
+				Items: []string{
+					"The local session on `vigilante/issue-1` is still stale (worktree path is missing).",
+					"Vigilante already used all 3 automatic stale-session restart attempts for this issue.",
+					"Next step: inspect the local state and run `vigilante redispatch --repo owner/repo --issue 1` when it is safe to try again.",
+				},
+				Tagline: "No loops without consent.",
+			}): "ok",
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]}]`,
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, "repo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: filepath.Join(home, "repo"), Repo: "owner/repo", Branch: "main"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:                     filepath.Join(home, "repo"),
+		Repo:                         "owner/repo",
+		IssueNumber:                  1,
+		IssueTitle:                   "first",
+		IssueURL:                     "https://github.com/owner/repo/issues/1",
+		Branch:                       "vigilante/issue-1",
+		WorktreePath:                 worktreePath,
+		Status:                       state.SessionStatusRunning,
+		ProcessID:                    999999,
+		StartedAt:                    now.Add(-20 * time.Minute).Format(time.RFC3339),
+		LastHeartbeatAt:              now.Add(-20 * time.Minute).Format(time.RFC3339),
+		UpdatedAt:                    now.Add(-20 * time.Minute).Format(time.RFC3339),
+		StaleAutoRestartAttempts:     3,
+		StaleAutoRestartPendingSince: now.Add(-20 * time.Minute).Format(time.RFC3339),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if sessions[0].Status != state.SessionStatusFailed {
+		t.Fatalf("expected failed terminal session after limit, got: %#v", sessions[0])
+	}
+	if sessions[0].StaleAutoRestartStoppedAt == "" {
+		t.Fatalf("expected stop marker after limit, got: %#v", sessions[0])
+	}
+	if sessions[0].StaleAutoRestartPendingSince != "" {
+		t.Fatalf("expected pending timestamp to clear after limit, got: %#v", sessions[0])
+	}
+	if got := stdout.String(); !strings.Contains(got, "repo: owner/repo no eligible issues (1 open)") {
 		t.Fatalf("unexpected output: %s", got)
 	}
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -186,6 +186,9 @@ func ActiveSessionCount(sessions []state.Session, target state.WatchTarget) int 
 }
 
 func sessionPreventsRedispatch(session state.Session) bool {
+	if session.StaleAutoRestartStoppedAt != "" {
+		return true
+	}
 	if sessionConsumesDispatchCapacity(session) || session.Status == state.SessionStatusBlocked {
 		return true
 	}

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -132,6 +132,23 @@ func TestSelectIssuesSkipsBlockedAndOpenPullRequestSessionsWithoutConsumingCapac
 	}
 }
 
+func TestSelectIssuesSkipsSessionAfterStaleAutoRestartLimitReached(t *testing.T) {
+	issues := []Issue{
+		{Number: 1, Labels: []Label{{Name: "to-do"}}},
+		{Number: 2, Labels: []Label{{Name: "to-do"}}},
+	}
+
+	selected := SelectIssues(issues, []state.Session{{
+		Repo:                      "owner/repo",
+		IssueNumber:               1,
+		Status:                    state.SessionStatusFailed,
+		StaleAutoRestartStoppedAt: "2026-03-10T15:00:00Z",
+	}}, state.WatchTarget{Repo: "owner/repo", Labels: []string{"to-do"}}, 2)
+	if len(selected) != 1 || selected[0].Number != 2 {
+		t.Fatalf("unexpected selected issues: %#v", selected)
+	}
+}
+
 func TestListOpenIssuesSupportsExplicitAssignee(t *testing.T) {
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -106,6 +106,9 @@ type Session struct {
 	LastCleanupSource              string        `json:"last_cleanup_source,omitempty"`
 	LastCleanupCommentID           int64         `json:"last_cleanup_comment_id,omitempty"`
 	LastCleanupCommentAt           string        `json:"last_cleanup_comment_at,omitempty"`
+	StaleAutoRestartAttempts       int           `json:"stale_auto_restart_attempts,omitempty"`
+	StaleAutoRestartPendingSince   string        `json:"stale_auto_restart_pending_since,omitempty"`
+	StaleAutoRestartStoppedAt      string        `json:"stale_auto_restart_stopped_at,omitempty"`
 	RecoveredAt                    string        `json:"recovered_at,omitempty"`
 	MonitoringStoppedAt            string        `json:"monitoring_stopped_at,omitempty"`
 	CleanupCompletedAt             string        `json:"cleanup_completed_at,omitempty"`


### PR DESCRIPTION
## Summary
- add persisted stale auto-restart session bookkeeping with a 20 minute eligibility delay and a 3-attempt cap
- auto-restart stale implementation sessions through the existing cleanup and dispatch flow while keeping stale-to-PR-maintenance recovery unchanged
- add regression coverage for pending, restart, and limit-reached paths and document the behavior in `README.md`

## Validation
- `go test ./...`

Closes #279
