### PR TITLE
Make setup own daemon installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ Prepare the local machine with your preferred coding-agent provider:
 vigilante setup --provider codex
 ```
 
-Register a repository and install the background service:
+Register a repository after setup installs the background service:
 
 ```sh
-vigilante watch -d ~/path/to/repo
+vigilante watch ~/path/to/repo
 ```
 
 Useful follow-up commands:
@@ -255,16 +255,6 @@ vigilante watch --branch develop ~/hello-world-app
 vigilante watch --track-default-branch ~/hello-world-app
 ```
 
-### `vigilante watch -d <path>`
-
-Register a repository and ensure the daemon/service is installed and started.
-
-Expected behavior:
-
-- adds the target to the watchlist
-- installs the `vigilante` daemon on the current operating system
-- starts or reloads the service
-
 ### `vigilante list`
 
 Show the currently watched repositories and their metadata.
@@ -377,9 +367,9 @@ Expected behavior:
   - `vigilante-create-issue`
   - `vigilante-local-service-dependencies`
   - `docker-compose-launch`
-- installs or updates the daemon definition when requested
+- installs or updates the daemon definition
 
-On macOS, `vigilante setup -d` resolves Homebrew-style symlinks before it prepares the daemon binary. For Homebrew cask installs, Vigilante first clears `com.apple.provenance` and `com.apple.quarantine` recursively from the enclosing Caskroom version directory, then removes those same xattrs from the resolved binary when present, ad-hoc signs that binary, and runs `spctl --assess --type execute -vv` against the resolved path before loading the service.
+On macOS, `vigilante setup` resolves Homebrew-style symlinks before it prepares the daemon binary. For Homebrew cask installs, Vigilante first clears `com.apple.provenance` and `com.apple.quarantine` recursively from the enclosing Caskroom version directory, then removes those same xattrs from the resolved binary when present, ad-hoc signs that binary, and runs `spctl --assess --type execute -vv` against the resolved path before loading the service.
 
 If Gatekeeper still rejects the binary, the error now reports both the assessed path and the invoked path when they differ. A useful manual recovery sequence is:
 
@@ -417,7 +407,7 @@ Primary tasks:
 - `task install` copies the built binary to `~/.local/bin/vigilante`
 - `task setup` runs `./vigilante setup`
 - `task install-setup` runs `~/.local/bin/vigilante setup`
-- `task setup-daemon` runs a small wrapper around `~/.local/bin/vigilante setup -d` that retries once on macOS after cleaning up an existing `launchd` agent
+- `task setup-daemon` runs a small wrapper around `~/.local/bin/vigilante setup` that retries once on macOS after cleaning up an existing `launchd` agent
 
 Recommended loop:
 
@@ -458,14 +448,14 @@ task setup-daemon
 
 On macOS, `task setup-daemon` now performs one explicit recovery attempt when an existing `com.vigilante.agent` launch agent is already present. If the first refresh fails, the task cleans up the existing launch agent, retries once, and prints a short manual `launchctl bootout ...` hint if recovery still fails.
 
-On macOS, `vigilante setup -d` also prepares the installed daemon binary before reloading the LaunchAgent by clearing observed Gatekeeper xattrs from the Homebrew cask install root when applicable, clearing those xattrs from the resolved binary, applying ad-hoc signing, and validating the binary with `spctl`. If macOS still rejects the binary, setup exits with a code-signing error instead of leaving the agent stuck in `OS_REASON_CODESIGNING`.
+On macOS, `vigilante setup` also prepares the installed daemon binary before reloading the LaunchAgent by clearing observed Gatekeeper xattrs from the Homebrew cask install root when applicable, clearing those xattrs from the resolved binary, applying ad-hoc signing, and validating the binary with `spctl`. If macOS still rejects the binary, setup exits with a code-signing error instead of leaving the agent stuck in `OS_REASON_CODESIGNING`.
 
 Notes:
 
 - foreground runs are the quickest way to iterate on scheduler, worktree, and coding-agent execution behavior
 - when `vigilante` runs from a repository checkout, `setup` refreshes installed skills from the local repo `skills/` folder so skill edits are picked up immediately
 - when `vigilante` runs as an installed binary outside the repo checkout, `setup` uses skills embedded in the binary so it works from any directory without depending on the source tree
-- after changing service installation logic on macOS, rerun `setup -d` so the `launchd` plist is regenerated with the current shell-derived PATH
+- after changing service installation logic on macOS, rerun `setup` so the `launchd` plist is regenerated with the current shell-derived PATH
 - the CLI entrypoint lives in `cmd/vigilante/`, while non-exported implementation packages live under `internal/`
 
 ## CI and Releases
@@ -574,7 +564,7 @@ Use logs to decide which recovery command fits the evidence already recorded loc
 4. If the per-issue log shows the agent can continue from the existing worktree and session state, prefer `vigilante resume --repo <owner/name> --issue <n>`.
 5. If the per-issue log shows corrupted local state, a dead worktree, or a failed run that should be restarted cleanly, use `vigilante redispatch --repo <owner/name> --issue <n>`.
 6. If the log shows the local session artifacts are stale and should be removed without starting new work immediately, use `vigilante cleanup --repo <owner/name> --issue <n>` or repo-wide cleanup as appropriate.
-7. If the daemon log points to service-manager failures, scan-loop problems, or machine-level issues, troubleshoot the daemon with `vigilante service restart`, `vigilante setup -d`, or a foreground `vigilante daemon run --once` check before touching issue sessions.
+7. If the daemon log points to service-manager failures, scan-loop problems, or machine-level issues, troubleshoot the daemon with `vigilante service restart`, `vigilante setup`, or a foreground `vigilante daemon run --once` check before touching issue sessions.
 
 Suggested `watchlist.json` shape:
 
@@ -587,7 +577,6 @@ Suggested `watchlist.json` shape:
     "branch": "main",
     "assignee": "me",
     "max_parallel_sessions": 0,
-    "daemon_enabled": true,
     "last_scan_at": "2026-03-10T12:00:00Z"
   }
 ]

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -275,14 +275,13 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 	case "setup":
 		fs := flag.NewFlagSet("setup", flag.ContinueOnError)
 		configureFlagSet(fs, func(w io.Writer) {
-			fmt.Fprintln(w, "usage: vigilante setup [-d] [--provider value]")
+			fmt.Fprintln(w, "usage: vigilante setup [--provider value]")
 			fmt.Fprintln(w)
 			fmt.Fprintln(w, "Prepare the machine for autonomous execution.")
 			fmt.Fprintln(w)
 			fs.SetOutput(w)
 			fs.PrintDefaults()
 		})
-		installDaemon := fs.Bool("d", false, "install daemon service")
 		selectedProvider := fs.String("provider", provider.DefaultID, "coding agent provider")
 		if err := parseFlagSet(fs, args[1:], a.stdout); err != nil {
 			if errors.Is(err, errHelpHandled) {
@@ -290,18 +289,17 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 			}
 			return err
 		}
-		return a.SetupWithProvider(ctx, *installDaemon, *selectedProvider)
+		return a.SetupWithProvider(ctx, *selectedProvider)
 	case "watch":
 		fs := flag.NewFlagSet("watch", flag.ContinueOnError)
 		configureFlagSet(fs, func(w io.Writer) {
-			fmt.Fprintln(w, "usage: vigilante watch [-d] [--label value] [--assignee value] [--max-parallel value] [--provider value] [--branch value | --track-default-branch] <path>")
+			fmt.Fprintln(w, "usage: vigilante watch [--label value] [--assignee value] [--max-parallel value] [--provider value] [--branch value | --track-default-branch] <path>")
 			fmt.Fprintln(w)
 			fmt.Fprintln(w, "Register a local repository for issue monitoring.")
 			fmt.Fprintln(w)
 			fs.SetOutput(w)
 			fs.PrintDefaults()
 		})
-		daemon := fs.Bool("d", false, "install and start daemon service")
 		var labels stringListFlag
 		fs.Var(&labels, "label", "allow only issues with this label; repeatable")
 		assignee := fs.String("assignee", "", "issue assignee filter (defaults to me)")
@@ -316,7 +314,7 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 			return err
 		}
 		if fs.NArg() != 1 {
-			return errors.New("usage: vigilante watch [-d] [--label value] [--assignee value] [--max-parallel value] [--provider value] [--branch value | --track-default-branch] <path>")
+			return errors.New("usage: vigilante watch [--label value] [--assignee value] [--max-parallel value] [--provider value] [--branch value | --track-default-branch] <path>")
 		}
 		parsedMaxParallel := unsetMaxParallel
 		branchOptions := watchBranchOptions{}
@@ -335,7 +333,7 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 		if branchOptions.branchFlagSet && branchOptions.trackDefaultFlagSet {
 			return errors.New("watch accepts either --branch or --track-default-branch, not both")
 		}
-		return a.watchWithOptions(ctx, fs.Arg(0), *daemon, labels, *assignee, parsedMaxParallel, *selectedProvider, branchOptions)
+		return a.watchWithOptions(ctx, fs.Arg(0), labels, *assignee, parsedMaxParallel, *selectedProvider, branchOptions)
 	case "unwatch":
 		if len(args) != 2 {
 			return errors.New("usage: vigilante unwatch <path>")
@@ -685,12 +683,12 @@ func (a *App) RestartService(ctx context.Context) error {
 	return nil
 }
 
-func (a *App) Setup(ctx context.Context, installDaemon bool) error {
-	return a.SetupWithProvider(ctx, installDaemon, provider.DefaultID)
+func (a *App) Setup(ctx context.Context) error {
+	return a.SetupWithProvider(ctx, provider.DefaultID)
 }
 
-func (a *App) SetupWithProvider(ctx context.Context, installDaemon bool, providerID string) error {
-	a.state.AppendDaemonLog("setup start install_daemon=%t", installDaemon)
+func (a *App) SetupWithProvider(ctx context.Context, providerID string) error {
+	a.state.AppendDaemonLog("setup start install_daemon=true")
 	if err := a.state.EnsureLayout(); err != nil {
 		return err
 	}
@@ -704,12 +702,10 @@ func (a *App) SetupWithProvider(ctx context.Context, installDaemon bool, provide
 	if err := a.installBundledSkills(); err != nil {
 		return err
 	}
-	if installDaemon {
-		if err := service.Install(ctx, a.env, a.state, selectedProvider); err != nil {
-			return err
-		}
+	if err := service.Install(ctx, a.env, a.state, selectedProvider); err != nil {
+		return err
 	}
-	a.state.AppendDaemonLog("setup complete install_daemon=%t", installDaemon)
+	a.state.AppendDaemonLog("setup complete install_daemon=true")
 	fmt.Fprintln(a.stdout, "setup complete")
 	return nil
 }
@@ -730,16 +726,16 @@ func (a *App) installBundledSkills() error {
 	return nil
 }
 
-func (a *App) Watch(ctx context.Context, rawPath string, daemon bool, labels []string, assignee string, maxParallel int) error {
-	return a.WatchWithProvider(ctx, rawPath, daemon, labels, assignee, maxParallel, "")
+func (a *App) Watch(ctx context.Context, rawPath string, labels []string, assignee string, maxParallel int) error {
+	return a.WatchWithProvider(ctx, rawPath, labels, assignee, maxParallel, "")
 }
 
-func (a *App) WatchWithProvider(ctx context.Context, rawPath string, daemon bool, labels []string, assignee string, maxParallel int, providerID string) error {
-	return a.watchWithOptions(ctx, rawPath, daemon, labels, assignee, maxParallel, providerID, watchBranchOptions{})
+func (a *App) WatchWithProvider(ctx context.Context, rawPath string, labels []string, assignee string, maxParallel int, providerID string) error {
+	return a.watchWithOptions(ctx, rawPath, labels, assignee, maxParallel, providerID, watchBranchOptions{})
 }
 
-func (a *App) watchWithOptions(ctx context.Context, rawPath string, daemon bool, labels []string, assignee string, maxParallel int, providerID string, branchOptions watchBranchOptions) error {
-	a.state.AppendDaemonLog("watch start raw_path=%q daemon=%t assignee=%q max_parallel=%d", rawPath, daemon, assignee, maxParallel)
+func (a *App) watchWithOptions(ctx context.Context, rawPath string, labels []string, assignee string, maxParallel int, providerID string, branchOptions watchBranchOptions) error {
+	a.state.AppendDaemonLog("watch start raw_path=%q assignee=%q max_parallel=%d", rawPath, assignee, maxParallel)
 	if err := a.state.EnsureLayout(); err != nil {
 		return err
 	}
@@ -794,7 +790,6 @@ func (a *App) watchWithOptions(ctx context.Context, rawPath string, daemon bool,
 			if maxParallel >= 0 {
 				targets[i].MaxParallel = maxParallel
 			}
-			targets[i].DaemonEnabled = daemon
 			switch {
 			case branchOptions.branchFlagSet:
 				targets[i].BranchMode = state.BranchModePinned
@@ -834,7 +829,6 @@ func (a *App) watchWithOptions(ctx context.Context, rawPath string, daemon bool,
 			Labels:         labels,
 			Assignee:       assigneeOrDefault(assignee),
 			MaxParallel:    configuredMaxParallel(maxParallel),
-			DaemonEnabled:  daemon,
 			AddedAt:        a.clock().Format(time.RFC3339),
 		}
 		if providerID != "" {
@@ -858,26 +852,37 @@ func (a *App) watchWithOptions(ctx context.Context, rawPath string, daemon bool,
 		return err
 	}
 
-	if daemon {
-		setupProvider := providerID
-		if setupProvider == "" {
-			setupProvider = findWatchTargetProvider(targets, info.Path)
-		}
-		if err := a.SetupWithProvider(ctx, true, setupProvider); err != nil {
-			return err
-		}
-	}
-
 	if updated {
 		updatedTarget := findWatchTargetByPath(targets, info.Path)
-		a.state.AppendDaemonLog("watch updated path=%s repo=%s branch=%s branch_mode=%s assignee=%s max_parallel=%d daemon=%t", info.Path, info.Repo, updatedTarget.Branch, updatedTarget.EffectiveBranchMode(), assigneeOrDefault(findWatchTargetAssignee(targets, info.Path)), findWatchTargetMaxParallel(targets, info.Path), daemon)
+		a.state.AppendDaemonLog("watch updated path=%s repo=%s branch=%s branch_mode=%s assignee=%s max_parallel=%d", info.Path, info.Repo, updatedTarget.Branch, updatedTarget.EffectiveBranchMode(), assigneeOrDefault(findWatchTargetAssignee(targets, info.Path)), findWatchTargetMaxParallel(targets, info.Path))
 		fmt.Fprintln(a.stdout, "updated", info.Path)
 	} else {
 		addedTarget := findWatchTargetByPath(targets, info.Path)
-		a.state.AppendDaemonLog("watch added path=%s repo=%s branch=%s branch_mode=%s assignee=%s max_parallel=%d daemon=%t", info.Path, info.Repo, addedTarget.Branch, addedTarget.EffectiveBranchMode(), assigneeOrDefault(assignee), configuredMaxParallel(maxParallel), daemon)
+		a.state.AppendDaemonLog("watch added path=%s repo=%s branch=%s branch_mode=%s assignee=%s max_parallel=%d", info.Path, info.Repo, addedTarget.Branch, addedTarget.EffectiveBranchMode(), assigneeOrDefault(assignee), configuredMaxParallel(maxParallel))
 		fmt.Fprintln(a.stdout, "watching", info.Path)
 	}
+	a.printWatchRuntimeGuidance(ctx)
 	return nil
+}
+
+func (a *App) printWatchRuntimeGuidance(ctx context.Context) {
+	status, err := service.ServiceStatus(ctx, a.env)
+	if err != nil {
+		fmt.Fprintf(a.stdout, "service status unavailable: %v\n", err)
+		fmt.Fprintln(a.stdout, "next step: run `vigilante setup` to install the managed service, or `vigilante daemon run` to process the watchlist in the foreground.")
+		return
+	}
+
+	switch {
+	case status.Running:
+		fmt.Fprintln(a.stdout, "managed service is running; this watch target will be picked up automatically.")
+	case status.Installed:
+		fmt.Fprintln(a.stdout, "managed service is installed but not running.")
+		fmt.Fprintln(a.stdout, "next step: run `vigilante service restart` to resume automatic processing, or `vigilante daemon run` to process the watchlist in the foreground.")
+	default:
+		fmt.Fprintln(a.stdout, "managed service is not installed.")
+		fmt.Fprintln(a.stdout, "next step: run `vigilante setup` to install it, or `vigilante daemon run` to process the watchlist in the foreground.")
+	}
 }
 
 func (a *App) Unwatch(rawPath string) error {
@@ -3339,7 +3344,6 @@ func watchTargetForSession(session state.Session, fallbackTarget state.WatchTarg
 		Labels:         fallbackTarget.Labels,
 		Assignee:       fallbackTarget.Assignee,
 		MaxParallel:    fallbackTarget.MaxParallel,
-		DaemonEnabled:  fallbackTarget.DaemonEnabled,
 	}
 	return target
 }
@@ -4605,8 +4609,8 @@ func isHelpToken(value string) bool {
 
 func (a *App) printUsage(w io.Writer) {
 	fmt.Fprintln(w, "usage:")
-	fmt.Fprintln(w, "  vigilante setup [-d] [--provider value]")
-	fmt.Fprintln(w, "  vigilante watch [-d] [--label value] [--assignee value] [--max-parallel value] [--provider value] [--branch value | --track-default-branch] <path>")
+	fmt.Fprintln(w, "  vigilante setup [--provider value]")
+	fmt.Fprintln(w, "  vigilante watch [--label value] [--assignee value] [--max-parallel value] [--provider value] [--branch value | --track-default-branch] <path>")
 	fmt.Fprintln(w, "  vigilante unwatch <path>")
 	fmt.Fprintln(w, "  vigilante list [--blocked | --running]")
 	fmt.Fprintln(w, "  vigilante status")
@@ -4663,11 +4667,11 @@ _vigilante()
 
     case "${words[1]}" in
         setup)
-            COMPREPLY=( $(compgen -W "-d --provider" -- "$cur") )
+            COMPREPLY=( $(compgen -W "--provider" -- "$cur") )
             return
             ;;
         watch)
-            COMPREPLY=( $(compgen -W "-d --label --assignee --max-parallel --provider --branch --track-default-branch" -- "$cur") )
+            COMPREPLY=( $(compgen -W "--label --assignee --max-parallel --provider --branch --track-default-branch" -- "$cur") )
             return
             ;;
         list)
@@ -4729,14 +4733,12 @@ complete -c vigilante -f -n '__fish_use_subcommand' -a 'daemon' -d 'Run daemon c
 complete -c vigilante -f -n '__fish_use_subcommand' -a 'completion' -d 'Generate shell completion scripts'
 
 complete -c vigilante -n '__fish_seen_subcommand_from setup' -l provider
-complete -c vigilante -n '__fish_seen_subcommand_from setup' -s d
 complete -c vigilante -n '__fish_seen_subcommand_from watch' -l label
 complete -c vigilante -n '__fish_seen_subcommand_from watch' -l assignee
 complete -c vigilante -n '__fish_seen_subcommand_from watch' -l max-parallel
 complete -c vigilante -n '__fish_seen_subcommand_from watch' -l provider
 complete -c vigilante -n '__fish_seen_subcommand_from watch' -l branch
 complete -c vigilante -n '__fish_seen_subcommand_from watch' -l track-default-branch
-complete -c vigilante -n '__fish_seen_subcommand_from watch' -s d
 complete -c vigilante -n '__fish_seen_subcommand_from list' -l blocked
 complete -c vigilante -n '__fish_seen_subcommand_from list' -l running
 complete -c vigilante -n '__fish_seen_subcommand_from cleanup' -l repo
@@ -4781,10 +4783,10 @@ _vigilante() {
 
   case "$words[2]" in
     setup)
-      compadd -- -d --provider
+      compadd -- --provider
       ;;
     watch)
-      compadd -- -d --label --assignee --max-parallel --provider --branch --track-default-branch
+      compadd -- --label --assignee --max-parallel --provider --branch --track-default-branch
       ;;
     list)
       compadd -- --blocked --running

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1122,6 +1122,7 @@ func TestSetupCreatesStateLayoutAndInstallsBundledSkillsForAllProviders(t *testi
 	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
 	t.Setenv("CLAUDE_HOME", filepath.Join(home, ".claude"))
 	t.Setenv("GEMINI_HOME", filepath.Join(home, ".gemini"))
+	t.Setenv("SHELL", "")
 
 	app := New()
 	app.stdout = testutil.IODiscard{}
@@ -1134,7 +1135,22 @@ func TestSetupCreatesStateLayoutAndInstallsBundledSkillsForAllProviders(t *testi
 		},
 	}
 
-	if err := app.Setup(context.Background(), false); err != nil {
+	app.env.OS = "linux"
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"codex --version":                                                 "codex 0.114.0",
+			"gh auth status":                                                  "ok",
+			"systemctl --user daemon-reload":                                  "",
+			"systemctl --user enable --now vigilante.service":                 "",
+			`/bin/sh -lc PATH="` + os.Getenv("PATH") + `" command -v 'git'`:   "/usr/bin/git\n",
+			`/bin/sh -lc PATH="` + os.Getenv("PATH") + `" command -v 'gh'`:    "/usr/bin/gh\n",
+			`/bin/sh -lc PATH="` + os.Getenv("PATH") + `" command -v 'codex'`: "/usr/bin/codex\n",
+			`/bin/sh -lc PATH="` + os.Getenv("PATH") + `" 'codex' --version`:  "codex 0.114.0\n",
+		},
+	}
+
+	if err := app.Setup(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1171,19 +1187,27 @@ func TestSetupWithGeminiInstallsBundledSkillsForAllProviders(t *testing.T) {
 	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
 	t.Setenv("CLAUDE_HOME", filepath.Join(home, ".claude"))
 	t.Setenv("GEMINI_HOME", filepath.Join(home, ".gemini"))
+	t.Setenv("SHELL", "")
 
 	app := New()
 	app.stdout = testutil.IODiscard{}
 	app.stderr = testutil.IODiscard{}
+	app.env.OS = "linux"
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "gemini": "/usr/bin/gemini"},
 		Outputs: map[string]string{
-			"gemini --version": "gemini 0.34.0",
-			"gh auth status":   "ok",
+			"gemini --version":                                                 "gemini 0.34.0",
+			"gh auth status":                                                   "ok",
+			"systemctl --user daemon-reload":                                   "",
+			"systemctl --user enable --now vigilante.service":                  "",
+			`/bin/sh -lc PATH="` + os.Getenv("PATH") + `" command -v 'git'`:    "/usr/bin/git\n",
+			`/bin/sh -lc PATH="` + os.Getenv("PATH") + `" command -v 'gh'`:     "/usr/bin/gh\n",
+			`/bin/sh -lc PATH="` + os.Getenv("PATH") + `" command -v 'gemini'`: "/usr/bin/gemini\n",
+			`/bin/sh -lc PATH="` + os.Getenv("PATH") + `" 'gemini' --version`:  "gemini 0.34.0\n",
 		},
 	}
 
-	if err := app.SetupWithProvider(context.Background(), false, "gemini"); err != nil {
+	if err := app.SetupWithProvider(context.Background(), "gemini"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1231,7 +1255,7 @@ func TestWatchListAndUnwatch(t *testing.T) {
 		},
 	}
 
-	if err := app.Watch(context.Background(), repoPath, false, []string{"to-do", "good first issue"}, "", 0); err != nil {
+	if err := app.Watch(context.Background(), repoPath, []string{"to-do", "good first issue"}, "", 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1299,12 +1323,12 @@ func TestWatchUpdatesExistingTarget(t *testing.T) {
 		},
 	}
 
-	if err := app.Watch(context.Background(), repoPath, false, nil, "nicobistolfi", 3); err != nil {
+	if err := app.Watch(context.Background(), repoPath, nil, "nicobistolfi", 3); err != nil {
 		t.Fatal(err)
 	}
 
 	stdout.Reset()
-	if err := app.Watch(context.Background(), repoPath, true, []string{"vibe-code", "vibe-code"}, "", 0); err != nil {
+	if err := app.Watch(context.Background(), repoPath, []string{"vibe-code", "vibe-code"}, "", 0); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(stdout.String(), "updated "+repoPath) {
@@ -1317,9 +1341,6 @@ func TestWatchUpdatesExistingTarget(t *testing.T) {
 	}
 	if len(targets) != 1 {
 		t.Fatalf("unexpected targets: %#v", targets)
-	}
-	if !targets[0].DaemonEnabled {
-		t.Fatalf("expected daemon_enabled to be updated: %#v", targets[0])
 	}
 	if len(targets[0].Labels) != 1 || targets[0].Labels[0] != "vibe-code" {
 		t.Fatalf("expected labels to be updated: %#v", targets[0])
@@ -1352,7 +1373,7 @@ func TestWatchCommandWithoutMaxParallelPreservesExistingTargetValue(t *testing.T
 		},
 	}
 
-	if err := app.Watch(context.Background(), repoPath, false, nil, "", 3); err != nil {
+	if err := app.Watch(context.Background(), repoPath, nil, "", 3); err != nil {
 		t.Fatal(err)
 	}
 	if err := app.runCommand(context.Background(), []string{"watch", repoPath}); err != nil {
@@ -1401,7 +1422,7 @@ func TestWatchWithProviderPersistsClaudeSelection(t *testing.T) {
 		},
 	}
 
-	if err := app.WatchWithProvider(context.Background(), repoPath, false, nil, "", 0, "claude"); err != nil {
+	if err := app.WatchWithProvider(context.Background(), repoPath, nil, "", 0, "claude"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1439,7 +1460,7 @@ func TestWatchPersistsRepoClassification(t *testing.T) {
 		},
 	}
 
-	if err := app.Watch(context.Background(), repoPath, false, nil, "", 0); err != nil {
+	if err := app.Watch(context.Background(), repoPath, nil, "", 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1475,7 +1496,7 @@ func TestWatchWithGeminiProviderPersistsSelection(t *testing.T) {
 		},
 	}
 
-	if err := app.WatchWithProvider(context.Background(), repoPath, false, nil, "", 0, "gemini"); err != nil {
+	if err := app.WatchWithProvider(context.Background(), repoPath, nil, "", 0, "gemini"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1504,9 +1525,148 @@ func TestSetupFailsWhenProviderVersionIsIncompatible(t *testing.T) {
 		},
 	}
 
-	err := app.Setup(context.Background(), false)
+	err := app.Setup(context.Background())
 	if err == nil || !strings.Contains(err.Error(), "codex CLI version 2.0.0 is incompatible") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSetupCommandRejectsLegacyDaemonFlag(t *testing.T) {
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+
+	err := app.runCommand(context.Background(), []string{"setup", "-d"})
+	if err == nil || !strings.Contains(err.Error(), "flag provided but not defined: -d") {
+		t.Fatalf("expected legacy setup -d flag rejection, got %v", err)
+	}
+}
+
+func TestWatchCommandRejectsLegacyDaemonFlag(t *testing.T) {
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+
+	err := app.runCommand(context.Background(), []string{"watch", "-d", "/tmp/repo"})
+	if err == nil || !strings.Contains(err.Error(), "flag provided but not defined: -d") {
+		t.Fatalf("expected legacy watch -d flag rejection, got %v", err)
+	}
+}
+
+func TestWatchReportsManagedServiceRunning(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "vigilante.service")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unitPath, []byte("unit"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.OS = "linux"
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                  "true\n",
+			testutil.Key("git", "remote", "get-url", "origin"):                         "git@github.com:nicobistolfi/vigilante.git\n",
+			testutil.Key("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"): "origin/main\n",
+			"systemctl --user show --property=LoadState,ActiveState vigilante.service": "LoadState=loaded\nActiveState=active\n",
+		},
+	}
+
+	if err := app.Watch(context.Background(), repoPath, nil, "", 0); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), "managed service is running; this watch target will be picked up automatically.") {
+		t.Fatalf("unexpected output: %s", stdout.String())
+	}
+}
+
+func TestWatchReportsSetupAndManualDaemonWhenServiceMissing(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                  "true\n",
+			testutil.Key("git", "remote", "get-url", "origin"):                         "git@github.com:nicobistolfi/vigilante.git\n",
+			testutil.Key("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"): "origin/main\n",
+		},
+	}
+
+	if err := app.Watch(context.Background(), repoPath, nil, "", 0); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"managed service is not installed.",
+		"run `vigilante setup` to install it",
+		"`vigilante daemon run` to process the watchlist in the foreground",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("expected output to contain %q, got %q", want, stdout.String())
+		}
+	}
+}
+
+func TestWatchReportsRestartOrManualDaemonWhenServiceStopped(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "vigilante.service")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unitPath, []byte("unit"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.OS = "linux"
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                  "true\n",
+			testutil.Key("git", "remote", "get-url", "origin"):                         "git@github.com:nicobistolfi/vigilante.git\n",
+			testutil.Key("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"): "origin/main\n",
+			"systemctl --user show --property=LoadState,ActiveState vigilante.service": "LoadState=loaded\nActiveState=inactive\n",
+		},
+	}
+
+	if err := app.Watch(context.Background(), repoPath, nil, "", 0); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"managed service is installed but not running.",
+		"`vigilante service restart`",
+		"`vigilante daemon run`",
+	} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("expected output to contain %q, got %q", want, stdout.String())
+		}
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -26,7 +26,6 @@ type WatchTarget struct {
 	Labels         []string            `json:"labels,omitempty"`
 	Assignee       string              `json:"assignee,omitempty"`
 	MaxParallel    int                 `json:"max_parallel_sessions"`
-	DaemonEnabled  bool                `json:"daemon_enabled"`
 	LastScanAt     string              `json:"last_scan_at,omitempty"`
 	AddedAt        string              `json:"added_at,omitempty"`
 }

--- a/scripts/setup-daemon.sh
+++ b/scripts/setup-daemon.sh
@@ -16,7 +16,7 @@ current_os() {
 }
 
 run_setup() {
-  "$INSTALL_PATH" setup -d
+  "$INSTALL_PATH" setup
 }
 
 print_interrupted_hint() {
@@ -36,7 +36,7 @@ cleanup_launchd() {
 main() {
   os_name="$(current_os)"
   if [ "$os_name" != "darwin" ]; then
-    exec "$INSTALL_PATH" setup -d
+    exec "$INSTALL_PATH" setup
   fi
 
   run_setup

--- a/scripts/setup_daemon_test.go
+++ b/scripts/setup_daemon_test.go
@@ -22,8 +22,11 @@ exit 0
 	if result.exitCode != 0 {
 		t.Fatalf("expected success, got %d with output %s", result.exitCode, result.output)
 	}
-	if !strings.Contains(result.log, "setup -d") {
+	if !strings.Contains(result.log, "setup") {
 		t.Fatalf("expected direct setup invocation, log=%q", result.log)
+	}
+	if strings.Contains(result.log, "setup -d") {
+		t.Fatalf("expected legacy setup -d invocation to be removed, log=%q", result.log)
 	}
 	if strings.Contains(result.log, "launchctl") {
 		t.Fatalf("expected no launchctl cleanup, log=%q", result.log)


### PR DESCRIPTION
## Summary

- make `vigilante setup` always install or refresh the managed service
- remove legacy `-d` handling from `setup` and `watch`, plus related state/docs/scripts references
- add post-`watch` runtime guidance for running, stopped, and not-installed service states

## Validation

- `go test ./...`

Closes #303
