### PR TITLE
Add first-class base branch support beyond main

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Upgrade later with:
 brew upgrade --cask vigilante
 ```
 
-### `vigilante watch [--assignee <value>] [--max-parallel <value>] [--provider <codex|claude|gemini>] <path>`
+### `vigilante watch [--assignee <value>] [--max-parallel <value>] [--provider <codex|claude|gemini>] [--branch <name> | --track-default-branch] <path>`
 
 Register a local repository for issue monitoring.
 
@@ -209,10 +209,14 @@ Expected behavior:
 - expands `~` and resolves the absolute path
 - validates the folder is a git repository
 - discovers the GitHub remote from git config
+- defaults new watch targets to tracking the repository's current default branch automatically
+- pins the base branch when `--branch <name>` is supplied
+- switches an existing target back to default-branch tracking when `--track-default-branch` is supplied
 - defaults the assignee filter to `me` unless overridden
 - defaults `--max-parallel` to `0` when not configured, where `0` means unlimited
 - defaults `--provider` to `codex` unless overridden
 - resolves `me` to the authenticated GitHub login at runtime before issue queries
+- preserves an existing target's branch mode unless one of the branch flags is supplied
 - stores the target in `~/.vigilante/watchlist.json`
 
 Example:
@@ -241,6 +245,14 @@ vigilante watch --provider claude ~/hello-world-app
 vigilante watch --provider gemini ~/hello-world-app
 ```
 
+```sh
+vigilante watch --branch develop ~/hello-world-app
+```
+
+```sh
+vigilante watch --track-default-branch ~/hello-world-app
+```
+
 ### `vigilante watch -d <path>`
 
 Register a repository and ensure the daemon/service is installed and started.
@@ -263,6 +275,7 @@ Expected fields:
 - daemon status
 - last scan time
 - active issue/session, if any
+- effective base branch and whether it is `auto` or `pinned`
 
 ### `vigilante list --running`
 
@@ -276,7 +289,7 @@ Expected behavior:
 
 - reports a stable `state` value of `running`, `stopped`, or `not-installed`
 - includes the service manager, service identifier, and installed service file path
-- includes a watched-repositories summary with key per-repo metadata such as repo slug, branch, provider, filters or limits, activity, and last scan time
+- includes a watched-repositories summary with key per-repo metadata such as repo slug, branch plus branch mode, provider, filters or limits, activity, and last scan time
 - exits successfully when the service is not installed so operators and scripts can inspect the reported state
 - fails with a clear error on unsupported operating systems or when the underlying service manager cannot be queried
 
@@ -544,6 +557,7 @@ Suggested `watchlist.json` shape:
   {
     "path": "/Users/example/hello-world-app",
     "repo": "owner/hello-world-app",
+    "branch_mode": "auto",
     "branch": "main",
     "assignee": "me",
     "max_parallel_sessions": 0,
@@ -575,7 +589,7 @@ Future policy can expand to richer label filters, assignment rules, and priority
 
 For pull requests tied to an active Vigilante session:
 
-- keep the branch updated against `origin/main` through the existing maintenance loop
+- keep the branch updated against the session or pull request base branch through the existing maintenance loop instead of assuming `main`
 - if either the source issue or the PR has `vigilante:automerge`, attempt a GitHub squash merge only after required checks pass and GitHub reports the PR is mergeable
 - keep the legacy plain `automerge` PR label working as a compatibility alias during migration to the namespaced label
 - never force through branch protection, required reviews, or failing checks

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -102,6 +102,13 @@ type githubRateLimitState struct {
 
 type stringListFlag []string
 
+type watchBranchOptions struct {
+	pinnedBranch        string
+	trackDefaultBranch  bool
+	branchFlagSet       bool
+	trackDefaultFlagSet bool
+}
+
 func (f *stringListFlag) String() string {
 	return strings.Join(*f, ",")
 }
@@ -267,7 +274,7 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 	case "watch":
 		fs := flag.NewFlagSet("watch", flag.ContinueOnError)
 		configureFlagSet(fs, func(w io.Writer) {
-			fmt.Fprintln(w, "usage: vigilante watch [-d] [--label value] [--assignee value] [--max-parallel value] [--provider value] <path>")
+			fmt.Fprintln(w, "usage: vigilante watch [-d] [--label value] [--assignee value] [--max-parallel value] [--provider value] [--branch value | --track-default-branch] <path>")
 			fmt.Fprintln(w)
 			fmt.Fprintln(w, "Register a local repository for issue monitoring.")
 			fmt.Fprintln(w)
@@ -280,6 +287,8 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 		assignee := fs.String("assignee", "", "issue assignee filter (defaults to me)")
 		maxParallel := fs.Int("max-parallel", 0, "maximum concurrent issue sessions for this repository (0 = unlimited)")
 		selectedProvider := fs.String("provider", "", "coding agent provider")
+		branch := fs.String("branch", "", "pin the watched repository to a specific base branch")
+		trackDefaultBranch := fs.Bool("track-default-branch", false, "track the repository default branch automatically")
 		if err := parseFlagSet(fs, args[1:], a.stdout); err != nil {
 			if errors.Is(err, errHelpHandled) {
 				return nil
@@ -287,15 +296,26 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 			return err
 		}
 		if fs.NArg() != 1 {
-			return errors.New("usage: vigilante watch [-d] [--label value] [--assignee value] [--max-parallel value] [--provider value] <path>")
+			return errors.New("usage: vigilante watch [-d] [--label value] [--assignee value] [--max-parallel value] [--provider value] [--branch value | --track-default-branch] <path>")
 		}
 		parsedMaxParallel := unsetMaxParallel
+		branchOptions := watchBranchOptions{}
 		fs.Visit(func(f *flag.Flag) {
-			if f.Name == "max-parallel" {
+			switch f.Name {
+			case "max-parallel":
 				parsedMaxParallel = *maxParallel
+			case "branch":
+				branchOptions.branchFlagSet = true
+			case "track-default-branch":
+				branchOptions.trackDefaultFlagSet = true
 			}
 		})
-		return a.WatchWithProvider(ctx, fs.Arg(0), *daemon, labels, *assignee, parsedMaxParallel, *selectedProvider)
+		branchOptions.pinnedBranch = strings.TrimSpace(*branch)
+		branchOptions.trackDefaultBranch = *trackDefaultBranch
+		if branchOptions.branchFlagSet && branchOptions.trackDefaultFlagSet {
+			return errors.New("watch accepts either --branch or --track-default-branch, not both")
+		}
+		return a.watchWithOptions(ctx, fs.Arg(0), *daemon, labels, *assignee, parsedMaxParallel, *selectedProvider, branchOptions)
 	case "unwatch":
 		if len(args) != 2 {
 			return errors.New("usage: vigilante unwatch <path>")
@@ -682,12 +702,19 @@ func (a *App) Watch(ctx context.Context, rawPath string, daemon bool, labels []s
 }
 
 func (a *App) WatchWithProvider(ctx context.Context, rawPath string, daemon bool, labels []string, assignee string, maxParallel int, providerID string) error {
+	return a.watchWithOptions(ctx, rawPath, daemon, labels, assignee, maxParallel, providerID, watchBranchOptions{})
+}
+
+func (a *App) watchWithOptions(ctx context.Context, rawPath string, daemon bool, labels []string, assignee string, maxParallel int, providerID string, branchOptions watchBranchOptions) error {
 	a.state.AppendDaemonLog("watch start raw_path=%q daemon=%t assignee=%q max_parallel=%d", rawPath, daemon, assignee, maxParallel)
 	if err := a.state.EnsureLayout(); err != nil {
 		return err
 	}
 	if maxParallel < 0 && maxParallel != unsetMaxParallel {
 		return errors.New("max parallel must be at least 0")
+	}
+	if branchOptions.branchFlagSet && branchOptions.pinnedBranch == "" {
+		return errors.New("branch cannot be empty")
 	}
 	if strings.TrimSpace(providerID) != "" {
 		resolvedProvider, err := provider.Resolve(providerID)
@@ -718,7 +745,6 @@ func (a *App) WatchWithProvider(ctx context.Context, rawPath string, daemon bool
 	for i, target := range targets {
 		if target.Path == info.Path {
 			targets[i].Repo = info.Repo
-			targets[i].Branch = info.Branch
 			targets[i].Classification = info.Classification
 			if strings.TrimSpace(targets[i].Provider) == "" {
 				targets[i].Provider = provider.DefaultID
@@ -736,6 +762,29 @@ func (a *App) WatchWithProvider(ctx context.Context, rawPath string, daemon bool
 				targets[i].MaxParallel = maxParallel
 			}
 			targets[i].DaemonEnabled = daemon
+			switch {
+			case branchOptions.branchFlagSet:
+				targets[i].BranchMode = state.BranchModePinned
+				targets[i].Branch = branchOptions.pinnedBranch
+				resolvedBranch, err := repo.ResolveBranch(ctx, a.env.Runner, info.Path, string(targets[i].EffectiveBranchMode()), targets[i].Branch)
+				if err != nil {
+					return err
+				}
+				targets[i].Branch = resolvedBranch
+			case branchOptions.trackDefaultFlagSet:
+				targets[i].BranchMode = state.BranchModeAuto
+				resolvedBranch, err := repo.ResolveBranch(ctx, a.env.Runner, info.Path, string(targets[i].EffectiveBranchMode()), targets[i].Branch)
+				if err != nil {
+					return err
+				}
+				targets[i].Branch = resolvedBranch
+			case targets[i].EffectiveBranchMode() == state.BranchModeAuto:
+				resolvedBranch, err := repo.ResolveBranch(ctx, a.env.Runner, info.Path, string(targets[i].EffectiveBranchMode()), targets[i].Branch)
+				if err != nil {
+					return err
+				}
+				targets[i].Branch = resolvedBranch
+			}
 			updated = true
 			break
 		}
@@ -745,6 +794,7 @@ func (a *App) WatchWithProvider(ctx context.Context, rawPath string, daemon bool
 		target := state.WatchTarget{
 			Path:           info.Path,
 			Repo:           info.Repo,
+			BranchMode:     state.BranchModeAuto,
 			Branch:         info.Branch,
 			Classification: info.Classification,
 			Provider:       provider.DefaultID,
@@ -756,6 +806,15 @@ func (a *App) WatchWithProvider(ctx context.Context, rawPath string, daemon bool
 		}
 		if providerID != "" {
 			target.Provider = providerID
+		}
+		if branchOptions.branchFlagSet {
+			target.BranchMode = state.BranchModePinned
+			target.Branch = branchOptions.pinnedBranch
+			resolvedBranch, err := repo.ResolveBranch(ctx, a.env.Runner, info.Path, string(target.EffectiveBranchMode()), target.Branch)
+			if err != nil {
+				return err
+			}
+			target.Branch = resolvedBranch
 		}
 		targets = append(targets, target)
 	}
@@ -777,10 +836,12 @@ func (a *App) WatchWithProvider(ctx context.Context, rawPath string, daemon bool
 	}
 
 	if updated {
-		a.state.AppendDaemonLog("watch updated path=%s repo=%s branch=%s assignee=%s max_parallel=%d daemon=%t", info.Path, info.Repo, info.Branch, assigneeOrDefault(findWatchTargetAssignee(targets, info.Path)), findWatchTargetMaxParallel(targets, info.Path), daemon)
+		updatedTarget := findWatchTargetByPath(targets, info.Path)
+		a.state.AppendDaemonLog("watch updated path=%s repo=%s branch=%s branch_mode=%s assignee=%s max_parallel=%d daemon=%t", info.Path, info.Repo, updatedTarget.Branch, updatedTarget.EffectiveBranchMode(), assigneeOrDefault(findWatchTargetAssignee(targets, info.Path)), findWatchTargetMaxParallel(targets, info.Path), daemon)
 		fmt.Fprintln(a.stdout, "updated", info.Path)
 	} else {
-		a.state.AppendDaemonLog("watch added path=%s repo=%s branch=%s assignee=%s max_parallel=%d daemon=%t", info.Path, info.Repo, info.Branch, assigneeOrDefault(assignee), configuredMaxParallel(maxParallel), daemon)
+		addedTarget := findWatchTargetByPath(targets, info.Path)
+		a.state.AppendDaemonLog("watch added path=%s repo=%s branch=%s branch_mode=%s assignee=%s max_parallel=%d daemon=%t", info.Path, info.Repo, addedTarget.Branch, addedTarget.EffectiveBranchMode(), assigneeOrDefault(assignee), configuredMaxParallel(maxParallel), daemon)
 		fmt.Fprintln(a.stdout, "watching", info.Path)
 	}
 	return nil
@@ -976,6 +1037,16 @@ func (a *App) ScanOnce(ctx context.Context) error {
 			}
 			target.MaxParallel = configuredMaxParallel(target.MaxParallel)
 			target.Classification = repo.Classify(target.Path)
+			if target.EffectiveBranchMode() == state.BranchModeAuto {
+				resolvedBranch, err := repo.ResolveBranch(ctx, a.env.Runner, target.Path, string(target.EffectiveBranchMode()), target.Branch)
+				if err != nil {
+					return err
+				}
+				if target.Branch != resolvedBranch {
+					a.state.AppendDaemonLog("watch branch refreshed repo=%s path=%s old=%s new=%s mode=%s", target.Repo, target.Path, target.Branch, resolvedBranch, target.EffectiveBranchMode())
+					target.Branch = resolvedBranch
+				}
+			}
 			var started int
 			sessions, started, err = a.processGitHubIterationRequestsForTarget(ctx, *target, sessions)
 			if err != nil {
@@ -1024,6 +1095,22 @@ func (a *App) ScanOnce(ctx context.Context) error {
 					a.state.AppendDaemonLog("scan repo issue provider override repo=%s issue=%d provider=%s source=label", target.Repo, next.Number, selectedProvider)
 				}
 				a.state.AppendDaemonLog("scan repo issue skill repo=%s issue=%d skill=%s shape=%s", target.Repo, next.Number, skill.IssueImplementationSkill(*target), target.Classification.Shape)
+				resolvedBranch, err := repo.ResolveBranch(ctx, a.env.Runner, target.Path, string(target.EffectiveBranchMode()), target.Branch)
+				if err != nil {
+					session := blockedIssueSessionForDispatchFailure(*target, next, selectedProvider, err, a.clock())
+					previous, _ := findSession(sessions, target.Repo, next.Number)
+					a.commentDispatchFailure(ctx, previous, &session, "dispatch")
+					a.state.AppendDaemonLog("scan repo dispatch blocked repo=%s issue=%d err=%v", target.Repo, next.Number, err)
+					sessions = upsertSession(sessions, session)
+					if err := a.state.SaveSessions(sessions); err != nil {
+						return err
+					}
+					a.emitSessionTransition(previous.Status, session, "dispatch")
+					a.syncSessionIssueLabelsBestEffort(ctx, session, nil)
+					fmt.Fprintf(a.stdout, "repo: %s blocked issue #%d: %s\n", target.Repo, next.Number, summarizeText(err.Error()))
+					continue
+				}
+				target.Branch = resolvedBranch
 
 				wt, err := worktree.CreateIssueWorktree(ctx, a.env.Runner, *target, next.Number, next.Title)
 				if err != nil {
@@ -1608,8 +1695,17 @@ func (a *App) waitForSessions() {
 func (a *App) maintainOpenPullRequest(ctx context.Context, session *state.Session, pr ghcli.PullRequest) error {
 	previousMaintenanceError := session.LastMaintenanceError
 	session.LastMaintenanceError = ""
+	fallbackTarget := a.fallbackWatchTargetForSession(*session)
+	baseBranch := strings.TrimSpace(pr.BaseRefName)
+	if baseBranch == "" {
+		baseBranch = effectiveSessionBaseBranch(*session, fallbackTarget)
+	}
+	if baseBranch == "" {
+		return errors.New("pull request base branch is unavailable")
+	}
+	session.PullRequestBaseBranch = baseBranch
 
-	if _, err := a.env.Runner.Run(ctx, session.WorktreePath, "git", "fetch", "origin", "main"); err != nil {
+	if _, err := a.env.Runner.Run(ctx, session.WorktreePath, "git", "fetch", "origin", baseBranch); err != nil {
 		return err
 	}
 
@@ -1638,10 +1734,6 @@ func (a *App) maintainOpenPullRequest(ctx context.Context, session *state.Sessio
 		return a.dispatchConflictResolution(ctx, session, *details)
 	}
 
-	baseBranch := strings.TrimSpace(session.BaseBranch)
-	if baseBranch == "" {
-		baseBranch = "main"
-	}
 	baseRef := "origin/" + baseBranch
 	rebaseOutput, err := a.env.Runner.Run(ctx, session.WorktreePath, "git", "rebase", baseRef)
 	rebased := rebaseChangedHistory(rebaseOutput)
@@ -1681,7 +1773,7 @@ func (a *App) maintainOpenPullRequest(ctx context.Context, session *state.Sessio
 		Percent:    90,
 		ETAMinutes: 5,
 		Items: []string{
-			fmt.Sprintf("Rebased PR #%d onto the latest `origin/main`.", pr.Number),
+			fmt.Sprintf("Rebased PR #%d onto the latest `origin/%s`.", pr.Number, baseBranch),
 			"Reran `go test ./...` after the rebase.",
 			fmt.Sprintf("Pushed the updated branch `%s`.", session.Branch),
 		},
@@ -1703,10 +1795,7 @@ func (a *App) dispatchConflictResolution(ctx context.Context, session *state.Ses
 		session.IssueURL = issueDetails.URL
 	}
 
-	baseBranch := strings.TrimSpace(session.BaseBranch)
-	if baseBranch == "" {
-		baseBranch = "main"
-	}
+	baseBranch := pullRequestBaseBranch(*session)
 	body := ghcli.FormatProgressComment(ghcli.ProgressComment{
 		Stage:      "Conflict Resolution Started",
 		Emoji:      "⚔️",
@@ -1723,7 +1812,7 @@ func (a *App) dispatchConflictResolution(ctx context.Context, session *state.Ses
 		a.state.AppendDaemonLog("pr conflict comment failed repo=%s issue=%d pr=%d err=%v", session.Repo, session.IssueNumber, pr.Number, commentErr)
 	}
 
-	target := state.WatchTarget{Path: session.RepoPath, Repo: session.Repo, Branch: baseBranch}
+	target := watchTargetForSession(*session, a.fallbackWatchTargetForSession(*session))
 	if conflictErr := issuerunner.RunConflictResolutionSession(ctx, a.env, a.state, target, *session, pr); conflictErr != nil {
 		return conflictErr
 	}
@@ -1855,7 +1944,7 @@ func (a *App) handleFailingPullRequestChecks(ctx context.Context, session *state
 	})
 	a.commentOnIssueBestEffort(ctx, session.Repo, session.IssueNumber, startBody, "ci remediation start")
 
-	target := state.WatchTarget{Path: session.RepoPath, Repo: session.Repo, Branch: "main"}
+	target := watchTargetForSession(*session, a.fallbackWatchTargetForSession(*session))
 	if err := issuerunner.RunCIRemediationSession(ctx, a.env, a.state, target, *session, pr, failingChecks); err != nil {
 		blocked := classifyBlockedReason("ci_remediation", "coding agent remediation", err)
 		markSessionBlocked(session, "ci_remediation", blocked, a.clock())
@@ -2531,7 +2620,11 @@ func (a *App) preflightResume(ctx context.Context, session state.Session) error 
 	tool := providerRuntimeTool(selectedProvider)
 	switch session.BlockedReason.Kind {
 	case "git_auth":
-		_, err = a.env.Runner.Run(ctx, session.WorktreePath, "git", "fetch", "origin", "main")
+		baseBranch := effectiveSessionBaseBranch(session, a.fallbackWatchTargetForSession(session))
+		if baseBranch == "" {
+			return errors.New("base branch is unavailable for git auth preflight")
+		}
+		_, err = a.env.Runner.Run(ctx, session.WorktreePath, "git", "fetch", "origin", baseBranch)
 		return err
 	case "gh_auth":
 		if _, err := a.env.Runner.Run(ctx, "", "gh", "auth", "status"); err != nil {
@@ -2575,7 +2668,7 @@ func (a *App) resumeBlockedMaintenance(ctx context.Context, session *state.Sessi
 
 func (a *App) resumeBlockedIssueExecution(ctx context.Context, session *state.Session) error {
 	issue := ghcli.Issue{Number: session.IssueNumber, Title: session.IssueTitle, URL: session.IssueURL}
-	target := state.WatchTarget{Path: session.RepoPath, Repo: session.Repo, Branch: "main"}
+	target := watchTargetForSession(*session, a.fallbackWatchTargetForSession(*session))
 	selectedProvider, err := provider.Resolve(session.Provider)
 	if err != nil {
 		return err
@@ -2626,7 +2719,10 @@ func (a *App) resumeBlockedConflictResolution(ctx context.Context, session *stat
 	if pr == nil {
 		return errors.New("no pull request found for blocked conflict-resolution session")
 	}
-	target := state.WatchTarget{Path: session.RepoPath, Repo: session.Repo, Branch: "main"}
+	if strings.TrimSpace(pr.BaseRefName) != "" {
+		session.PullRequestBaseBranch = strings.TrimSpace(pr.BaseRefName)
+	}
+	target := watchTargetForSession(*session, a.fallbackWatchTargetForSession(*session))
 	if err := issuerunner.RunConflictResolutionSession(ctx, a.env, a.state, target, *session, *pr); err != nil {
 		return err
 	}
@@ -3062,7 +3158,11 @@ func updatePullRequestTrackingFromLookup(session *state.Session, pr ghcli.PullRe
 	session.PullRequestURL = strings.TrimSpace(pr.URL)
 	session.PullRequestState = strings.TrimSpace(pr.State)
 	session.PullRequestHeadBranch = strings.TrimSpace(session.Branch)
-	session.PullRequestBaseBranch = pullRequestBaseBranch(*session)
+	if baseRef := strings.TrimSpace(pr.BaseRefName); baseRef != "" {
+		session.PullRequestBaseBranch = baseRef
+	} else {
+		session.PullRequestBaseBranch = pullRequestBaseBranch(*session)
+	}
 	if pr.MergedAt != nil {
 		session.PullRequestMergedAt = pr.MergedAt.UTC().Format(time.RFC3339)
 	}
@@ -3082,11 +3182,52 @@ func updatePullRequestMaintenanceSnapshot(session *state.Session, pr ghcli.PullR
 }
 
 func pullRequestBaseBranch(session state.Session) string {
-	baseBranch := strings.TrimSpace(session.BaseBranch)
-	if baseBranch == "" {
-		return "main"
+	if baseBranch := strings.TrimSpace(session.PullRequestBaseBranch); baseBranch != "" {
+		return baseBranch
 	}
+	baseBranch := strings.TrimSpace(session.BaseBranch)
 	return baseBranch
+}
+
+func effectiveSessionBaseBranch(session state.Session, fallbackTarget state.WatchTarget) string {
+	if baseBranch := pullRequestBaseBranch(session); baseBranch != "" {
+		return baseBranch
+	}
+	if baseBranch := strings.TrimSpace(fallbackTarget.Branch); baseBranch != "" {
+		return baseBranch
+	}
+	return "main"
+}
+
+func watchTargetForSession(session state.Session, fallbackTarget state.WatchTarget) state.WatchTarget {
+	target := state.WatchTarget{
+		Path:           session.RepoPath,
+		Repo:           session.Repo,
+		BranchMode:     state.BranchModePinned,
+		Branch:         effectiveSessionBaseBranch(session, fallbackTarget),
+		Classification: fallbackTarget.Classification,
+		Provider:       fallbackTarget.Provider,
+		Labels:         fallbackTarget.Labels,
+		Assignee:       fallbackTarget.Assignee,
+		MaxParallel:    fallbackTarget.MaxParallel,
+		DaemonEnabled:  fallbackTarget.DaemonEnabled,
+	}
+	return target
+}
+
+func (a *App) fallbackWatchTargetForSession(session state.Session) state.WatchTarget {
+	targets, err := a.state.LoadWatchTargets()
+	if err == nil {
+		if target, ok := findWatchTargetByRepo(targets, session.Repo); ok {
+			return target
+		}
+	}
+	return state.WatchTarget{
+		Path:       session.RepoPath,
+		Repo:       session.Repo,
+		BranchMode: state.BranchModePinned,
+		Branch:     strings.TrimSpace(session.BaseBranch),
+	}
 }
 
 func pullRequestStatusFingerprint(session state.Session, pr ghcli.PullRequest) string {
@@ -4318,7 +4459,7 @@ func isHelpToken(value string) bool {
 func (a *App) printUsage(w io.Writer) {
 	fmt.Fprintln(w, "usage:")
 	fmt.Fprintln(w, "  vigilante setup [-d] [--provider value]")
-	fmt.Fprintln(w, "  vigilante watch [-d] [--label value] [--assignee value] [--max-parallel value] [--provider value] <path>")
+	fmt.Fprintln(w, "  vigilante watch [-d] [--label value] [--assignee value] [--max-parallel value] [--provider value] [--branch value | --track-default-branch] <path>")
 	fmt.Fprintln(w, "  vigilante unwatch <path>")
 	fmt.Fprintln(w, "  vigilante list [--blocked | --running]")
 	fmt.Fprintln(w, "  vigilante status")
@@ -4379,7 +4520,7 @@ _vigilante()
             return
             ;;
         watch)
-            COMPREPLY=( $(compgen -W "-d --label --assignee --max-parallel --provider" -- "$cur") )
+            COMPREPLY=( $(compgen -W "-d --label --assignee --max-parallel --provider --branch --track-default-branch" -- "$cur") )
             return
             ;;
         list)
@@ -4446,6 +4587,8 @@ complete -c vigilante -n '__fish_seen_subcommand_from watch' -l label
 complete -c vigilante -n '__fish_seen_subcommand_from watch' -l assignee
 complete -c vigilante -n '__fish_seen_subcommand_from watch' -l max-parallel
 complete -c vigilante -n '__fish_seen_subcommand_from watch' -l provider
+complete -c vigilante -n '__fish_seen_subcommand_from watch' -l branch
+complete -c vigilante -n '__fish_seen_subcommand_from watch' -l track-default-branch
 complete -c vigilante -n '__fish_seen_subcommand_from watch' -s d
 complete -c vigilante -n '__fish_seen_subcommand_from list' -l blocked
 complete -c vigilante -n '__fish_seen_subcommand_from list' -l running
@@ -4494,7 +4637,7 @@ _vigilante() {
       compadd -- -d --provider
       ;;
     watch)
-      compadd -- -d --label --assignee --max-parallel --provider
+      compadd -- -d --label --assignee --max-parallel --provider --branch --track-default-branch
       ;;
     list)
       compadd -- --blocked --running
@@ -4566,6 +4709,15 @@ func findWatchTargetByRepo(targets []state.WatchTarget, repo string) (state.Watc
 		}
 	}
 	return state.WatchTarget{}, false
+}
+
+func findWatchTargetByPath(targets []state.WatchTarget, path string) state.WatchTarget {
+	for _, target := range targets {
+		if target.Path == path {
+			return target
+		}
+	}
+	return state.WatchTarget{}
 }
 
 func issueMatchesLabelAllowlist(issue ghcli.Issue, allowlist []string) bool {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -741,6 +741,7 @@ func TestSyncSessionIssueLabelsUsesPullRequestReviewState(t *testing.T) {
 			"gh pr view --repo owner/repo 17 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup": `{"number":17,"title":"Demo PR","body":"PR body","url":"https://github.com/owner/repo/pull/17","state":"OPEN","mergedAt":null,"labels":[],"isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[{"context":"test","state":"COMPLETED","conclusion":"SUCCESS"}]}`,
 			"gh api repos/owner/repo/issues/7": `{"labels":[{"name":"vigilante:ready-for-review"},{"name":"vigilante:needs-review"}]}`,
 			"gh issue edit --repo owner/repo 7 --add-label vigilante:awaiting-user-validation --remove-label vigilante:needs-review --remove-label vigilante:ready-for-review": "ok",
+			"gh issue edit --repo owner/repo 7 --remove-label vigilante:needs-review":                                                                                          "ok",
 		},
 	}
 
@@ -4042,6 +4043,7 @@ func TestScanOnceReusesExistingRemoteIssueBranchAndPersistsDiffContext(t *testin
 			"gh auth status":          "ok",
 			"gh api user --jq .login": "nicobistolfi\n",
 			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[{"name":"to-do"}]}]`,
+			"git ls-remote --exit-code --heads origin main":                                                                 "abcdef1234567890\trefs/heads/main\n",
 			"git worktree prune":                              "ok",
 			"git fetch origin " + branch + ":" + branch:       "ok",
 			"git worktree add " + worktreePath + " " + branch: "ok",
@@ -4100,6 +4102,7 @@ func TestScanOnceBlocksIssueWhenReusedRemoteBranchDiffAnalysisFails(t *testing.T
 			"gh auth status":          "ok",
 			"gh api user --jq .login": "nicobistolfi\n",
 			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[{"name":"to-do"}]}]`,
+			"git ls-remote --exit-code --heads origin main":                                                                 "abcdef1234567890\trefs/heads/main\n",
 			"git worktree prune":                              "ok",
 			"git fetch origin " + branch + ":" + branch:       "ok",
 			"git worktree add " + worktreePath + " " + branch: "ok",
@@ -6381,6 +6384,7 @@ func TestScanOnceSkipsDuplicateConflictResolutionDispatchWhenPRFingerprintIsUnch
 	if err != nil {
 		t.Fatal(err)
 	}
+	sessions[0].BaseBranch = "main"
 	updatePullRequestMaintenanceSnapshot(&sessions[0], ghcli.PullRequest{
 		Number:            31,
 		Title:             "Test PR",
@@ -6473,10 +6477,11 @@ func failedResumeSession(session state.Session) state.Session {
 
 func freshBaseBranchOutputs(repoPath string, branch string) map[string]string {
 	return map[string]string{
-		"git fetch origin " + branch:                  "ok",
-		"git worktree list --porcelain":               "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/" + branch + "\n",
-		"git status --porcelain --untracked-files=no": "",
-		"git merge --ff-only origin/" + branch:        "Already up to date.\n",
+		"git ls-remote --exit-code --heads origin " + branch: "abcdef1234567890\trefs/heads/" + branch + "\n",
+		"git fetch origin " + branch:                         "ok",
+		"git worktree list --porcelain":                      "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/" + branch + "\n",
+		"git status --porcelain --untracked-files=no":        "",
+		"git merge --ff-only origin/" + branch:               "Already up to date.\n",
 	}
 }
 

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -227,7 +227,7 @@ func watchedRepoStatuses(targets []state.WatchTarget, sessions []state.Session) 
 func formatWatchTargetRow(status watchedRepoStatus) string {
 	target := status.Target
 	fields := []string{
-		fmt.Sprintf("branch %s", valueOrUnknown(target.Branch)),
+		fmt.Sprintf("branch %s (%s)", valueOrUnknown(target.Branch), target.EffectiveBranchMode()),
 		fmt.Sprintf("provider %s", valueOrUnknown(target.Provider)),
 	}
 	if assignee := strings.TrimSpace(target.Assignee); assignee != "" {

--- a/internal/app/status_test.go
+++ b/internal/app/status_test.go
@@ -420,9 +420,9 @@ func TestStatusCommandShowsWatchedRepositories(t *testing.T) {
 	output := stdout.String()
 	for _, want := range []string{
 		"Watched repositories (2)",
-		"owner/alpha (branch main, provider codex, assignee me, max 2, 1 active, 1 blocked, last scan 2026-03-19 11:55 UTC)",
+		"owner/alpha (branch main (pinned), provider codex, assignee me, max 2, 1 active, 1 blocked, last scan 2026-03-19 11:55 UTC)",
 		"path: /repos/alpha",
-		"owner/beta (branch develop, provider claude, labels to-do,bug, idle, last scan 2026-03-19 11:40 UTC)",
+		"owner/beta (branch develop (pinned), provider claude, labels to-do,bug, idle, last scan 2026-03-19 11:40 UTC)",
 		"path: /repos/beta",
 	} {
 		if !strings.Contains(output, want) {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -30,6 +30,7 @@ type PullRequest struct {
 	Body              string            `json:"body"`
 	URL               string            `json:"url"`
 	State             string            `json:"state"`
+	BaseRefName       string            `json:"baseRefName"`
 	MergedAt          *time.Time        `json:"mergedAt"`
 	Labels            []Label           `json:"labels"`
 	IsDraft           bool              `json:"isDraft"`
@@ -612,7 +613,35 @@ func GetPullRequestDetails(ctx context.Context, runner environment.Runner, repo 
 	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &pr); err != nil {
 		return nil, fmt.Errorf("parse gh pr view output: %w", err)
 	}
+	if baseRefName, err := pullRequestBaseRefName(ctx, runner, repo, number); err == nil {
+		pr.BaseRefName = baseRefName
+	}
 	return &pr, nil
+}
+
+func pullRequestBaseRefName(ctx context.Context, runner environment.Runner, repo string, number int) (string, error) {
+	output, err := runner.Run(
+		ctx,
+		"",
+		"gh",
+		"pr",
+		"view",
+		"--repo",
+		repo,
+		fmt.Sprintf("%d", number),
+		"--json",
+		"baseRefName",
+	)
+	if err != nil {
+		return "", err
+	}
+	var payload struct {
+		BaseRefName string `json:"baseRefName"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &payload); err != nil {
+		return "", fmt.Errorf("parse gh pr base ref output: %w", err)
+	}
+	return strings.TrimSpace(payload.BaseRefName), nil
 }
 
 func MergePullRequestSquash(ctx context.Context, runner environment.Runner, repo string, number int) error {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -355,6 +355,7 @@ func TestGetPullRequestDetails(t *testing.T) {
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{
 			"gh pr view --repo owner/repo 17 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup": `{"number":17,"title":"Feature","body":"PR body","url":"https://github.com/owner/repo/pull/17","state":"OPEN","mergedAt":null,"labels":[{"name":"automerge"}],"isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[{"context":"test","state":"COMPLETED","conclusion":"SUCCESS"}]}`,
+			"gh pr view --repo owner/repo 17 --json baseRefName": "{" + `"baseRefName":"develop"` + "}",
 		},
 	}
 
@@ -364,6 +365,9 @@ func TestGetPullRequestDetails(t *testing.T) {
 	}
 	if pr.Number != 17 || pr.Title != "Feature" || pr.Mergeable != "MERGEABLE" || pr.MergeStateStatus != "CLEAN" || pr.ReviewDecision != "APPROVED" {
 		t.Fatalf("unexpected pull request details: %#v", pr)
+	}
+	if pr.BaseRefName != "develop" {
+		t.Fatalf("unexpected pull request base: %#v", pr)
 	}
 	if len(pr.Labels) != 1 || pr.Labels[0].Name != "automerge" {
 		t.Fatalf("expected automerge label, got: %#v", pr.Labels)

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -73,11 +73,9 @@ func Discover(ctx context.Context, runner environment.Runner, path string) (Info
 		return Info{}, err
 	}
 
-	branch := "main"
-	if remoteHead, err := runner.Run(ctx, absPath, "git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"); err == nil {
-		branch = strings.TrimPrefix(strings.TrimSpace(remoteHead), "origin/")
-	} else if current, err := runner.Run(ctx, absPath, "git", "branch", "--show-current"); err == nil && strings.TrimSpace(current) != "" {
-		branch = strings.TrimSpace(current)
+	branch, err := ResolveDefaultBranch(ctx, runner, absPath, "")
+	if err != nil {
+		return Info{}, err
 	}
 
 	return Info{
@@ -86,6 +84,78 @@ func Discover(ctx context.Context, runner environment.Runner, path string) (Info
 		Branch:         branch,
 		Classification: Classify(absPath),
 	}, nil
+}
+
+func ResolveBranch(ctx context.Context, runner environment.Runner, repoPath string, branchMode string, branch string) (string, error) {
+	switch strings.TrimSpace(branchMode) {
+	case "", "pinned":
+		branch := strings.TrimSpace(branch)
+		if branch == "" {
+			return "", errors.New("pinned branch is not configured")
+		}
+		exists, err := remoteBranchExists(ctx, runner, repoPath, branch)
+		if err != nil {
+			return "", err
+		}
+		if !exists {
+			return "", fmt.Errorf("pinned base branch %q was not found on origin", branch)
+		}
+		return branch, nil
+	case "auto":
+		return ResolveDefaultBranch(ctx, runner, repoPath, branch)
+	default:
+		return "", fmt.Errorf("unsupported branch mode %q", branchMode)
+	}
+}
+
+func ResolveDefaultBranch(ctx context.Context, runner environment.Runner, repoPath string, fallback string) (string, error) {
+	if branch, err := remoteHEADBranch(ctx, runner, repoPath); err == nil && branch != "" {
+		return branch, nil
+	}
+	if branch, err := localRemoteHEADBranch(ctx, runner, repoPath); err == nil && branch != "" {
+		return branch, nil
+	}
+	fallback = strings.TrimSpace(fallback)
+	if fallback != "" {
+		return fallback, nil
+	}
+	if current, err := runner.Run(ctx, repoPath, "git", "branch", "--show-current"); err == nil && strings.TrimSpace(current) != "" {
+		return strings.TrimSpace(current), nil
+	}
+	return "", errors.New("could not resolve repository default branch")
+}
+
+func remoteHEADBranch(ctx context.Context, runner environment.Runner, repoPath string) (string, error) {
+	output, err := runner.Run(ctx, repoPath, "git", "ls-remote", "--symref", "origin", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) >= 3 && fields[0] == "ref:" && fields[2] == "HEAD" {
+			return strings.TrimPrefix(fields[1], "refs/heads/"), nil
+		}
+	}
+	return "", errors.New("origin HEAD did not report a branch")
+}
+
+func localRemoteHEADBranch(ctx context.Context, runner environment.Runner, repoPath string) (string, error) {
+	output, err := runner.Run(ctx, repoPath, "git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(strings.TrimSpace(output), "origin/"), nil
+}
+
+func remoteBranchExists(ctx context.Context, runner environment.Runner, repoPath string, branch string) (bool, error) {
+	_, err := runner.Run(ctx, repoPath, "git", "ls-remote", "--exit-code", "--heads", "origin", branch)
+	if err == nil {
+		return true, nil
+	}
+	if strings.Contains(err.Error(), "exit status 1") || strings.Contains(err.Error(), "exit status 2") {
+		return false, nil
+	}
+	return false, err
 }
 
 func Classify(path string) Classification {

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -179,13 +179,10 @@ func BuildIssuePromptForRuntime(runtime string, target state.WatchTarget, issue 
 		lines = append(lines, iterationContext)
 	}
 	if strings.TrimSpace(session.ReusedRemoteBranch) != "" {
-		baseBranch := strings.TrimSpace(session.BaseBranch)
-		if baseBranch == "" {
-			baseBranch = "main"
-		}
+		baseBranch := promptBaseBranch(target, session)
 		lines = append(lines,
 			fmt.Sprintf("Existing remote issue branch detected: origin/%s", session.ReusedRemoteBranch),
-			fmt.Sprintf("Default branch for comparison: %s", baseBranch),
+			fmt.Sprintf("Base branch for comparison: %s", baseBranch),
 			fmt.Sprintf("Diff summary against `%s`: %s", baseBranch, fallbackPromptText(session.BranchDiffSummary, "Diff analysis was requested but no summary was recorded.")),
 			"Continue from the reused branch state and build on top of the existing diff instead of restarting from scratch.",
 		)
@@ -354,12 +351,9 @@ func monorepoExecutionContextJSON(target state.WatchTarget, selectedSkill string
 }
 
 func BuildIssuePreflightPrompt(target state.WatchTarget, issue ghcli.Issue, session state.Session) string {
-	baselineLine := fmt.Sprintf("Before implementing issue #%d, validate the repository baseline from the current `main`-derived worktree without making any file changes.", issue.Number)
+	baseBranch := promptBaseBranch(target, session)
+	baselineLine := fmt.Sprintf("Before implementing issue #%d, validate the repository baseline from the current `%s`-derived worktree without making any file changes.", issue.Number, baseBranch)
 	if strings.TrimSpace(session.ReusedRemoteBranch) != "" {
-		baseBranch := strings.TrimSpace(session.BaseBranch)
-		if baseBranch == "" {
-			baseBranch = "main"
-		}
 		baselineLine = fmt.Sprintf("Before implementing issue #%d, validate the repository baseline from the current reused issue-branch worktree without making any file changes. This branch is being continued from `origin/%s` and compared against `%s`.", issue.Number, session.ReusedRemoteBranch, baseBranch)
 	}
 	lines := []string{
@@ -424,10 +418,7 @@ func BuildConflictResolutionPromptForRuntime(runtime string, target state.WatchT
 	}
 	baseBranch := strings.TrimSpace(session.BaseBranch)
 	if baseBranch == "" {
-		baseBranch = strings.TrimSpace(target.Branch)
-	}
-	if baseBranch == "" {
-		baseBranch = "main"
+		baseBranch = promptBaseBranch(target, session)
 	}
 	baseRef := "origin/" + baseBranch
 	lines = append(lines,
@@ -455,6 +446,19 @@ func BuildConflictResolutionPromptForRuntime(runtime string, target state.WatchT
 		lines = append(lines, fmt.Sprintf("Existing branch summary: %s", session.BranchDiffSummary))
 	}
 	return strings.Join(lines, "\n")
+}
+
+func promptBaseBranch(target state.WatchTarget, session state.Session) string {
+	if baseBranch := strings.TrimSpace(session.PullRequestBaseBranch); baseBranch != "" {
+		return baseBranch
+	}
+	if baseBranch := strings.TrimSpace(session.BaseBranch); baseBranch != "" {
+		return baseBranch
+	}
+	if baseBranch := strings.TrimSpace(target.Branch); baseBranch != "" {
+		return baseBranch
+	}
+	return "main"
 }
 
 func BuildCIRemediationPrompt(target state.WatchTarget, session state.Session, pr ghcli.PullRequest, checks []ghcli.StatusCheckRoll) string {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -155,7 +155,7 @@ func TestBuildIssuePromptIncludesReusedRemoteBranchContext(t *testing.T) {
 	prompt := BuildIssuePrompt(target, issue, session)
 	for _, text := range []string{
 		"Existing remote issue branch detected: origin/vigilante/issue-12-fix-bug",
-		"Default branch for comparison: main",
+		"Base branch for comparison: main",
 		"Diff summary against `main`: README.md | 2 ++",
 		"Continue from the reused branch state",
 	} {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -18,6 +18,7 @@ import (
 type WatchTarget struct {
 	Path           string              `json:"path"`
 	Repo           string              `json:"repo"`
+	BranchMode     BranchMode          `json:"branch_mode,omitempty"`
 	Branch         string              `json:"branch"`
 	Classification repo.Classification `json:"classification,omitempty"`
 	Provider       string              `json:"provider,omitempty"`
@@ -27,6 +28,22 @@ type WatchTarget struct {
 	DaemonEnabled  bool                `json:"daemon_enabled"`
 	LastScanAt     string              `json:"last_scan_at,omitempty"`
 	AddedAt        string              `json:"added_at,omitempty"`
+}
+
+type BranchMode string
+
+const (
+	BranchModeAuto   BranchMode = "auto"
+	BranchModePinned BranchMode = "pinned"
+)
+
+func (t WatchTarget) EffectiveBranchMode() BranchMode {
+	switch t.BranchMode {
+	case BranchModeAuto:
+		return BranchModeAuto
+	default:
+		return BranchModePinned
+	}
 }
 
 const DefaultMaxParallelSessions = 0


### PR DESCRIPTION
## Summary
- add explicit watch-target branch modes with auto default-branch tracking and pinned branch support
- route dispatch, resume, maintenance, and prompt generation through the resolved session or PR base branch
- show branch mode in operator-facing status output and document the new watch behavior

## Validation
- `go test ./...`

Closes #290
