### PR TITLE
Add command access log visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,13 +295,14 @@ Expected behavior:
 - exits successfully when the service is not installed so operators and scripts can inspect the reported state
 - fails with a clear error on unsupported operating systems or when the underlying service manager cannot be queried
 
-### `vigilante logs [--repo <owner/name>] [--issue <n>]`
+### `vigilante logs [--access] [--repo <owner/name>] [--issue <n>]`
 
 Inspect local log files under `~/.vigilante/logs/`.
 
 Expected behavior:
 
-- `vigilante logs` lists the available daemon and per-issue session logs so an operator can see which local evidence exists before choosing a recovery action
+- `vigilante logs` lists the available daemon, access, and per-issue session logs so an operator can see which local evidence exists before choosing a recovery action
+- `vigilante logs --access` prints the structured access log at `~/.vigilante/logs/access.jsonl`, where each JSON line records one subprocess execution with timing, execution context, repo or issue metadata when available, sanitized argv, and exit status
 - `vigilante logs --repo <owner/name> --issue <n>` prints the log for one issue session so an operator can inspect the latest local execution details directly
 - logs complement `vigilante list`, `vigilante status`, and GitHub issue comments; they do not replace session state or the remote audit trail
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -138,6 +138,7 @@ func New() *App {
 			Runner: environment.LoggingRunner{
 				Base:             environment.ExecRunner{},
 				CaptureCommand:   telemetry.CaptureInternalCommand,
+				AccessLog:        store.AppendAccessLogEntry,
 				Logf:             store.AppendDaemonLog,
 				LogSuccessOutput: os.Getenv("VIGILANTE_DEBUG_COMMAND_OUTPUT") == "1",
 			},
@@ -577,19 +578,31 @@ func (a *App) runCompletionCommand(args []string) error {
 func (a *App) runLogsCommand(args []string) error {
 	fs := flag.NewFlagSet("logs", flag.ContinueOnError)
 	configureFlagSet(fs, func(w io.Writer) {
-		fmt.Fprintln(w, "usage: vigilante logs [--repo <owner/name>] [--issue <n>]")
+		fmt.Fprintln(w, "usage: vigilante logs [--access] [--repo <owner/name>] [--issue <n>]")
 		fmt.Fprintln(w)
-		fmt.Fprintln(w, "List session log files or show a specific session log.")
+		fmt.Fprintln(w, "List daemon, access, and session log files or show a specific log.")
 		fmt.Fprintln(w)
 		fs.SetOutput(w)
 		fs.PrintDefaults()
 	})
+	accessFlag := fs.Bool("access", false, "show the structured access log")
 	repoFlag := fs.String("repo", "", "repository slug")
 	issueFlag := fs.Int("issue", 0, "issue number")
 	if err := parseFlagSet(fs, args, a.stdout); err != nil {
 		if errors.Is(err, errHelpHandled) {
 			return nil
 		}
+		return err
+	}
+	if *accessFlag {
+		if *repoFlag != "" || *issueFlag > 0 {
+			return errors.New("--access cannot be combined with --repo or --issue")
+		}
+		content, err := os.ReadFile(a.state.AccessLogPath())
+		if err != nil {
+			return errors.New("no access log found")
+		}
+		_, err = fmt.Fprint(a.stdout, string(content))
 		return err
 	}
 
@@ -4463,7 +4476,7 @@ func (a *App) printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  vigilante unwatch <path>")
 	fmt.Fprintln(w, "  vigilante list [--blocked | --running]")
 	fmt.Fprintln(w, "  vigilante status")
-	fmt.Fprintln(w, "  vigilante logs [--repo <owner/name>] [--issue <n>]")
+	fmt.Fprintln(w, "  vigilante logs [--access] [--repo <owner/name>] [--issue <n>]")
 	fmt.Fprintln(w, "  vigilante cleanup --repo <owner/name> [--issue <n>]")
 	fmt.Fprintln(w, "  vigilante cleanup --all")
 	fmt.Fprintln(w, "  vigilante redispatch --repo <owner/name> --issue <n>")

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -6576,6 +6576,9 @@ func TestLogsCommandListsFiles(t *testing.T) {
 	if err := os.MkdirAll(logsDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(logsDir, "access.jsonl"), []byte("{\"context\":\"daemon\"}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(filepath.Join(logsDir, "vigilante.log"), []byte("daemon log"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -6596,8 +6599,37 @@ func TestLogsCommandListsFiles(t *testing.T) {
 	if !strings.Contains(output, "owner-repo-issue-42.log") {
 		t.Fatalf("expected output to list session log, got %q", output)
 	}
+	if !strings.Contains(output, "access.jsonl") {
+		t.Fatalf("expected output to list access log, got %q", output)
+	}
 	if !strings.Contains(output, "vigilante.log") {
 		t.Fatalf("expected output to list daemon log, got %q", output)
+	}
+}
+
+func TestLogsCommandShowsAccessLog(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	logsDir := filepath.Join(home, ".vigilante", "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logContent := "{\"context\":\"daemon\",\"tool\":\"gh\"}\n"
+	if err := os.WriteFile(filepath.Join(logsDir, "access.jsonl"), []byte(logContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+
+	exitCode := app.Run(context.Background(), []string{"logs", "--access"})
+	if exitCode != 0 {
+		t.Fatalf("expected success exit code, got %d", exitCode)
+	}
+	if stdout.String() != logContent {
+		t.Fatalf("expected access log content %q, got %q", logContent, stdout.String())
 	}
 }
 

--- a/internal/environment/accesslog.go
+++ b/internal/environment/accesslog.go
@@ -1,0 +1,170 @@
+package environment
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type AccessLogContext struct {
+	ExecutionContext string `json:"context,omitempty"`
+	Repo             string `json:"repo,omitempty"`
+	IssueNumber      int    `json:"issue_number,omitempty"`
+	Branch           string `json:"branch,omitempty"`
+	WorktreePath     string `json:"worktree_path,omitempty"`
+}
+
+type AccessLogEntry struct {
+	Timestamp        string   `json:"timestamp"`
+	CompletedAt      string   `json:"completed_at"`
+	ExecutionContext string   `json:"context"`
+	Repo             string   `json:"repo,omitempty"`
+	IssueNumber      int      `json:"issue_number,omitempty"`
+	Branch           string   `json:"branch,omitempty"`
+	WorktreePath     string   `json:"worktree_path,omitempty"`
+	Dir              string   `json:"dir,omitempty"`
+	Tool             string   `json:"tool"`
+	Argv             []string `json:"argv"`
+	ExitCode         int      `json:"exit_code"`
+	DurationMs       int64    `json:"duration_ms"`
+	Success          bool     `json:"success"`
+}
+
+type accessLogContextKey struct{}
+
+func WithAccessLogContext(ctx context.Context, meta AccessLogContext) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	current, _ := ctx.Value(accessLogContextKey{}).(AccessLogContext)
+	if strings.TrimSpace(meta.ExecutionContext) != "" {
+		current.ExecutionContext = strings.TrimSpace(meta.ExecutionContext)
+	}
+	if strings.TrimSpace(meta.Repo) != "" {
+		current.Repo = strings.TrimSpace(meta.Repo)
+	}
+	if meta.IssueNumber > 0 {
+		current.IssueNumber = meta.IssueNumber
+	}
+	if strings.TrimSpace(meta.Branch) != "" {
+		current.Branch = strings.TrimSpace(meta.Branch)
+	}
+	if strings.TrimSpace(meta.WorktreePath) != "" {
+		current.WorktreePath = strings.TrimSpace(meta.WorktreePath)
+	}
+	return context.WithValue(ctx, accessLogContextKey{}, current)
+}
+
+func buildAccessLogEntry(ctx context.Context, dir string, name string, args []string, startedAt time.Time, endedAt time.Time, err error) AccessLogEntry {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	meta, _ := ctx.Value(accessLogContextKey{}).(AccessLogContext)
+	executionContext := strings.TrimSpace(meta.ExecutionContext)
+	if executionContext == "" {
+		executionContext = "daemon"
+	}
+	return AccessLogEntry{
+		Timestamp:        startedAt.UTC().Format(time.RFC3339Nano),
+		CompletedAt:      endedAt.UTC().Format(time.RFC3339Nano),
+		ExecutionContext: executionContext,
+		Repo:             strings.TrimSpace(meta.Repo),
+		IssueNumber:      meta.IssueNumber,
+		Branch:           strings.TrimSpace(meta.Branch),
+		WorktreePath:     strings.TrimSpace(meta.WorktreePath),
+		Dir:              strings.TrimSpace(dir),
+		Tool:             strings.TrimSpace(name),
+		Argv:             sanitizeAccessLogArgs(args),
+		ExitCode:         exitCodeForError(err),
+		DurationMs:       endedAt.Sub(startedAt).Milliseconds(),
+		Success:          err == nil,
+	}
+}
+
+func exitCodeForError(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	if err == context.DeadlineExceeded {
+		return 124
+	}
+	if err == context.Canceled {
+		return 130
+	}
+	return 1
+}
+
+func sanitizeAccessLogArgs(args []string) []string {
+	if len(args) == 0 {
+		return nil
+	}
+	sanitized := make([]string, 0, len(args))
+	redactNext := false
+	for _, arg := range args {
+		trimmed := strings.TrimSpace(arg)
+		switch {
+		case redactNext:
+			sanitized = append(sanitized, "<redacted>")
+			redactNext = false
+		case isHeaderFlag(trimmed):
+			sanitized = append(sanitized, trimmed)
+			redactNext = true
+		case hasSensitiveAssignment(trimmed):
+			key, _, _ := strings.Cut(trimmed, "=")
+			sanitized = append(sanitized, key+"=<redacted>")
+		case hasSensitiveFlag(trimmed):
+			sanitized = append(sanitized, trimmed)
+			redactNext = true
+		case looksSensitiveValue(trimmed):
+			sanitized = append(sanitized, "<redacted>")
+		default:
+			sanitized = append(sanitized, trimmed)
+		}
+	}
+	return sanitized
+}
+
+func isHeaderFlag(arg string) bool {
+	return arg == "-H" || arg == "--header"
+}
+
+func hasSensitiveAssignment(arg string) bool {
+	key, value, ok := strings.Cut(arg, "=")
+	if !ok {
+		return false
+	}
+	return value != "" && looksSensitiveFlagName(key)
+}
+
+func hasSensitiveFlag(arg string) bool {
+	if !strings.HasPrefix(arg, "-") {
+		return false
+	}
+	return looksSensitiveFlagName(arg)
+}
+
+func looksSensitiveFlagName(arg string) bool {
+	lower := strings.ToLower(strings.TrimLeft(strings.TrimSpace(arg), "-"))
+	for _, token := range []string{"token", "secret", "password", "authorization", "auth", "cookie"} {
+		if strings.Contains(lower, token) {
+			return true
+		}
+	}
+	return false
+}
+
+func looksSensitiveValue(arg string) bool {
+	lower := strings.ToLower(strings.TrimSpace(arg))
+	for _, token := range []string{"authorization:", "bearer ", "token ", "ghp_", "github_pat_"} {
+		if strings.Contains(lower, token) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -20,6 +20,7 @@ type ExecRunner struct{}
 type LoggingRunner struct {
 	Base             Runner
 	CaptureCommand   func(context.Context, string, []string, int, int64)
+	AccessLog        func(AccessLogEntry)
 	Logf             func(format string, args ...any)
 	LogSuccessOutput bool
 }
@@ -54,12 +55,13 @@ func (r LoggingRunner) Run(ctx context.Context, dir string, name string, args ..
 		r.Logf("command start dir=%q cmd=%s", dir, commandString(name, args...))
 	}
 	output, err := r.Base.Run(ctx, dir, name, args...)
-	exitCode := 0
-	if err != nil {
-		exitCode = 1
-	}
+	endedAt := time.Now().UTC()
+	exitCode := exitCodeForError(err)
 	if r.CaptureCommand != nil {
-		r.CaptureCommand(ctx, name, args, exitCode, time.Since(startedAt).Milliseconds())
+		r.CaptureCommand(ctx, name, args, exitCode, endedAt.Sub(startedAt).Milliseconds())
+	}
+	if r.AccessLog != nil {
+		r.AccessLog(buildAccessLogEntry(ctx, dir, name, args, startedAt, endedAt, err))
 	}
 	if r.Logf != nil {
 		if err != nil {

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -130,6 +130,73 @@ func TestLoggingRunnerEmitsTelemetryForTargetedInternalCommandsOnly(t *testing.T
 	}
 }
 
+func TestLoggingRunnerAccessLogDefaultsToDaemonContext(t *testing.T) {
+	var entries []AccessLogEntry
+	runner := LoggingRunner{
+		Base: testutil.FakeRunner{
+			Outputs: map[string]string{
+				"gh api /user -H Authorization: Bearer super-secret --jq .login": "octocat\n",
+			},
+		},
+		AccessLog: func(entry AccessLogEntry) {
+			entries = append(entries, entry)
+		},
+	}
+
+	if _, err := runner.Run(context.Background(), "/tmp/repo", "gh", "api", "/user", "-H", "Authorization: Bearer super-secret", "--jq", ".login"); err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 access log entry, got %d", len(entries))
+	}
+	if got, want := entries[0].ExecutionContext, "daemon"; got != want {
+		t.Fatalf("context = %q, want %q", got, want)
+	}
+	if got := strings.Join(entries[0].Argv, " "); strings.Contains(got, "super-secret") {
+		t.Fatalf("expected sanitized argv, got %q", got)
+	}
+	if got := strings.Join(entries[0].Argv, " "); !strings.Contains(got, "-H <redacted>") {
+		t.Fatalf("expected redacted header, got %q", got)
+	}
+}
+
+func TestLoggingRunnerAccessLogIncludesSessionContext(t *testing.T) {
+	var entries []AccessLogEntry
+	runner := LoggingRunner{
+		Base: testutil.FakeRunner{
+			Outputs: map[string]string{
+				"git status --short": "M README.md\n",
+			},
+		},
+		AccessLog: func(entry AccessLogEntry) {
+			entries = append(entries, entry)
+		},
+	}
+	ctx := WithAccessLogContext(context.Background(), AccessLogContext{
+		ExecutionContext: "session",
+		Repo:             "owner/repo",
+		IssueNumber:      7,
+		Branch:           "vigilante/issue-7",
+		WorktreePath:     "/tmp/worktree",
+	})
+
+	if _, err := runner.Run(ctx, "/tmp/worktree", "git", "status", "--short"); err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 access log entry, got %d", len(entries))
+	}
+	if got, want := entries[0].ExecutionContext, "session"; got != want {
+		t.Fatalf("context = %q, want %q", got, want)
+	}
+	if got, want := entries[0].Repo, "owner/repo"; got != want {
+		t.Fatalf("repo = %q, want %q", got, want)
+	}
+	if got, want := entries[0].IssueNumber, 7; got != want {
+		t.Fatalf("issue = %d, want %d", got, want)
+	}
+}
+
 func sprintf(format string, args ...any) string {
 	return fmt.Sprintf(format, args...)
 }

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -21,6 +21,13 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 	if session.Repo == "" {
 		session.Repo = target.Repo
 	}
+	ctx = environment.WithAccessLogContext(ctx, environment.AccessLogContext{
+		ExecutionContext: "session",
+		Repo:             session.Repo,
+		IssueNumber:      issue.Number,
+		Branch:           session.Branch,
+		WorktreePath:     session.WorktreePath,
+	})
 	logPath := store.SessionLogPath(session.Repo, issue.Number)
 	selectedProvider, err := provider.Resolve(session.Provider)
 	if err != nil {
@@ -187,6 +194,13 @@ func RunConflictResolutionSession(ctx context.Context, env *environment.Environm
 	if repoSlug == "" {
 		repoSlug = target.Repo
 	}
+	ctx = environment.WithAccessLogContext(ctx, environment.AccessLogContext{
+		ExecutionContext: "maintenance",
+		Repo:             repoSlug,
+		IssueNumber:      session.IssueNumber,
+		Branch:           session.Branch,
+		WorktreePath:     session.WorktreePath,
+	})
 	logPath := store.SessionLogPath(repoSlug, session.IssueNumber)
 	selectedProvider, err := provider.Resolve(session.Provider)
 	if err != nil {
@@ -234,6 +248,13 @@ func RunCIRemediationSession(ctx context.Context, env *environment.Environment, 
 	if repoSlug == "" {
 		repoSlug = target.Repo
 	}
+	ctx = environment.WithAccessLogContext(ctx, environment.AccessLogContext{
+		ExecutionContext: "maintenance",
+		Repo:             repoSlug,
+		IssueNumber:      session.IssueNumber,
+		Branch:           session.Branch,
+		WorktreePath:     session.WorktreePath,
+	})
 	logPath := store.SessionLogPath(repoSlug, session.IssueNumber)
 	selectedProvider, err := provider.Resolve(session.Provider)
 	if err != nil {

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -25,7 +25,7 @@ import (
 func TestRunIssueSessionSuccess(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
-	runner := testutil.FakeRunner{
+	baseRunner := testutil.FakeRunner{
 		Outputs: map[string]string{
 			"codex --version": "codex 0.114.0",
 			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
@@ -44,10 +44,16 @@ func TestRunIssueSessionSuccess(t *testing.T) {
 			issuePromptCommand("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", "vigilante/issue-7"):     "done",
 		},
 	}
-	env := &environment.Environment{OS: "darwin", Runner: runner}
 	store := state.NewStore()
 	if err := store.EnsureLayout(); err != nil {
 		t.Fatal(err)
+	}
+	env := &environment.Environment{
+		OS: "darwin",
+		Runner: environment.LoggingRunner{
+			Base:      baseRunner,
+			AccessLog: store.AppendAccessLogEntry,
+		},
 	}
 	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
 	got := RunIssueSession(context.Background(), env, store, state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
@@ -60,6 +66,17 @@ func TestRunIssueSessionSuccess(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "session succeeded") || !strings.Contains(string(data), "done") {
 		t.Fatalf("unexpected log: %s", string(data))
+	}
+	accessLog, err := os.ReadFile(store.AccessLogPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(accessLog)
+	if !strings.Contains(text, `"context":"session"`) {
+		t.Fatalf("expected session context in access log, got %s", text)
+	}
+	if !strings.Contains(text, `"repo":"owner/repo"`) || !strings.Contains(text, `"issue_number":7`) {
+		t.Fatalf("expected repo and issue metadata in access log, got %s", text)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/nicobistolfi/vigilante/internal/environment"
 	"github.com/nicobistolfi/vigilante/internal/logtime"
 	"github.com/nicobistolfi/vigilante/internal/repo"
 )
@@ -208,6 +209,10 @@ func (s *Store) DaemonLogPath() string {
 	return filepath.Join(s.LogsDir(), "vigilante.log")
 }
 
+func (s *Store) AccessLogPath() string {
+	return filepath.Join(s.LogsDir(), "access.jsonl")
+}
+
 var invalidSessionLogNameChars = regexp.MustCompile(`[^A-Za-z0-9]+`)
 
 func (s *Store) SessionLogPath(repoSlug string, issueNumber int) string {
@@ -377,6 +382,10 @@ func (s *Store) AppendDaemonLog(format string, args ...any) {
 	appendLogFile(s.DaemonLogPath(), fmt.Sprintf(format, args...))
 }
 
+func (s *Store) AppendAccessLogEntry(value environment.AccessLogEntry) {
+	appendJSONLine(s.AccessLogPath(), value)
+}
+
 func appendLogFile(path string, message string) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return
@@ -387,6 +396,22 @@ func appendLogFile(path string, message string) {
 	}
 	defer f.Close()
 	_, _ = fmt.Fprintf(f, "[%s] %s\n", logtime.FormatLocal(time.Now()), strings.TrimSpace(message))
+}
+
+func appendJSONLine(path string, value any) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_, _ = f.Write(append(data, '\n'))
 }
 
 func (s *Store) TryWithScanLock(fn func() error) (bool, error) {


### PR DESCRIPTION
## Summary
- add a dedicated `~/.vigilante/logs/access.jsonl` stream for subprocess executions
- capture daemon, session, and maintenance command context with sanitized argv, timing, and exit status
- expose the access log via `vigilante logs --access` and document the new operator surface

## Validation
- `go test ./...`

Closes #301