### PR TITLE
Fix nightly Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ Nightly install path:
 
 ```sh
 brew tap aliengiraffe/spaceship
-brew install --cask vigilante-nightly
+brew install vigilante-nightly
 ```
 
 Stable installs remain on the tagged release path:


### PR DESCRIPTION
## Summary
- fix the nightly Homebrew install command in the README to use `brew install vigilante-nightly`
- leave stable Homebrew install instructions unchanged

## Validation
- `rg -n "brew install --cask vigilante-nightly|brew install vigilante-nightly|brew install --cask vigilante" -S README.md`
- `git diff -- README.md`

Closes #307
