### PR TITLE
Update README stable Homebrew install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,13 @@ Vigilante turns a repository checkout into a controlled autonomous worker instea
 Install with Homebrew:
 
 ```sh
-brew tap aliengiraffe/spaceship
-brew install --cask vigilante
+brew install vigilante
 ```
 
 Prepare the local machine with your preferred coding-agent provider:
 
 ```sh
-vigilante setup --provider codex
+vigilante setup -d --provider codex
 ```
 
 Register a repository after setup installs the background service:
@@ -189,17 +188,16 @@ The proxy preserves the underlying tool's stdout, stderr, and exit status. Telem
 
 ## Installation
 
-Install `vigilante` from the Homebrew tap:
+Install `vigilante` with Homebrew:
 
 ```sh
-brew tap aliengiraffe/spaceship
-brew install --cask vigilante
+brew install vigilante
 ```
 
 Upgrade later with:
 
 ```sh
-brew upgrade --cask vigilante
+brew upgrade vigilante
 ```
 
 ### `vigilante watch [--assignee <value>] [--max-parallel <value>] [--provider <codex|claude|gemini>] [--branch <name> | --track-default-branch] <path>`
@@ -474,7 +472,7 @@ Tagged releases are built and published with GoReleaser. Pushing a version tag t
 - `darwin/arm64`
 - `linux/amd64`
 - a `checksums.txt` file for the published archives
-- an updated Homebrew cask in `aliengiraffe/homebrew-spaceship` so `brew install --cask vigilante` installs the tagged release from `aliengiraffe/spaceship`
+- an updated Homebrew formula in `homebrew/core` so `brew install vigilante` installs the tagged release
 
 The release workflow requires a GitHub App that can write to the tap repository:
 
@@ -495,8 +493,7 @@ brew install vigilante-nightly
 Stable installs remain on the tagged release path:
 
 ```sh
-brew tap aliengiraffe/spaceship
-brew install --cask vigilante
+brew install vigilante
 ```
 
 Recommended release flow:


### PR DESCRIPTION
## Summary
- update stable Homebrew install examples in `README.md` to use `brew install vigilante`
- update the Quickstart setup example to `vigilante setup -d --provider codex`
- update the stable upgrade and release-path wording to remove stale cask references

## Validation
- `rg -n -- '--cask vigilante' README.md`
- `rg -n -e '--cask vigilante' -e 'brew install vigilante' -e 'brew upgrade vigilante' -e 'setup -d --provider codex' -e 'vigilante-nightly' README.md`
- `git diff -- README.md`

Closes #296
