### PR TITLE
Add watch mode to vigilante status

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -362,10 +362,7 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 		}
 		return a.List(*blockedOnly, *runningOnly)
 	case "status":
-		if len(args) != 1 {
-			return errors.New("usage: vigilante status")
-		}
-		return a.Status(ctx)
+		return a.runStatusCommand(ctx, args[1:])
 	case "logs":
 		return a.runLogsCommand(args[1:])
 	case "cleanup":
@@ -656,7 +653,38 @@ func (a *App) runLogsCommand(args []string) error {
 }
 
 func (a *App) Status(ctx context.Context) error {
-	return a.statusExpanded(ctx)
+	return a.StatusWithOptions(ctx, false)
+}
+
+func (a *App) StatusWithOptions(ctx context.Context, watch bool) error {
+	if !watch {
+		return a.statusExpanded(ctx)
+	}
+	return a.statusWatch(ctx, time.Second)
+}
+
+func (a *App) runStatusCommand(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("status", flag.ContinueOnError)
+	configureFlagSet(fs, func(w io.Writer) {
+		fmt.Fprintln(w, "usage: vigilante status [-w]")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Show service, watch target, and session status.")
+		fmt.Fprintln(w)
+		fs.SetOutput(w)
+		fs.PrintDefaults()
+	})
+	watch := fs.Bool("w", false, "refresh the status view about once per second")
+	fs.BoolVar(watch, "watch", false, "refresh the status view about once per second")
+	if err := parseFlagSet(fs, args, a.stdout); err != nil {
+		if errors.Is(err, errHelpHandled) {
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() != 0 {
+		return errors.New("usage: vigilante status [-w]")
+	}
+	return a.StatusWithOptions(ctx, *watch)
 }
 
 func (a *App) statusServiceSection(ctx context.Context) (serviceStatusInfo, error) {
@@ -4613,7 +4641,7 @@ func (a *App) printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  vigilante watch [--label value] [--assignee value] [--max-parallel value] [--provider value] [--branch value | --track-default-branch] <path>")
 	fmt.Fprintln(w, "  vigilante unwatch <path>")
 	fmt.Fprintln(w, "  vigilante list [--blocked | --running]")
-	fmt.Fprintln(w, "  vigilante status")
+	fmt.Fprintln(w, "  vigilante status [-w]")
 	fmt.Fprintln(w, "  vigilante logs [--access] [--repo <owner/name>] [--issue <n>]")
 	fmt.Fprintln(w, "  vigilante cleanup --repo <owner/name> [--issue <n>]")
 	fmt.Fprintln(w, "  vigilante cleanup --all")

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -964,6 +964,41 @@ func TestStatusCommandFailsOnUnsupportedOS(t *testing.T) {
 	}
 }
 
+func TestStatusCommandRejectsUnexpectedArgs(t *testing.T) {
+	app := New()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = &stderr
+
+	exitCode := app.Run(context.Background(), []string{"status", "extra"})
+	if exitCode != 1 {
+		t.Fatalf("expected failure exit code, got %d", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "error: usage: vigilante status [-w]") {
+		t.Fatalf("unexpected stderr: %q", stderr.String())
+	}
+}
+
+func TestStatusCommandHelpIncludesWatchFlag(t *testing.T) {
+	app := New()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = &stderr
+
+	exitCode := app.Run(context.Background(), []string{"status", "--help"})
+	if exitCode != 0 {
+		t.Fatalf("expected success exit code, got %d", exitCode)
+	}
+	if !strings.Contains(stdout.String(), "usage: vigilante status [-w]") {
+		t.Fatalf("unexpected help output: %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "-watch") && !strings.Contains(stdout.String(), "--watch") {
+		t.Fatalf("expected watch flag in help output, got %q", stdout.String())
+	}
+}
+
 func TestServiceRestartCommandRequestsRestart(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -18,8 +18,10 @@ const (
 )
 
 type sessionGroup struct {
-	Label    string
-	Sessions []state.Session
+	Label          string
+	Sessions       []state.Session
+	CompletedCount int
+	FailedCount    int
 }
 
 type watchedRepoStatus struct {
@@ -71,10 +73,11 @@ func groupSessions(sessions []state.Session, now time.Time, inactivityTimeout ti
 		groups = append(groups, sessionGroup{Label: "Stale sessions", Sessions: stale})
 	}
 	if len(completed) > 0 || len(failed) > 0 {
-		var summary []state.Session
-		summary = append(summary, completed...)
-		summary = append(summary, failed...)
-		groups = append(groups, sessionGroup{Label: "Completed / failed", Sessions: summary})
+		groups = append(groups, sessionGroup{
+			Label:          "Completed / failed",
+			CompletedCount: len(completed),
+			FailedCount:    len(failed),
+		})
 	}
 	return groups
 }
@@ -160,11 +163,44 @@ func writeSessionGroups(w io.Writer, groups []sessionGroup) {
 		if i > 0 {
 			fmt.Fprintln(w)
 		}
-		fmt.Fprintf(w, "%s (%d)\n", g.Label, len(g.Sessions))
+		total := len(g.Sessions) + g.CompletedCount + g.FailedCount
+		fmt.Fprintf(w, "%s (%d)\n", g.Label, total)
+		if g.CompletedCount > 0 || g.FailedCount > 0 {
+			fmt.Fprintf(w, "  completed: %d\n", g.CompletedCount)
+			fmt.Fprintf(w, "  failed: %d\n", g.FailedCount)
+			continue
+		}
 		for _, s := range g.Sessions {
 			fmt.Fprintln(w, formatSessionRow(s))
 		}
 	}
+}
+
+func (a *App) statusWatch(ctx context.Context, interval time.Duration) error {
+	if err := writeStatusRefreshFrame(a.stdout, func() error { return a.statusExpanded(ctx) }); err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := writeStatusRefreshFrame(a.stdout, func() error { return a.statusExpanded(ctx) }); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func writeStatusRefreshFrame(w io.Writer, render func() error) error {
+	if _, err := io.WriteString(w, "\033[H\033[2J"); err != nil {
+		return err
+	}
+	return render()
 }
 
 func writeRateLimitSection(w io.Writer, snapshot ghcli.RateLimitSnapshot) {

--- a/internal/app/status_test.go
+++ b/internal/app/status_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -117,8 +119,11 @@ func TestGroupSessionsCompletedAndFailed(t *testing.T) {
 	if groups[0].Label != "Completed / failed" {
 		t.Fatalf("expected 'Completed / failed', got %q", groups[0].Label)
 	}
-	if len(groups[0].Sessions) != 2 {
-		t.Fatalf("expected 2 sessions, got %d", len(groups[0].Sessions))
+	if groups[0].CompletedCount != 1 || groups[0].FailedCount != 1 {
+		t.Fatalf("expected 1 completed and 1 failed, got %+v", groups[0])
+	}
+	if len(groups[0].Sessions) != 0 {
+		t.Fatalf("expected completed/failed details to be collapsed, got %d rows", len(groups[0].Sessions))
 	}
 }
 
@@ -135,11 +140,8 @@ func TestGroupSessionsExcludesClosed(t *testing.T) {
 	if groups[0].Label != "Completed / failed" {
 		t.Fatalf("expected 'Completed / failed', got %q", groups[0].Label)
 	}
-	if len(groups[0].Sessions) != 1 {
-		t.Fatalf("expected 1 session, got %d", len(groups[0].Sessions))
-	}
-	if groups[0].Sessions[0].IssueNumber != 71 {
-		t.Fatalf("expected only open operational session to remain visible, got %#v", groups[0].Sessions)
+	if groups[0].CompletedCount != 1 || groups[0].FailedCount != 0 {
+		t.Fatalf("expected only one completed session to remain visible, got %+v", groups[0])
 	}
 }
 
@@ -428,6 +430,31 @@ func TestStatusCommandShowsSessionGroups(t *testing.T) {
 		if !strings.Contains(output, want) {
 			t.Errorf("expected output to contain %q, got:\n%s", want, output)
 		}
+	}
+}
+
+func TestWriteSessionGroupsCompletedFailedShowsTotalsOnly(t *testing.T) {
+	groups := []sessionGroup{{
+		Label:          "Completed / failed",
+		CompletedCount: 2,
+		FailedCount:    1,
+	}}
+
+	var buf bytes.Buffer
+	writeSessionGroups(&buf, groups)
+	output := buf.String()
+
+	for _, want := range []string{
+		"Completed / failed (3)",
+		"completed: 2",
+		"failed: 1",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "Issue #") {
+		t.Fatalf("expected totals-only completed/failed output, got:\n%s", output)
 	}
 }
 
@@ -777,11 +804,58 @@ func TestStatusCommandExcludesClosedSessionsFromCountsAndGroups(t *testing.T) {
 	if !strings.Contains(output, "Completed / failed (1)") {
 		t.Fatalf("expected only visible operational sessions in completed/failed group, got:\n%s", output)
 	}
+	if !strings.Contains(output, "completed: 1") {
+		t.Fatalf("expected completed subtotal, got:\n%s", output)
+	}
 	if strings.Contains(output, "Issue #70") {
 		t.Fatalf("expected closed session to be hidden from status output, got:\n%s", output)
 	}
-	if !strings.Contains(output, "Issue #71 in owner/repo: success") {
-		t.Fatalf("expected success session to remain visible, got:\n%s", output)
+	if strings.Contains(output, "Issue #71 in owner/repo: success") {
+		t.Fatalf("expected completed section details to be collapsed, got:\n%s", output)
+	}
+}
+
+func TestWriteStatusRefreshFrameClearsBeforeRendering(t *testing.T) {
+	var buf bytes.Buffer
+	if err := writeStatusRefreshFrame(&buf, func() error {
+		_, err := io.WriteString(&buf, "snapshot")
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := buf.String(), "\033[H\033[2Jsnapshot"; got != want {
+		t.Fatalf("writeStatusRefreshFrame output = %q, want %q", got, want)
+	}
+}
+
+func TestStatusWatchStopsOnContextCancellation(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	app := New()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.OS = "linux"
+	app.env.Runner = testutil.FakeRunner{}
+
+	if err := app.statusWatch(ctx, time.Hour); err != nil {
+		t.Fatalf("expected watch mode to stop cleanly, got %v", err)
+	}
+	if !strings.HasPrefix(stdout.String(), "\033[H\033[2J") {
+		t.Fatalf("expected watch mode to clear the screen before rendering, got %q", stdout.String())
+	}
+}
+
+func TestStatusWatchReturnsRenderErrors(t *testing.T) {
+	wantErr := errors.New("boom")
+	err := writeStatusRefreshFrame(io.Discard, func() error { return wantErr })
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("writeStatusRefreshFrame error = %v, want %v", err, wantErr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `-w` / `--watch` support to `vigilante status` with an in-place one-second refresh loop
- collapse the `Completed / failed` status group to aggregate completed and failed totals
- cover the new flag parsing, refresh-frame behavior, and totals-only rendering with tests

## Validation
- `go test ./...`

Closes #315
