### PR TITLE
Show the running daemon version in vigilante status

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -667,12 +667,13 @@ func (a *App) statusServiceSection(ctx context.Context) (serviceStatusInfo, erro
 		return serviceStatusInfo{}, err
 	}
 	return serviceStatusInfo{
-		State:     status.State,
-		Manager:   status.Manager,
-		Service:   status.Service,
-		FilePath:  status.FilePath,
-		Installed: status.Installed,
-		Running:   status.Running,
+		State:         status.State,
+		Manager:       status.Manager,
+		Service:       status.Service,
+		FilePath:      status.FilePath,
+		Installed:     status.Installed,
+		Running:       status.Running,
+		DaemonVersion: status.DaemonVersion,
 	}, nil
 }
 

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -364,13 +364,26 @@ func writeStatusServiceSection(w io.Writer, s serviceStatusInfo) {
 	} else {
 		fmt.Fprintln(w, "  running: no")
 	}
+	if s.Installed {
+		switch {
+		case s.DaemonVersion != "" && s.Running:
+			fmt.Fprintf(w, "  daemon version: %s\n", s.DaemonVersion)
+		case s.DaemonVersion != "":
+			fmt.Fprintf(w, "  daemon version: %s (configured binary; service not running)\n", s.DaemonVersion)
+		case s.Running:
+			fmt.Fprintln(w, "  daemon version: unavailable")
+		default:
+			fmt.Fprintln(w, "  daemon version: unavailable (service not running)")
+		}
+	}
 }
 
 type serviceStatusInfo struct {
-	State     string
-	Manager   string
-	Service   string
-	FilePath  string
-	Installed bool
-	Running   bool
+	State         string
+	Manager       string
+	Service       string
+	FilePath      string
+	Installed     bool
+	Running       bool
+	DaemonVersion string
 }

--- a/internal/app/status_test.go
+++ b/internal/app/status_test.go
@@ -244,7 +244,7 @@ func TestStatusCommandOutputPreservesServiceState(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(unitPath, []byte("unit"), 0o644); err != nil {
+	if err := os.WriteFile(unitPath, []byte("[Service]\nExecStart=/home/test/.local/bin/vigilante daemon run\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -264,6 +264,7 @@ func TestStatusCommandOutputPreservesServiceState(t *testing.T) {
 	app.env.Runner = testutil.FakeRunner{
 		Outputs: map[string]string{
 			"systemctl --user show --property=LoadState,ActiveState vigilante.service": "LoadState=loaded\nActiveState=active\n",
+			"/home/test/.local/bin/vigilante --version":                                "vigilante 1.2.3\n",
 		},
 		Errors: map[string]error{
 			"gh api /rate_limit": nil,
@@ -280,10 +281,89 @@ func TestStatusCommandOutputPreservesServiceState(t *testing.T) {
 		"service: vigilante.service",
 		"installed: yes",
 		"running: yes",
+		"daemon version: 1.2.3",
 	} {
 		if !strings.Contains(stdout.String(), want) {
 			t.Errorf("expected output to contain %q, got:\n%s", want, stdout.String())
 		}
+	}
+}
+
+func TestStatusCommandOutputShowsConfiguredDaemonVersionWhenStopped(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "vigilante.service")
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unitPath, []byte("[Service]\nExecStart=/home/test/.local/bin/vigilante daemon run\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	vigilanteHome := filepath.Join(home, ".vigilante")
+	if err := os.MkdirAll(vigilanteHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(vigilanteHome, "sessions.json"), []byte("[]"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.OS = "linux"
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"systemctl --user show --property=LoadState,ActiveState vigilante.service": "LoadState=loaded\nActiveState=inactive\n",
+			"/home/test/.local/bin/vigilante --version":                                "vigilante 1.2.3\n",
+		},
+		Errors: map[string]error{
+			"gh api /rate_limit": nil,
+		},
+	}
+
+	exitCode := app.Run(context.Background(), []string{"status"})
+	if exitCode != 0 {
+		t.Fatalf("expected success exit code, got %d; stdout: %s", exitCode, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "daemon version: 1.2.3 (configured binary; service not running)") {
+		t.Fatalf("expected stopped daemon version signal, got:\n%s", stdout.String())
+	}
+}
+
+func TestStatusCommandOutputOmitsDaemonVersionWhenServiceIsNotInstalled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	vigilanteHome := filepath.Join(home, ".vigilante")
+	if err := os.MkdirAll(vigilanteHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(vigilanteHome, "sessions.json"), []byte("[]"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.OS = "linux"
+	app.env.Runner = testutil.FakeRunner{
+		Errors: map[string]error{
+			"gh api /rate_limit": nil,
+		},
+	}
+
+	exitCode := app.Run(context.Background(), []string{"status"})
+	if exitCode != 0 {
+		t.Fatalf("expected success exit code, got %d; stdout: %s", exitCode, stdout.String())
+	}
+	if strings.Contains(stdout.String(), "daemon version:") {
+		t.Fatalf("expected no daemon version when service is not installed, got:\n%s", stdout.String())
 	}
 }
 
@@ -296,7 +376,7 @@ func TestStatusCommandShowsSessionGroups(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(unitPath, []byte("unit"), 0o644); err != nil {
+	if err := os.WriteFile(unitPath, []byte("[Service]\nExecStart=/home/test/.local/bin/vigilante daemon run\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -360,7 +440,7 @@ func TestStatusCommandShowsWatchedRepositories(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(unitPath, []byte("unit"), 0o644); err != nil {
+	if err := os.WriteFile(unitPath, []byte("[Service]\nExecStart=/home/test/.local/bin/vigilante daemon run\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"html"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -32,13 +34,17 @@ const (
 )
 
 type Status struct {
-	Manager   string
-	Service   string
-	FilePath  string
-	State     string
-	Installed bool
-	Running   bool
+	Manager       string
+	Service       string
+	FilePath      string
+	State         string
+	Installed     bool
+	Running       bool
+	DaemonVersion string
 }
+
+var daemonVersionPattern = regexp.MustCompile(`\b(v?\d+\.\d+\.\d+)\b`)
+var launchdProgramArgumentsPattern = regexp.MustCompile(`(?s)<key>\s*ProgramArguments\s*</key>\s*<array>\s*<string>([^<]+)</string>`)
 
 func Install(ctx context.Context, env *environment.Environment, store *state.Store, selectedProvider provider.Provider) error {
 	cfg, err := BuildConfig(ctx, env, selectedProvider)
@@ -209,8 +215,26 @@ func ServiceStatus(ctx context.Context, env *environment.Environment) (Status, e
 	} else {
 		status.State = StatusStopped
 	}
+	status.DaemonVersion = detectConfiguredDaemonVersion(ctx, env, status)
 
 	return status, nil
+}
+
+func detectConfiguredDaemonVersion(ctx context.Context, env *environment.Environment, status Status) string {
+	if !status.Installed {
+		return ""
+	}
+
+	executable, err := daemonExecutableFromServiceDefinition(env.OS, status.FilePath)
+	if err != nil || strings.TrimSpace(executable) == "" {
+		return ""
+	}
+
+	output, err := env.Runner.Run(ctx, "", executable, "--version")
+	if err != nil {
+		return ""
+	}
+	return normalizeDaemonVersionOutput(output)
 }
 
 func Restart(ctx context.Context, env *environment.Environment) error {
@@ -334,6 +358,69 @@ func runtimeTool(selectedProvider provider.Provider) string {
 
 func shellQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
+}
+
+func daemonExecutableFromServiceDefinition(goos string, filePath string) (string, error) {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+
+	switch goos {
+	case "darwin":
+		return parseLaunchdExecutable(string(content)), nil
+	case "linux":
+		return parseSystemdExecutable(string(content)), nil
+	default:
+		return "", errors.New("unsupported OS")
+	}
+}
+
+func parseLaunchdExecutable(content string) string {
+	matches := launchdProgramArgumentsPattern.FindStringSubmatch(content)
+	if len(matches) != 2 {
+		return ""
+	}
+	return strings.TrimSpace(html.UnescapeString(matches[1]))
+}
+
+func parseSystemdExecutable(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "ExecStart=") {
+			continue
+		}
+		value := strings.TrimSpace(strings.TrimPrefix(line, "ExecStart="))
+		if value == "" {
+			return ""
+		}
+		if idx := strings.Index(value, " daemon run"); idx > 0 {
+			return strings.TrimSpace(value[:idx])
+		}
+		fields := strings.Fields(value)
+		if len(fields) == 0 {
+			return ""
+		}
+		return fields[0]
+	}
+	return ""
+}
+
+func normalizeDaemonVersionOutput(output string) string {
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return ""
+	}
+	if match := daemonVersionPattern.FindStringSubmatch(trimmed); len(match) == 2 {
+		return strings.TrimPrefix(match[1], "v")
+	}
+	for _, line := range strings.Split(trimmed, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line
+		}
+	}
+	return ""
 }
 
 func prepareMacOSDaemonBinary(ctx context.Context, runner environment.Runner, executable string) error {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -219,7 +219,18 @@ func TestServiceStatusReportsLaunchdRunning(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(plistPath, []byte("plist"), 0o644); err != nil {
+	if err := os.WriteFile(plistPath, []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/test/.local/bin/vigilante</string>
+    <string>daemon</string>
+    <string>run</string>
+  </array>
+</dict>
+</plist>
+`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -227,7 +238,8 @@ func TestServiceStatusReportsLaunchdRunning(t *testing.T) {
 		OS: "darwin",
 		Runner: testutil.FakeRunner{
 			Outputs: map[string]string{
-				testutil.Key("launchctl", "print", launchdTarget()): "pid = 412\nstate = running\n",
+				testutil.Key("launchctl", "print", launchdTarget()):           "pid = 412\nstate = running\n",
+				testutil.Key("/Users/test/.local/bin/vigilante", "--version"): "vigilante 1.2.3\n",
 			},
 		},
 	}
@@ -241,6 +253,9 @@ func TestServiceStatusReportsLaunchdRunning(t *testing.T) {
 	}
 	if status.Manager != "launchd" || status.Service != launchdLabel || status.FilePath != plistPath {
 		t.Fatalf("unexpected service metadata: %#v", status)
+	}
+	if status.DaemonVersion != "1.2.3" {
+		t.Fatalf("unexpected daemon version: %#v", status)
 	}
 }
 
@@ -280,7 +295,7 @@ func TestServiceStatusReportsSystemdRunning(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(unitPath, []byte("unit"), 0o644); err != nil {
+	if err := os.WriteFile(unitPath, []byte("[Service]\nExecStart=/home/test/.local/bin/vigilante daemon run\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -289,6 +304,7 @@ func TestServiceStatusReportsSystemdRunning(t *testing.T) {
 		Runner: testutil.FakeRunner{
 			Outputs: map[string]string{
 				testutil.Key("systemctl", "--user", "show", "--property=LoadState,ActiveState", systemdUnitName): "LoadState=loaded\nActiveState=active\n",
+				testutil.Key("/home/test/.local/bin/vigilante", "--version"):                                     "vigilante 1.2.3\n",
 			},
 		},
 	}
@@ -299,6 +315,42 @@ func TestServiceStatusReportsSystemdRunning(t *testing.T) {
 	}
 	if !status.Installed || !status.Running || status.State != StatusRunning {
 		t.Fatalf("unexpected status: %#v", status)
+	}
+	if status.DaemonVersion != "1.2.3" {
+		t.Fatalf("unexpected daemon version: %#v", status)
+	}
+}
+
+func TestServiceStatusReportsSystemdStoppedWithConfiguredDaemonVersion(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "vigilante.service")
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unitPath, []byte("[Service]\nExecStart=/home/test/.local/bin/vigilante daemon run\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := &environment.Environment{
+		OS: "linux",
+		Runner: testutil.FakeRunner{
+			Outputs: map[string]string{
+				testutil.Key("systemctl", "--user", "show", "--property=LoadState,ActiveState", systemdUnitName): "LoadState=loaded\nActiveState=inactive\n",
+				testutil.Key("/home/test/.local/bin/vigilante", "--version"):                                     "vigilante 1.2.3\n",
+			},
+		},
+	}
+
+	status, err := ServiceStatus(context.Background(), env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !status.Installed || status.Running || status.State != StatusStopped {
+		t.Fatalf("unexpected status: %#v", status)
+	}
+	if status.DaemonVersion != "1.2.3" {
+		t.Fatalf("unexpected daemon version: %#v", status)
 	}
 }
 
@@ -320,6 +372,9 @@ func TestServiceStatusReportsNotInstalledWhenUnitFileIsMissing(t *testing.T) {
 	}
 	if status.FilePath != filepath.Join(home, ".config", "systemd", "user", "vigilante.service") {
 		t.Fatalf("unexpected service file path: %#v", status)
+	}
+	if status.DaemonVersion != "" {
+		t.Fatalf("expected no daemon version: %#v", status)
 	}
 }
 


### PR DESCRIPTION
## Summary
- derive the service-managed Vigilante executable from the installed launchd/systemd definition during `vigilante status`
- report a labeled `daemon version` field, with explicit non-running wording when the service is stopped
- add regression coverage for running, stopped, and not-installed service states

## Validation
- `go test ./internal/service ./internal/app`
- `go test ./...`

Closes #310
