### PR TITLE
Use vigilante logs in the conflict-resolution workflow

### DIFF
--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -446,6 +446,7 @@ func BuildConflictResolutionPromptForRuntime(runtime string, target state.WatchT
 		fmt.Sprintf("GitHub mergeability: mergeable=%s mergeStateStatus=%s", fallbackPromptText(pr.Mergeable, "UNKNOWN"), fallbackPromptText(pr.MergeStateStatus, "UNKNOWN")),
 		"Conflict-resolution workflow: rebase the branch onto the latest base branch if that has not already started; if a rebase is already in progress, continue it from the current stopped commit.",
 		"Work through the rebase commit by commit. Preserve the meaning of each existing issue-branch commit and keep the original issue specification authoritative.",
+		"If the rebase fails, post-rebase validation fails, or the current session state is unclear, inspect `vigilante logs --repo <owner/name> --issue <n>` before retrying so the session transcript guides the next safe action.",
 		"Do not silently discard commits or issue-specific behavior just to get a clean merge. Prefer the smallest safe conflict fix.",
 		"Use `vigilante gh issue comment` for progress and failures, rerun `go test ./...` after conflict resolution succeeds, and push the updated branch with `vigilante git push` when finished.",
 		"If you cannot preserve the issue intent safely, leave a concise GitHub blocker comment and exit with a non-zero status.",

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -510,7 +510,7 @@ func TestBuildConflictResolutionPrompt(t *testing.T) {
 	session := state.Session{IssueNumber: 12, IssueTitle: "Fix bug", IssueBody: "Preserve the original validation behavior.", IssueURL: "https://example.com/issues/12", BaseBranch: "main", WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", BranchDiffSummary: "Keep the error-state form inputs intact."}
 	pr := ghcli.PullRequest{Number: 88, URL: "https://example.com/pull/88", Title: "Fix bug", Body: "This PR keeps the original UX behavior.", Mergeable: "CONFLICTING", MergeStateStatus: "DIRTY"}
 	prompt := BuildConflictResolutionPrompt(target, session, pr)
-	for _, text := range []string{"Use the `vigilante-conflict-resolution` skill", "Issue specification: Preserve the original validation behavior.", "Pull Request title: Fix bug", "GitHub mergeability: mergeable=CONFLICTING mergeStateStatus=DIRTY", "Work through the rebase commit by commit.", "go test ./...", "Existing branch summary: Keep the error-state form inputs intact."} {
+	for _, text := range []string{"Use the `vigilante-conflict-resolution` skill", "Issue specification: Preserve the original validation behavior.", "Pull Request title: Fix bug", "GitHub mergeability: mergeable=CONFLICTING mergeStateStatus=DIRTY", "Work through the rebase commit by commit.", "vigilante logs --repo <owner/name> --issue <n>", "go test ./...", "Existing branch summary: Keep the error-state form inputs intact."} {
 		if !strings.Contains(prompt, text) {
 			t.Fatalf("prompt missing %q: %s", text, prompt)
 		}

--- a/skills/vigilante-conflict-resolution/SKILL.md
+++ b/skills/vigilante-conflict-resolution/SKILL.md
@@ -13,9 +13,10 @@ Use this skill after Vigilante has already opened a pull request and a follow-up
 2. Read repository instructions that affect the touched files before editing.
 3. Comment on the issue when conflict resolution begins and again for meaningful milestones or failures.
 4. Resolve only the conflicts needed to complete the rebase cleanly, commit by commit, while preserving the original issue specification and branch intent.
-5. Rerun the requested validation after the rebase succeeds.
-6. Push the updated branch back to GitHub.
-7. Report the final result clearly on the issue, including any remaining blocker if the conflicts cannot be resolved safely.
+5. If the rebase fails, post-rebase validation fails, or the current session state is unclear, inspect `vigilante logs --repo <owner/name> --issue <n>` before retrying so the persisted session transcript becomes the factual source for the next safe action.
+6. After inspecting the log, either continue with the smallest safe fix, rerun the requested validation, or report a blocker on the issue when the transcript shows the branch should not be retried automatically.
+7. Push the updated branch back to GitHub after the rebase and requested validation succeed.
+8. Report the final result clearly on the issue, including any remaining blocker if the conflicts cannot be resolved safely.
 
 ## Guardrails
 - Stay inside the provided worktree.


### PR DESCRIPTION
## Summary
- add `vigilante logs --repo <owner/name> --issue <n>` triage guidance to the conflict-resolution skill for failed rebases, failed validation, and unclear session state
- align the generated conflict-resolution prompt with the same log-inspection step
- cover the prompt text in the existing conflict-resolution prompt test

## Validation
- `go test ./internal/skill`

Closes #283
