### PR TITLE
Add logs triage guidance to issue implementation skills

### DIFF
--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -209,6 +209,44 @@ func TestVigilanteSkillNamesIncludesLocalServiceDependencies(t *testing.T) {
 	}
 }
 
+func TestEnsureInstalledIssueImplementationSkillsIncludeLogsTriageGuidance(t *testing.T) {
+	dir := t.TempDir()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	outside := t.TempDir()
+	if err := os.Chdir(outside); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.Chdir(wd)
+	}()
+
+	if err := EnsureInstalled(RuntimeCodex, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedCommand := "vigilante logs --repo <owner/name> --issue <n>"
+	for _, name := range []string{
+		VigilanteIssueImplementation,
+		VigilanteIssueImplementationOnMonorepo,
+		VigilanteIssueImplementationOnTurborepo,
+		VigilanteIssueImplementationOnRushMonorepo,
+		VigilanteIssueImplementationOnBazelMonorepo,
+		VigilanteIssueImplementationOnGradleMultiProject,
+	} {
+		data, err := os.ReadFile(filepath.Join(dir, "skills", name, "SKILL.md"))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		body := string(data)
+		if !strings.Contains(body, expectedCommand) {
+			t.Fatalf("%s missing logs triage guidance", name)
+		}
+	}
+}
+
 func TestBuildIssuePromptSelectsMonorepoSkill(t *testing.T) {
 	target := state.WatchTarget{
 		Path: "/tmp/repo",

--- a/skills/vigilante-issue-implementation-on-bazel-monorepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-bazel-monorepo/SKILL.md
@@ -42,7 +42,7 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 5. Validate incrementally
 - Start with the smallest relevant Bazel target, package pattern, or documented wrapper command for the touched area.
 - Expand to closely related targets only when the first target scope is insufficient or shared code requires it.
-- If validation fails, determine whether the problem is in the code, target selection, test setup, or environment before retrying.
+- If validation fails, first inspect the per-issue session log with `vigilante logs --repo <owner/name> --issue <n>` to determine whether the problem is in the code, target selection, test setup, or environment before retrying.
 
 6. Commit, push, and open a pull request
 - Commit only issue-relevant changes in the assigned branch.
@@ -51,4 +51,5 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 
 7. Report progress and failures clearly
 - Use `vigilante gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
+- If execution is blocked, validation fails, or a resumed session is unclear, inspect `vigilante logs --repo <owner/name> --issue <n>` before retrying or reporting the blocker.
 - Keep comments concise, factual, and tied to real progress.

--- a/skills/vigilante-issue-implementation-on-gradle-multi-project/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-gradle-multi-project/SKILL.md
@@ -43,7 +43,7 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 5. Validate incrementally
 - Run the most relevant Gradle tasks for the affected subproject(s) first, such as repo-defined `test`, `check`, `build`, or narrower module tasks.
 - Log the selected subproject(s) and Gradle task scope in issue progress updates when validation starts or changes.
-- If validation fails, determine whether the problem is in the code, Gradle task selection, test setup, or environment before retrying.
+- If validation fails, first inspect the per-issue session log with `vigilante logs --repo <owner/name> --issue <n>` to determine whether the problem is in the code, Gradle task selection, test setup, or environment before retrying.
 
 6. Commit, push, and open a pull request
 - Commit only issue-relevant changes in the assigned branch.
@@ -52,4 +52,5 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 
 7. Report progress and failures clearly
 - Use `vigilante gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
+- If execution is blocked, validation fails, or a resumed session is unclear, inspect `vigilante logs --repo <owner/name> --issue <n>` before retrying or reporting the blocker.
 - Keep comments concise, factual, and tied to real progress.

--- a/skills/vigilante-issue-implementation-on-monorepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-monorepo/SKILL.md
@@ -42,7 +42,7 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 
 5. Validate incrementally
 - Run the most relevant package/app/workspace checks first, then expand only if needed.
-- If validation fails, determine whether the problem is in the code, test setup, or environment before retrying.
+- If validation fails, first inspect the per-issue session log with `vigilante logs --repo <owner/name> --issue <n>` to determine whether the problem is in the code, test setup, or environment before retrying.
 
 6. Commit, push, and open a pull request
 - Commit only issue-relevant changes in the assigned branch.
@@ -51,4 +51,5 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 
 7. Report progress and failures clearly
 - Use `vigilante gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
+- If execution is blocked, validation fails, or a resumed session is unclear, inspect `vigilante logs --repo <owner/name> --issue <n>` before retrying or reporting the blocker.
 - Keep comments concise, factual, and tied to real progress.

--- a/skills/vigilante-issue-implementation-on-rush-monorepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-rush-monorepo/SKILL.md
@@ -42,7 +42,7 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 5. Validate incrementally with Rush-compatible commands
 - Prefer targeted Rush validation for the affected package or app, such as repo-defined `rush test`, `rush build`, `rushx`, phased commands, or package-level scripts invoked through Rush-compatible flows.
 - Avoid full-repo validation unless the repository workflow requires it or targeted validation is unavailable.
-- If validation fails, determine whether the problem is in the code, test setup, or environment before retrying.
+- If validation fails, first inspect the per-issue session log with `vigilante logs --repo <owner/name> --issue <n>` to determine whether the problem is in the code, test setup, or environment before retrying.
 
 6. Commit, push, and open a pull request
 - Commit only issue-relevant changes in the assigned branch.
@@ -51,4 +51,5 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 
 7. Report progress and failures clearly
 - Use `vigilante gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
+- If execution is blocked, validation fails, or a resumed session is unclear, inspect `vigilante logs --repo <owner/name> --issue <n>` before retrying or reporting the blocker.
 - Keep comments concise, factual, and tied to real progress.

--- a/skills/vigilante-issue-implementation-on-turborepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-turborepo/SKILL.md
@@ -50,7 +50,7 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - Run the smallest relevant workspace-aware checks first for install, lint, build, test, typecheck, or app verification.
 - Prefer commands already defined in `package.json`, workspace manifests, or `turbo.json`.
 - Expand validation scope only when the changed package affects shared dependencies, downstream apps, or integration behavior.
-- If validation fails, determine whether the problem is in the code, test setup, or environment before retrying.
+- If validation fails, first inspect the per-issue session log with `vigilante logs --repo <owner/name> --issue <n>` to determine whether the problem is in the code, test setup, or environment before retrying.
 
 6. Commit, push, and open a pull request
 - Commit only issue-relevant changes in the assigned branch.
@@ -59,5 +59,6 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 
 7. Report progress and failures clearly
 - Use `vigilante gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
+- If execution is blocked, validation fails, or a resumed session is unclear, inspect `vigilante logs --repo <owner/name> --issue <n>` before retrying or reporting the blocker.
 - Keep comments concise, factual, and tied to real progress.
 - Include the selected workspace scope in milestone updates when that information helps reviewers follow the implementation.

--- a/skills/vigilante-issue-implementation/SKILL.md
+++ b/skills/vigilante-issue-implementation/SKILL.md
@@ -50,7 +50,7 @@ Service dependencies:
 5. Validate incrementally
 - Run relevant tests, builds, or linters for the changed area before concluding work.
 - Prefer targeted validation first, then broader validation when necessary.
-- If a command fails, determine whether the problem is in the code, test setup, or environment before retrying.
+- If a command fails, first inspect the per-issue session log with `vigilante logs --repo <owner/name> --issue <n>` to determine whether the problem is in the code, test setup, or environment before retrying.
 
 6. Commit and push the branch
 - Commit only issue-relevant changes in the assigned branch.
@@ -72,7 +72,9 @@ Service dependencies:
 - Do not spam the issue with low-signal updates.
 
 9. Handle failures and blockers explicitly
-- If tool setup fails, validation fails, or the issue is blocked, comment on the issue with the concrete problem using `vigilante gh issue comment`.
+- If tool setup fails, validation fails, the provider stops unexpectedly, a resumed session still looks unclear, or the issue is otherwise blocked, first inspect the per-issue session log with `vigilante logs --repo <owner/name> --issue <n>`.
+- After checking the log, comment on the issue with the concrete problem using `vigilante gh issue comment`.
+- Use `vigilante logs` for targeted local triage only when work is blocked or failing; do not turn it into routine log scraping on successful runs.
 - Include enough detail for a human maintainer to understand the current state and next step.
 - If work cannot proceed safely, stop and report the blocker instead of guessing.
 
@@ -90,6 +92,7 @@ Service dependencies:
 - Add progress comments for non-trivial implementations as milestones are reached.
 - Comment when the PR is opened.
 - Comment immediately on any execution failure or blocking condition.
+- When a failure or blocker is unclear locally, inspect `vigilante logs --repo <owner/name> --issue <n>` before reporting or retrying.
 - Comments should be concise, concrete, and tied to real progress.
 - Avoid generic status text that does not help the issue reader.
 


### PR DESCRIPTION
## Summary
- add explicit `vigilante logs --repo <owner/name> --issue <n>` triage guidance to the base issue implementation skill
- mirror the same failure-path guidance in stack-specific implementation skills that restate validation or blocker handling
- add a focused test that asserts the installed skill assets include the logs triage command

## Validation
- `go test ./internal/skill`

Closes #282