### PR TITLE
Gate nightly cask updates on a published nightly release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -91,6 +91,17 @@ jobs:
             --notes "$release_notes" \
             --prerelease
 
+          gh release edit "$NIGHTLY_TAG" \
+            --draft=false \
+            --prerelease
+
+      - name: Verify nightly release publication
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NIGHTLY_TAG: ${{ env.NIGHTLY_TAG }}
+          NIGHTLY_VERSION: ${{ env.NIGHTLY_VERSION }}
+        run: bash ./scripts/verify-nightly-release.sh
+
       - name: Check out Homebrew tap
         env:
           TAP_TOKEN: ${{ steps.tap_token.outputs.token }}

--- a/scripts/verify-nightly-release.sh
+++ b/scripts/verify-nightly-release.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${NIGHTLY_TAG:?NIGHTLY_TAG is required}"
+: "${NIGHTLY_VERSION:?NIGHTLY_VERSION is required}"
+
+repo="${GITHUB_REPOSITORY:-}"
+if [[ -z "$repo" ]]; then
+  printf 'GITHUB_REPOSITORY is required\n' >&2
+  exit 1
+fi
+
+max_attempts="${MAX_ATTEMPTS:-10}"
+sleep_seconds="${SLEEP_SECONDS:-6}"
+
+expected_assets=(
+  "vigilante_${NIGHTLY_VERSION}_Linux_amd64.tar.gz"
+  "vigilante_${NIGHTLY_VERSION}_macOS_amd64.tar.gz"
+  "vigilante_${NIGHTLY_VERSION}_macOS_arm64.tar.gz"
+)
+
+release_api="repos/${repo}/releases/tags/${NIGHTLY_TAG}"
+base_download_url="https://github.com/${repo}/releases/download/${NIGHTLY_TAG}"
+
+release_is_ready() {
+  local release_json="$1"
+  local draft prerelease asset_name
+
+  draft="$(jq -r '.draft' <<<"$release_json")"
+  prerelease="$(jq -r '.prerelease' <<<"$release_json")"
+
+  if [[ "$draft" != "false" || "$prerelease" != "true" ]]; then
+    printf 'release state not ready yet: draft=%s prerelease=%s\n' "$draft" "$prerelease" >&2
+    return 1
+  fi
+
+  for asset_name in "${expected_assets[@]}"; do
+    if ! jq -e --arg name "$asset_name" 'any(.assets[]?; .name == $name)' <<<"$release_json" >/dev/null; then
+      printf 'expected asset not present yet: %s\n' "$asset_name" >&2
+      return 1
+    fi
+  done
+
+  return 0
+}
+
+asset_urls_are_reachable() {
+  local asset_name asset_url
+
+  for asset_name in "${expected_assets[@]}"; do
+    asset_url="${base_download_url}/${asset_name}"
+    if ! curl --fail --silent --show-error --location --head "$asset_url" >/dev/null; then
+      printf 'asset URL not reachable yet: %s\n' "$asset_url" >&2
+      return 1
+    fi
+  done
+
+  return 0
+}
+
+for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+  printf 'verification attempt %d/%d\n' "$attempt" "$max_attempts"
+  release_json="$(gh api "$release_api")"
+
+  if release_is_ready "$release_json" && asset_urls_are_reachable; then
+    printf 'nightly release %s is published and downloadable\n' "$NIGHTLY_TAG"
+    exit 0
+  fi
+
+  if (( attempt < max_attempts )); then
+    sleep "$sleep_seconds"
+  fi
+done
+
+printf 'nightly release %s did not become published and downloadable in time\n' "$NIGHTLY_TAG" >&2
+exit 1

--- a/scripts/verify_nightly_release_test.go
+++ b/scripts/verify_nightly_release_test.go
@@ -1,0 +1,214 @@
+package scripts
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVerifyNightlyReleaseSucceedsWhenReleaseIsPublishedAndAssetsAreReachable(t *testing.T) {
+	t.Parallel()
+
+	f := newVerifyNightlyFixture(t)
+	f.writeTool(t, "gh", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_TMPDIR/gh.log"
+cat "$TEST_TMPDIR/release.json"
+`)
+	f.writeTool(t, "curl", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_TMPDIR/curl.log"
+`)
+	f.writeTool(t, "sleep", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_TMPDIR/sleep.log"
+`)
+	f.writeReleaseJSON(t, false, true, f.expectedAssets())
+
+	result := f.run(t)
+	if result.exitCode != 0 {
+		t.Fatalf("expected success, got exit %d\noutput:\n%s", result.exitCode, result.output)
+	}
+	for _, asset := range f.expectedAssets() {
+		want := fmt.Sprintf("--fail --silent --show-error --location --head https://github.com/aliengiraffe/vigilante/releases/download/main-nightly/%s", asset)
+		if !strings.Contains(f.readLog(t, "curl.log"), want) {
+			t.Fatalf("missing curl check for %s\n%s", asset, f.readLog(t, "curl.log"))
+		}
+	}
+}
+
+func TestVerifyNightlyReleaseFailsWhenReleaseStaysDraft(t *testing.T) {
+	t.Parallel()
+
+	f := newVerifyNightlyFixture(t)
+	f.writeTool(t, "gh", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_TMPDIR/gh.log"
+cat "$TEST_TMPDIR/release.json"
+`)
+	f.writeTool(t, "curl", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_TMPDIR/curl.log"
+`)
+	f.writeTool(t, "sleep", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_TMPDIR/sleep.log"
+`)
+	f.writeReleaseJSON(t, true, true, f.expectedAssets())
+	f.maxAttempts = "2"
+	f.sleepSeconds = "0"
+
+	result := f.run(t)
+	if result.exitCode == 0 {
+		t.Fatalf("expected draft release verification to fail\noutput:\n%s", result.output)
+	}
+	if strings.Contains(f.readLogMaybe(t, "curl.log"), "https://github.com") {
+		t.Fatalf("curl should not run while release is still draft\n%s", f.readLogMaybe(t, "curl.log"))
+	}
+}
+
+func TestVerifyNightlyReleaseFailsWhenAssetURLIsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	f := newVerifyNightlyFixture(t)
+	f.writeTool(t, "gh", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_TMPDIR/gh.log"
+cat "$TEST_TMPDIR/release.json"
+`)
+	f.writeTool(t, "curl", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_TMPDIR/curl.log"
+if [[ "$*" == *"Linux_amd64"* ]]; then
+  exit 22
+fi
+`)
+	f.writeTool(t, "sleep", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_TMPDIR/sleep.log"
+`)
+	f.writeReleaseJSON(t, false, true, f.expectedAssets())
+	f.maxAttempts = "2"
+	f.sleepSeconds = "0"
+
+	result := f.run(t)
+	if result.exitCode == 0 {
+		t.Fatalf("expected unreachable asset verification to fail\noutput:\n%s", result.output)
+	}
+	if !strings.Contains(result.output, "asset URL not reachable yet") {
+		t.Fatalf("expected asset failure in output\n%s", result.output)
+	}
+}
+
+type verifyNightlyFixture struct {
+	tempDir      string
+	binDir       string
+	maxAttempts  string
+	sleepSeconds string
+}
+
+func newVerifyNightlyFixture(t *testing.T) verifyNightlyFixture {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	binDir := filepath.Join(tempDir, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	return verifyNightlyFixture{
+		tempDir:      tempDir,
+		binDir:       binDir,
+		maxAttempts:  "1",
+		sleepSeconds: "0",
+	}
+}
+
+func (f verifyNightlyFixture) writeTool(t *testing.T, name string, body string) {
+	t.Helper()
+
+	path := filepath.Join(f.binDir, name)
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (f verifyNightlyFixture) writeReleaseJSON(t *testing.T, draft bool, prerelease bool, assets []string) {
+	t.Helper()
+
+	quoted := make([]string, 0, len(assets))
+	for _, asset := range assets {
+		quoted = append(quoted, fmt.Sprintf(`{"name":%q}`, asset))
+	}
+	jsonBody := fmt.Sprintf("{\"draft\":%t,\"prerelease\":%t,\"assets\":[%s]}\n", draft, prerelease, strings.Join(quoted, ","))
+	if err := os.WriteFile(filepath.Join(f.tempDir, "release.json"), []byte(jsonBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (f verifyNightlyFixture) expectedAssets() []string {
+	const version = "0.0.0-nightly.20260326170625.503113fdfe81"
+	return []string{
+		"vigilante_" + version + "_Linux_amd64.tar.gz",
+		"vigilante_" + version + "_macOS_amd64.tar.gz",
+		"vigilante_" + version + "_macOS_arm64.tar.gz",
+	}
+}
+
+func (f verifyNightlyFixture) run(t *testing.T) verifyNightlyResult {
+	t.Helper()
+
+	cmd := exec.Command("/bin/bash", "./scripts/verify-nightly-release.sh")
+	cmd.Dir = repoRoot(t)
+	cmd.Env = append(os.Environ(),
+		"GITHUB_REPOSITORY=aliengiraffe/vigilante",
+		"NIGHTLY_TAG=main-nightly",
+		"NIGHTLY_VERSION=0.0.0-nightly.20260326170625.503113fdfe81",
+		"MAX_ATTEMPTS="+f.maxAttempts,
+		"SLEEP_SECONDS="+f.sleepSeconds,
+		"TEST_TMPDIR="+f.tempDir,
+		"PATH="+f.binDir+":"+os.Getenv("PATH"),
+	)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return verifyNightlyResult{output: string(output)}
+	}
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("run verify script: %v\n%s", err, output)
+	}
+	return verifyNightlyResult{exitCode: exitErr.ExitCode(), output: string(output)}
+}
+
+func (f verifyNightlyFixture) readLog(t *testing.T, name string) string {
+	t.Helper()
+
+	body, err := os.ReadFile(filepath.Join(f.tempDir, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(body)
+}
+
+func (f verifyNightlyFixture) readLogMaybe(t *testing.T, name string) string {
+	t.Helper()
+
+	body, err := os.ReadFile(filepath.Join(f.tempDir, name))
+	if os.IsNotExist(err) {
+		return ""
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(body)
+}
+
+type verifyNightlyResult struct {
+	exitCode int
+	output   string
+}


### PR DESCRIPTION
## Summary
- force the rolling nightly release out of draft state immediately after creation
- verify `main-nightly` is published and the expected nightly asset URLs are reachable before updating the Homebrew cask
- add regression tests for the verification gate helper script

## Validation
- `go test ./scripts/...`
- `bash -n scripts/verify-nightly-release.sh`

Closes #309
