### PR TITLE
Teach local service dependency skill to consult session logs

### DIFF
--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -802,6 +802,7 @@ func TestLocalServiceDependenciesSkillCoversStructuredOutputAndFailureModes(t *t
 		"Docker Compose is an allowed fallback, not the defining abstraction.",
 		"`status`: `ready`, `not_needed`, or `failed`",
 		"`mechanism`: `repo_native`, `repo_compose`, `repo_script`, `repo_task_runner`, or `generated_fallback`",
+		"`vigilante logs --repo <owner/name> --issue <n>`",
 		"missing local tooling",
 		"unsupported repository setup",
 		"startup failure",

--- a/skills/vigilante-local-service-dependencies/SKILL.md
+++ b/skills/vigilante-local-service-dependencies/SKILL.md
@@ -44,6 +44,7 @@ Require or infer these inputs before acting:
 - Keep generated artifacts explicit and local to the session.
 - Surface the exact command used to start services.
 - Wait for readiness when practical; do not claim success immediately after spawning a process if the service is not yet accepting connections.
+- When startup, readiness, or failure classification is unclear, inspect `vigilante logs --repo <owner/name> --issue <n>` before deciding which failure category applies.
 
 ## Structured Output Contract
 When you finish, return a concise structured summary that the parent workflow can reuse. Use this shape in plain text or JSON-like form:
@@ -65,7 +66,9 @@ When service preparation fails, explain which category applies:
 - startup failure
 - readiness or connection failure
 
-Include the failing command, the missing prerequisite or observed error, and the next most reasonable remediation step.
+For startup failures, readiness failures, or ambiguous cases, consult `vigilante logs --repo <owner/name> --issue <n>` so the persisted session transcript informs the diagnosis.
+
+Include the failing command, the missing prerequisite or observed error, the relevant log evidence when logs were checked, and the next most reasonable remediation step.
 
 ## Practical Defaults
 - Prioritize common local databases first: Postgres, MySQL, MariaDB, and MongoDB.


### PR DESCRIPTION
## Summary
- update the local service dependency skill to inspect `vigilante logs --repo <owner/name> --issue <n>` when startup, readiness, or classification failures need evidence
- keep the existing failure categories and structured output contract intact
- extend the skill prompt test to pin the new log guidance

## Validation
- `go test ./internal/skill`

Closes #284