### PR TITLE
Add vigilante logs command for session log viewing

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -328,6 +328,8 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 			return errors.New("usage: vigilante status")
 		}
 		return a.Status(ctx)
+	case "logs":
+		return a.runLogsCommand(args[1:])
 	case "cleanup":
 		return a.runCleanupCommand(ctx, args[1:])
 	case "redispatch":
@@ -550,6 +552,57 @@ func (a *App) runCompletionCommand(args []string) error {
 	}
 	_, err = fmt.Fprint(a.stdout, script)
 	return err
+}
+
+func (a *App) runLogsCommand(args []string) error {
+	fs := flag.NewFlagSet("logs", flag.ContinueOnError)
+	configureFlagSet(fs, func(w io.Writer) {
+		fmt.Fprintln(w, "usage: vigilante logs [--repo <owner/name>] [--issue <n>]")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "List session log files or show a specific session log.")
+		fmt.Fprintln(w)
+		fs.SetOutput(w)
+		fs.PrintDefaults()
+	})
+	repoFlag := fs.String("repo", "", "repository slug")
+	issueFlag := fs.Int("issue", 0, "issue number")
+	if err := parseFlagSet(fs, args, a.stdout); err != nil {
+		if errors.Is(err, errHelpHandled) {
+			return nil
+		}
+		return err
+	}
+
+	if *repoFlag != "" && *issueFlag > 0 {
+		path := a.state.SessionLogPath(*repoFlag, *issueFlag)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("no log found for %s#%d", *repoFlag, *issueFlag)
+		}
+		_, err = fmt.Fprint(a.stdout, string(content))
+		return err
+	}
+
+	entries, err := os.ReadDir(a.state.LogsDir())
+	if err != nil {
+		fmt.Fprintln(a.stdout, "no logs found")
+		return nil
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		fmt.Fprintf(a.stdout, "%-50s %8d bytes  %s\n",
+			entry.Name(),
+			info.Size(),
+			info.ModTime().Format("2006-01-02 15:04"),
+		)
+	}
+	return nil
 }
 
 func (a *App) Status(ctx context.Context) error {
@@ -4269,6 +4322,7 @@ func (a *App) printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  vigilante unwatch <path>")
 	fmt.Fprintln(w, "  vigilante list [--blocked | --running]")
 	fmt.Fprintln(w, "  vigilante status")
+	fmt.Fprintln(w, "  vigilante logs [--repo <owner/name>] [--issue <n>]")
 	fmt.Fprintln(w, "  vigilante cleanup --repo <owner/name> [--issue <n>]")
 	fmt.Fprintln(w, "  vigilante cleanup --all")
 	fmt.Fprintln(w, "  vigilante redispatch --repo <owner/name> --issue <n>")

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -6563,3 +6563,84 @@ func conflictResolutionPromptCommand(worktreePath string, repo string, repoPath 
 		pr,
 	))
 }
+
+func TestLogsCommandListsFiles(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	logsDir := filepath.Join(home, ".vigilante", "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(logsDir, "vigilante.log"), []byte("daemon log"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(logsDir, "owner-repo-issue-42.log"), []byte("session log content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+
+	exitCode := app.Run(context.Background(), []string{"logs"})
+	if exitCode != 0 {
+		t.Fatalf("expected success exit code, got %d", exitCode)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "owner-repo-issue-42.log") {
+		t.Fatalf("expected output to list session log, got %q", output)
+	}
+	if !strings.Contains(output, "vigilante.log") {
+		t.Fatalf("expected output to list daemon log, got %q", output)
+	}
+}
+
+func TestLogsCommandShowsSessionLog(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	logsDir := filepath.Join(home, ".vigilante", "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logContent := "[2026-03-24T10:00:00-07:00] session started issue=42 provider=claude\n"
+	if err := os.WriteFile(filepath.Join(logsDir, "owner-repo-issue-42.log"), []byte(logContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+
+	exitCode := app.Run(context.Background(), []string{"logs", "--repo", "owner/repo", "--issue", "42"})
+	if exitCode != 0 {
+		t.Fatalf("expected success exit code, got %d", exitCode)
+	}
+	if stdout.String() != logContent {
+		t.Fatalf("expected session log content %q, got %q", logContent, stdout.String())
+	}
+}
+
+func TestLogsCommandMissingLog(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	logsDir := filepath.Join(home, ".vigilante", "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = &stderr
+
+	exitCode := app.Run(context.Background(), []string{"logs", "--repo", "owner/repo", "--issue", "999"})
+	if exitCode != 1 {
+		t.Fatalf("expected failure exit code, got %d", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "no log found for owner/repo#999") {
+		t.Fatalf("expected error message about missing log, got %q", stderr.String())
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `vigilante logs` command that lists session log files and shows individual session logs by repo and issue number.

## Why this matters

Session logs are written to `~/.vigilante/logs/` but there's no built-in way to view them. After installing Vigilante and running `vigilante setup` + `vigilante daemon run --once`, I had to manually `cat ~/.vigilante/logs/vigilante.log` to see what happened. This adds the missing read path.

The project has invested in log quality over multiple PRs:

| Source | Evidence |
|--------|----------|
| [#179](https://github.com/aliengiraffe/vigilante/issues/179) | Scoped session log filenames by repository |
| [#26](https://github.com/aliengiraffe/vigilante/issues/26) | Local timezone in logs |
| [#117](https://github.com/aliengiraffe/vigilante/issues/117) | Reduced daemon log noise |
| [#267](https://github.com/aliengiraffe/vigilante/issues/267) | Expanded status with session health and rate limits |

All that log infrastructure exists but has no viewer. `vigilante logs` completes the observability surface alongside `vigilante list` and `vigilante status`.

## Changes

- `internal/app/app.go`: Added `runLogsCommand` function with `--repo` and `--issue` flags, plus the `case "logs"` dispatch in `runCommand` and the usage string entry
- `internal/app/app_test.go`: 3 test functions covering list, show, and missing-log error cases

## Testing

- `go test ./...` passes (all packages)
- `gofmt -l .` clean
- `go vet ./...` clean
- Built locally and tested all 3 modes:

### `vigilante logs` (list mode)

![list](https://files.catbox.moe/wqfuf1.png)

### `vigilante logs --help`

![help](https://files.catbox.moe/te6p86.png)

### `vigilante logs --repo owner/repo --issue 999` (error case)

![error](https://files.catbox.moe/8btgpf.png)

This contribution was developed with AI assistance (Claude Code).