### PR TITLE
Add recreate workflow for stuck issues via CLI and GitHub comments

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -372,6 +372,8 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 		return a.runCleanupCommand(ctx, args[1:])
 	case "redispatch":
 		return a.runRedispatchCommand(ctx, args[1:])
+	case "recreate":
+		return a.runRecreateCommand(ctx, args[1:])
 	case "resume":
 		return a.runResumeCommand(ctx, args[1:])
 	case "service":
@@ -521,6 +523,31 @@ func (a *App) runCleanupCommand(ctx context.Context, args []string) error {
 	default:
 		return a.CleanupSession(ctx, *repo, *issue, "cli")
 	}
+}
+
+func (a *App) runRecreateCommand(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("recreate", flag.ContinueOnError)
+	configureFlagSet(fs, func(w io.Writer) {
+		fmt.Fprintln(w, "usage: vigilante recreate --repo <owner/name> --issue <n>")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Recreate a stuck issue as a fresh duplicate, close the original as not planned,")
+		fmt.Fprintln(w, "and clean up stale PR/branch/session artifacts.")
+		fmt.Fprintln(w)
+		fs.SetOutput(w)
+		fs.PrintDefaults()
+	})
+	repo := fs.String("repo", "", "repository slug")
+	issue := fs.Int("issue", 0, "issue number")
+	if err := parseFlagSet(fs, args, a.stdout); err != nil {
+		if errors.Is(err, errHelpHandled) {
+			return nil
+		}
+		return err
+	}
+	if *repo == "" || *issue <= 0 {
+		return errors.New("usage: vigilante recreate --repo <owner/name> --issue <n>")
+	}
+	return a.RecreateSession(ctx, *repo, *issue, "cli")
 }
 
 func (a *App) runDaemonCommand(ctx context.Context, args []string) error {
@@ -1041,6 +1068,10 @@ func (a *App) ScanOnce(ctx context.Context) error {
 			return nil
 		}
 		sessions, err = a.processGitHubCleanupRequests(ctx, sessions)
+		if err != nil {
+			return err
+		}
+		sessions, err = a.processGitHubRecreateRequests(ctx, sessions)
 		if err != nil {
 			return err
 		}
@@ -2209,6 +2240,142 @@ func (a *App) processGitHubCleanupRequests(ctx context.Context, sessions []state
 	return sessions, nil
 }
 
+func (a *App) processGitHubRecreateRequests(ctx context.Context, sessions []state.Session) ([]state.Session, error) {
+	for i := range sessions {
+		session := &sessions[i]
+		if session.Status == state.SessionStatusClosed {
+			continue
+		}
+
+		comments, err := ghcli.ListIssueCommentsForPolling(ctx, a.env.Runner, session.Repo, session.IssueNumber, "recreate", a.state.AppendDaemonLog)
+		if err != nil {
+			a.state.AppendDaemonLog("recreate comment lookup failed repo=%s issue=%d err=%v", session.Repo, session.IssueNumber, err)
+			session.LastError = err.Error()
+			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			continue
+		}
+		comment := ghcli.FindRecreateComment(comments, session.LastRecreateCommentID)
+		if comment == nil {
+			continue
+		}
+		if err := ghcli.AddIssueCommentReaction(ctx, a.env.Runner, session.Repo, comment.ID, "eyes"); err != nil {
+			a.state.AppendDaemonLog("recreate reaction failed repo=%s issue=%d comment=%d err=%v", session.Repo, session.IssueNumber, comment.ID, err)
+			session.LastError = err.Error()
+			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			continue
+		}
+		session.LastRecreateCommentID = comment.ID
+		session.LastRecreateCommentAt = comment.CreatedAt.UTC().Format(time.RFC3339)
+
+		// Unlock the session mutex before calling RecreateSession, which acquires it.
+		// Instead, perform the recreate inline to avoid deadlock.
+		repo := session.Repo
+		issueNumber := session.IssueNumber
+
+		// Use a goroutine-free approach: call the core logic directly.
+		recreateErr := a.recreateSessionInline(ctx, session, sessions, "comment")
+
+		if recreateErr != nil {
+			body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Recreate Failed",
+				Emoji:      "❌",
+				Percent:    100,
+				ETAMinutes: 1,
+				Items: []string{
+					"Received `@vigilanteai recreate` for this issue.",
+					fmt.Sprintf("Error: %s.", recreateErr),
+					"The issue was not recreated. Please check the error and try again.",
+				},
+				Tagline: "Better luck next time.",
+			})
+			if err := a.commentOnIssue(ctx, repo, issueNumber, body, "recreate", "github_comment"); err != nil {
+				a.state.AppendDaemonLog("recreate failure comment failed repo=%s issue=%d err=%v", repo, issueNumber, err)
+			}
+		}
+	}
+	return sessions, nil
+}
+
+func (a *App) recreateSessionInline(ctx context.Context, session *state.Session, sessions []state.Session, source string) error {
+	repoSlug := session.Repo
+	issue := session.IssueNumber
+
+	details, err := ghcli.GetIssueDetails(ctx, a.env.Runner, repoSlug, issue)
+	if err != nil {
+		return fmt.Errorf("get issue details: %w", err)
+	}
+
+	var labelNames []string
+	for _, label := range details.Labels {
+		if strings.HasPrefix(label.Name, "vigilante:") {
+			continue
+		}
+		labelNames = append(labelNames, label.Name)
+	}
+	var assigneeLogins []string
+	for _, assignee := range details.Assignees {
+		assigneeLogins = append(assigneeLogins, assignee.Login)
+	}
+
+	newBody := details.Body + fmt.Sprintf("\n\n---\n_Recreated from #%d by Vigilante._", issue)
+	created, err := ghcli.CreateIssue(ctx, a.env.Runner, repoSlug, details.Title, newBody, labelNames, assigneeLogins)
+	if err != nil {
+		return fmt.Errorf("create replacement issue: %w", err)
+	}
+
+	crossLinkBody := fmt.Sprintf("## ♻️ Issue Recreated\n\nThis issue has been recreated as #%d.\n\nThe original issue is being closed as `not planned` and stale artifacts are being cleaned up.\n\nSource: `%s`.", created.Number, source)
+	a.commentOnIssueBestEffort(ctx, repoSlug, issue, crossLinkBody, "recreate cross-link")
+
+	if err := ghcli.CloseIssueNotPlanned(ctx, a.env.Runner, repoSlug, issue); err != nil {
+		return fmt.Errorf("close original issue: %w", err)
+	}
+
+	a.cancelRunningSession(session.Repo, session.IssueNumber)
+
+	var cleanupErrors []string
+
+	if session.PullRequestNumber > 0 {
+		if err := ghcli.ClosePullRequest(ctx, a.env.Runner, repoSlug, session.PullRequestNumber); err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Sprintf("close PR #%d: %s", session.PullRequestNumber, err))
+		}
+	}
+
+	if session.Branch != "" {
+		if err := ghcli.DeleteRemoteBranch(ctx, a.env.Runner, session.RepoPath, session.Branch); err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Sprintf("delete remote branch %s: %s", session.Branch, err))
+		}
+	}
+
+	branches := worktree.IssueBranchCandidates(session.IssueNumber, session.IssueTitle)
+	if session.Branch != "" && !containsString(branches, session.Branch) {
+		branches = append(branches, session.Branch)
+	}
+	if err := worktree.CleanupIssueArtifactsForBranches(ctx, a.env.Runner, session.RepoPath, session.WorktreePath, branches); err != nil {
+		cleanupErrors = append(cleanupErrors, fmt.Sprintf("local cleanup: %s", err))
+	}
+
+	now := a.clock().Format(time.RFC3339)
+	session.Status = state.SessionStatusClosed
+	session.ProcessID = 0
+	session.LastHeartbeatAt = ""
+	session.EndedAt = now
+	session.UpdatedAt = now
+	session.CleanupCompletedAt = now
+	session.LastCleanupSource = "recreate_" + source
+	session.LastRecreateSource = source
+	session.RecreatedAsIssue = created.Number
+	session.RecreatedAsIssueURL = created.URL
+	session.LastError = fmt.Sprintf("recreated as #%d via %s", created.Number, source)
+
+	body := recreateResultComment(issue, created.Number, created.URL, source, cleanupErrors)
+	if err := a.commentOnIssue(ctx, repoSlug, issue, body, "recreate", "github_comment"); err != nil {
+		a.state.AppendDaemonLog("recreate result comment failed repo=%s issue=%d err=%v", repoSlug, issue, err)
+	}
+
+	a.state.AppendDaemonLog("recreate completed repo=%s old_issue=%d new_issue=%d source=%s", repoSlug, issue, created.Number, source)
+	return nil
+}
+
 func (a *App) processGitHubResumeRequests(ctx context.Context, sessions []state.Session, issueCache scanIssueDetailsCache) ([]state.Session, error) {
 	for i := range sessions {
 		session := &sessions[i]
@@ -2515,6 +2682,143 @@ func (a *App) RedispatchSession(ctx context.Context, repoSlug string, issue int,
 
 	a.launchIssueSession(ctx, target, *selectedIssue, session)
 	return nil
+}
+
+func (a *App) RecreateSession(ctx context.Context, repoSlug string, issue int, source string) error {
+	if err := a.state.EnsureLayout(); err != nil {
+		return err
+	}
+
+	a.sessionMu.Lock()
+	defer a.sessionMu.Unlock()
+
+	targets, err := a.state.LoadWatchTargets()
+	if err != nil {
+		return err
+	}
+	if _, ok := findWatchTargetByRepo(targets, repoSlug); !ok {
+		return fmt.Errorf("watch target not found for %s", repoSlug)
+	}
+
+	details, err := ghcli.GetIssueDetails(ctx, a.env.Runner, repoSlug, issue)
+	if err != nil {
+		return fmt.Errorf("get issue details: %w", err)
+	}
+
+	// Collect labels to copy (skip vigilante lifecycle labels).
+	var labelNames []string
+	for _, label := range details.Labels {
+		if strings.HasPrefix(label.Name, "vigilante:") {
+			continue
+		}
+		labelNames = append(labelNames, label.Name)
+	}
+	var assigneeLogins []string
+	for _, assignee := range details.Assignees {
+		assigneeLogins = append(assigneeLogins, assignee.Login)
+	}
+
+	newBody := details.Body + fmt.Sprintf("\n\n---\n_Recreated from #%d by Vigilante._", issue)
+	created, err := ghcli.CreateIssue(ctx, a.env.Runner, repoSlug, details.Title, newBody, labelNames, assigneeLogins)
+	if err != nil {
+		return fmt.Errorf("create replacement issue: %w", err)
+	}
+
+	// Cross-link on the old issue and close it.
+	crossLinkBody := fmt.Sprintf("## ♻️ Issue Recreated\n\nThis issue has been recreated as #%d.\n\nThe original issue is being closed as `not planned` and stale artifacts are being cleaned up.\n\nSource: `%s`.", created.Number, source)
+	a.commentOnIssueBestEffort(ctx, repoSlug, issue, crossLinkBody, "recreate cross-link")
+
+	if err := ghcli.CloseIssueNotPlanned(ctx, a.env.Runner, repoSlug, issue); err != nil {
+		return fmt.Errorf("close original issue: %w", err)
+	}
+
+	// Clean up the PR, remote branch, and local session artifacts.
+	sessions, err := a.state.LoadSessions()
+	if err != nil {
+		return err
+	}
+
+	var cleanupErrors []string
+	for i := range sessions {
+		if sessions[i].Repo != repoSlug || sessions[i].IssueNumber != issue {
+			continue
+		}
+		session := &sessions[i]
+
+		// Cancel running process if any.
+		a.cancelRunningSession(session.Repo, session.IssueNumber)
+
+		// Close PR if one exists.
+		if session.PullRequestNumber > 0 {
+			if err := ghcli.ClosePullRequest(ctx, a.env.Runner, repoSlug, session.PullRequestNumber); err != nil {
+				cleanupErrors = append(cleanupErrors, fmt.Sprintf("close PR #%d: %s", session.PullRequestNumber, err))
+			}
+		}
+
+		// Delete remote branch.
+		if session.Branch != "" {
+			if err := ghcli.DeleteRemoteBranch(ctx, a.env.Runner, session.RepoPath, session.Branch); err != nil {
+				cleanupErrors = append(cleanupErrors, fmt.Sprintf("delete remote branch %s: %s", session.Branch, err))
+			}
+		}
+
+		// Clean up local worktree/branch artifacts.
+		branches := worktree.IssueBranchCandidates(session.IssueNumber, session.IssueTitle)
+		if session.Branch != "" && !containsString(branches, session.Branch) {
+			branches = append(branches, session.Branch)
+		}
+		if err := worktree.CleanupIssueArtifactsForBranches(ctx, a.env.Runner, session.RepoPath, session.WorktreePath, branches); err != nil {
+			cleanupErrors = append(cleanupErrors, fmt.Sprintf("local cleanup: %s", err))
+		}
+
+		now := a.clock().Format(time.RFC3339)
+		session.Status = state.SessionStatusClosed
+		session.ProcessID = 0
+		session.LastHeartbeatAt = ""
+		session.EndedAt = now
+		session.UpdatedAt = now
+		session.CleanupCompletedAt = now
+		session.LastCleanupSource = "recreate_" + source
+		session.LastRecreateSource = source
+		session.RecreatedAsIssue = created.Number
+		session.RecreatedAsIssueURL = created.URL
+		session.LastError = fmt.Sprintf("recreated as #%d via %s", created.Number, source)
+		break
+	}
+
+	if err := a.state.SaveSessions(sessions); err != nil {
+		return err
+	}
+
+	a.state.AppendDaemonLog("recreate completed repo=%s old_issue=%d new_issue=%d source=%s", repoSlug, issue, created.Number, source)
+
+	if len(cleanupErrors) > 0 {
+		fmt.Fprintf(a.stdout, "recreated %s issue #%d as #%d (%s) with partial cleanup errors: %s\n", repoSlug, issue, created.Number, created.URL, strings.Join(cleanupErrors, "; "))
+	} else {
+		fmt.Fprintf(a.stdout, "recreated %s issue #%d as #%d (%s)\n", repoSlug, issue, created.Number, created.URL)
+	}
+
+	return nil
+}
+
+func recreateResultComment(oldIssue int, newIssueNumber int, newIssueURL string, source string, cleanupErrors []string) string {
+	items := []string{
+		fmt.Sprintf("Created replacement issue #%d.", newIssueNumber),
+		fmt.Sprintf("Closed original issue #%d as `not planned`.", oldIssue),
+	}
+	if len(cleanupErrors) > 0 {
+		items = append(items, fmt.Sprintf("Partial cleanup errors: %s.", strings.Join(cleanupErrors, "; ")))
+	} else {
+		items = append(items, "Cleaned up stale PR, remote branch, and local session artifacts.")
+	}
+	return ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Issue Recreated",
+		Emoji:      "♻️",
+		Percent:    100,
+		ETAMinutes: 1,
+		Items:      items,
+		Tagline:    "Fresh start, clean slate.",
+	})
 }
 
 func (a *App) cleanupSessions(ctx context.Context, source string, successFormat string, match func(state.Session) bool, args ...any) error {
@@ -4618,6 +4922,7 @@ func (a *App) printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  vigilante cleanup --repo <owner/name> [--issue <n>]")
 	fmt.Fprintln(w, "  vigilante cleanup --all")
 	fmt.Fprintln(w, "  vigilante redispatch --repo <owner/name> --issue <n>")
+	fmt.Fprintln(w, "  vigilante recreate --repo <owner/name> --issue <n>")
 	fmt.Fprintln(w, "  vigilante resume --repo <owner/name> --issue <n>")
 	fmt.Fprintln(w, "  vigilante resume --all-blocked")
 	fmt.Fprintln(w, "  vigilante service restart")
@@ -4662,7 +4967,7 @@ _vigilante()
     local cur prev words cword
     _init_completion || return
 
-    local commands="setup watch unwatch list status cleanup redispatch resume service daemon completion"
+    local commands="setup watch unwatch list status cleanup redispatch recreate resume service daemon completion"
     local global_flags="-h --help"
 
     case "${words[1]}" in
@@ -4686,6 +4991,10 @@ _vigilante()
             return
             ;;
         redispatch)
+            COMPREPLY=( $(compgen -W "--repo --issue" -- "$cur") )
+            return
+            ;;
+        recreate)
             COMPREPLY=( $(compgen -W "--repo --issue" -- "$cur") )
             return
             ;;
@@ -4727,6 +5036,7 @@ complete -c vigilante -f -n '__fish_use_subcommand' -a 'list' -d 'Show watched r
 complete -c vigilante -f -n '__fish_use_subcommand' -a 'status' -d 'Show installed service state'
 complete -c vigilante -f -n '__fish_use_subcommand' -a 'cleanup' -d 'Clean up running sessions'
 complete -c vigilante -f -n '__fish_use_subcommand' -a 'redispatch' -d 'Restart one watched issue in a fresh local worktree'
+complete -c vigilante -f -n '__fish_use_subcommand' -a 'recreate' -d 'Recreate a stuck issue as a fresh duplicate'
 complete -c vigilante -f -n '__fish_use_subcommand' -a 'resume' -d 'Resume blocked sessions'
 complete -c vigilante -f -n '__fish_use_subcommand' -a 'service' -d 'Run service commands'
 complete -c vigilante -f -n '__fish_use_subcommand' -a 'daemon' -d 'Run daemon commands'
@@ -4746,6 +5056,8 @@ complete -c vigilante -n '__fish_seen_subcommand_from cleanup' -l issue
 complete -c vigilante -n '__fish_seen_subcommand_from cleanup' -l all
 complete -c vigilante -n '__fish_seen_subcommand_from redispatch' -l repo
 complete -c vigilante -n '__fish_seen_subcommand_from redispatch' -l issue
+complete -c vigilante -n '__fish_seen_subcommand_from recreate' -l repo
+complete -c vigilante -n '__fish_seen_subcommand_from recreate' -l issue
 complete -c vigilante -n '__fish_seen_subcommand_from resume' -l repo
 complete -c vigilante -n '__fish_seen_subcommand_from resume' -l issue
 complete -c vigilante -n '__fish_seen_subcommand_from resume' -l all-blocked
@@ -4770,6 +5082,7 @@ _vigilante() {
     'status:Show installed service state'
     'cleanup:Clean up running sessions'
     'redispatch:Restart one watched issue in a fresh local worktree'
+    'recreate:Recreate a stuck issue as a fresh duplicate'
     'resume:Resume blocked sessions'
     'service:Run service commands'
     'daemon:Run daemon commands'
@@ -4797,6 +5110,9 @@ _vigilante() {
       compadd -- --repo --issue --all
       ;;
     redispatch)
+      compadd -- --repo --issue
+      ;;
+    recreate)
       compadd -- --repo --issue
       ;;
     resume)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -6910,6 +6910,266 @@ func freshBaseBranchOutputs(repoPath string, branch string) map[string]string {
 	}
 }
 
+func TestRecreateSessionSuccess(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-50")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/50": `{"title":"stuck issue","body":"the body","html_url":"https://github.com/owner/repo/issues/50","state":"open","labels":[{"name":"bug"},{"name":"vigilante:running"}],"assignees":[{"login":"nico"}]}`,
+			testutil.Key("gh", "api", "--method", "POST", "-H", "Accept: application/vnd.github+json", "repos/owner/repo/issues", "-f", "title=stuck issue", "-f", "body=the body\n\n---\n_Recreated from #50 by Vigilante._", "-f", "labels[]=bug", "-f", "assignees[]=nico"): `{"number":51,"html_url":"https://github.com/owner/repo/issues/51"}`,
+			"gh issue comment --repo owner/repo 50 --body ## ♻️ Issue Recreated\n\nThis issue has been recreated as #51.\n\nThe original issue is being closed as `not planned` and stale artifacts are being cleaned up.\n\nSource: `cli`.":                                   "ok",
+			testutil.Key("gh", "api", "--method", "PATCH", "-H", "Accept: application/vnd.github+json", "repos/owner/repo/issues/50", "-f", "state=closed", "-f", "state_reason=not_planned"):                                                                                  "ok",
+			"gh pr close --repo owner/repo 10":                            "ok",
+			"git push origin --delete vigilante/issue-50":                 "ok",
+			"git worktree prune":                                          "ok",
+			"git worktree remove --force " + worktreePath:                 "ok",
+			"git worktree list --porcelain":                               "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-50": "ok",
+			"git branch -D vigilante/issue-50":                            "Deleted branch vigilante/issue-50\n",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{
+		Path: repoPath,
+		Repo: "owner/repo",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:          repoPath,
+		Repo:              "owner/repo",
+		IssueNumber:       50,
+		IssueTitle:        "stuck issue",
+		Status:            state.SessionStatusRunning,
+		Branch:            "vigilante/issue-50",
+		WorktreePath:      worktreePath,
+		PullRequestNumber: 10,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.RecreateSession(context.Background(), "owner/repo", 50, "cli"); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if sessions[0].Status != state.SessionStatusClosed {
+		t.Fatalf("expected closed status, got: %s", sessions[0].Status)
+	}
+	if sessions[0].RecreatedAsIssue != 51 {
+		t.Fatalf("expected recreated as issue 51, got: %d", sessions[0].RecreatedAsIssue)
+	}
+	if !strings.Contains(stdout.String(), "recreated owner/repo issue #50 as #51") {
+		t.Fatalf("unexpected output: %s", stdout.String())
+	}
+}
+
+func TestRecreateSessionFailsWhenRepoIsUnwatched(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := app.RecreateSession(context.Background(), "owner/repo", 50, "cli")
+	if err == nil || !strings.Contains(err.Error(), "watch target not found") {
+		t.Fatalf("expected watch target error, got: %v", err)
+	}
+}
+
+func TestRecreateSessionFailsWhenIssueDetailsFail(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Errors: map[string]error{
+			"gh api repos/owner/repo/issues/50": errors.New("not found"),
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{
+		Path: "/tmp/repo",
+		Repo: "owner/repo",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	err := app.RecreateSession(context.Background(), "owner/repo", 50, "cli")
+	if err == nil || !strings.Contains(err.Error(), "get issue details") {
+		t.Fatalf("expected issue details error, got: %v", err)
+	}
+}
+
+func TestRecreateCommandParsing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+
+	exitCode := app.Run(context.Background(), []string{"recreate", "--help"})
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0 for --help, got %d", exitCode)
+	}
+	if !strings.Contains(stdout.String(), "vigilante recreate --repo") {
+		t.Fatalf("expected usage text in help output, got: %s", stdout.String())
+	}
+}
+
+func TestRecreateCommandMissingFlags(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	var stderr bytes.Buffer
+	app.stdout = &bytes.Buffer{}
+	app.stderr = &stderr
+
+	exitCode := app.Run(context.Background(), []string{"recreate"})
+	if exitCode != 1 {
+		t.Fatalf("expected exit code 1 for missing flags, got %d", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "usage: vigilante recreate") {
+		t.Fatalf("expected usage error, got: %s", stderr.String())
+	}
+}
+
+func TestRecreateSessionPartialCleanupErrors(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-60")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/60": `{"title":"partial fail","body":"body","html_url":"https://github.com/owner/repo/issues/60","state":"open","labels":[],"assignees":[]}`,
+			testutil.Key("gh", "api", "--method", "POST", "-H", "Accept: application/vnd.github+json", "repos/owner/repo/issues", "-f", "title=partial fail", "-f", "body=body\n\n---\n_Recreated from #60 by Vigilante._"):                  `{"number":61,"html_url":"https://github.com/owner/repo/issues/61"}`,
+			"gh issue comment --repo owner/repo 60 --body ## ♻️ Issue Recreated\n\nThis issue has been recreated as #61.\n\nThe original issue is being closed as `not planned` and stale artifacts are being cleaned up.\n\nSource: `cli`.": "ok",
+			testutil.Key("gh", "api", "--method", "PATCH", "-H", "Accept: application/vnd.github+json", "repos/owner/repo/issues/60", "-f", "state=closed", "-f", "state_reason=not_planned"):                                                "ok",
+			"git worktree prune":            "ok",
+			"git worktree list --porcelain": "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
+		},
+		Errors: map[string]error{
+			"git push origin --delete vigilante/issue-60": errors.New("remote ref not found"),
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{
+		Path: repoPath,
+		Repo: "owner/repo",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:     repoPath,
+		Repo:         "owner/repo",
+		IssueNumber:  60,
+		IssueTitle:   "partial fail",
+		Status:       state.SessionStatusRunning,
+		Branch:       "vigilante/issue-60",
+		WorktreePath: worktreePath,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.RecreateSession(context.Background(), "owner/repo", 60, "cli"); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(stdout.String(), "partial cleanup errors") {
+		t.Fatalf("expected partial cleanup errors in output, got: %s", stdout.String())
+	}
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions[0].Status != state.SessionStatusClosed || sessions[0].RecreatedAsIssue != 61 {
+		t.Fatalf("unexpected session state: %#v", sessions[0])
+	}
+}
+
+func TestRecreateSessionNoExistingSession(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/70": `{"title":"no session","body":"body","html_url":"https://github.com/owner/repo/issues/70","state":"open","labels":[],"assignees":[]}`,
+			testutil.Key("gh", "api", "--method", "POST", "-H", "Accept: application/vnd.github+json", "repos/owner/repo/issues", "-f", "title=no session", "-f", "body=body\n\n---\n_Recreated from #70 by Vigilante._"):                    `{"number":71,"html_url":"https://github.com/owner/repo/issues/71"}`,
+			"gh issue comment --repo owner/repo 70 --body ## ♻️ Issue Recreated\n\nThis issue has been recreated as #71.\n\nThe original issue is being closed as `not planned` and stale artifacts are being cleaned up.\n\nSource: `cli`.": "ok",
+			testutil.Key("gh", "api", "--method", "PATCH", "-H", "Accept: application/vnd.github+json", "repos/owner/repo/issues/70", "-f", "state=closed", "-f", "state_reason=not_planned"):                                                "ok",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{
+		Path: repoPath,
+		Repo: "owner/repo",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.RecreateSession(context.Background(), "owner/repo", 70, "cli"); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(stdout.String(), "recreated owner/repo issue #70 as #71") {
+		t.Fatalf("unexpected output: %s", stdout.String())
+	}
+}
+
 func mergeStringMaps(maps ...map[string]string) map[string]string {
 	merged := map[string]string{}
 	for _, current := range maps {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -485,6 +485,10 @@ func FindCleanupComment(comments []IssueComment, claimedCommentID int64) *IssueC
 	return findCommandComment(comments, "@vigilanteai cleanup", claimedCommentID)
 }
 
+func FindRecreateComment(comments []IssueComment, claimedCommentID int64) *IssueComment {
+	return findCommandComment(comments, "@vigilanteai recreate", claimedCommentID)
+}
+
 func FindIterationComment(comments []IssueComment, claimedCommentID int64) *IssueComment {
 	for i := len(comments) - 1; i >= 0; i-- {
 		if claimedCommentID != 0 && comments[i].ID == claimedCommentID {
@@ -511,7 +515,7 @@ func IsIterationComment(comment IssueComment) bool {
 
 func IsKnownVigilanteCommandComment(body string) bool {
 	switch normalizeVigilanteComment(body) {
-	case "@vigilanteai resume", "@vigilanteai cleanup":
+	case "@vigilanteai resume", "@vigilanteai cleanup", "@vigilanteai recreate":
 		return true
 	default:
 		return false
@@ -639,6 +643,46 @@ func IsIssueUnavailableError(err error) bool {
 
 func MergePullRequestSquash(ctx context.Context, runner environment.Runner, repo string, number int) error {
 	_, err := runner.Run(ctx, "", "gh", "pr", "merge", "--repo", repo, fmt.Sprintf("%d", number), "--squash", "--delete-branch")
+	return err
+}
+
+type CreatedIssue struct {
+	Number int    `json:"number"`
+	URL    string `json:"html_url"`
+}
+
+func CreateIssue(ctx context.Context, runner environment.Runner, repo string, title string, body string, labels []string, assignees []string) (*CreatedIssue, error) {
+	args := []string{"gh", "api", "--method", "POST", "-H", "Accept: application/vnd.github+json", "repos/" + repo + "/issues", "-f", "title=" + title, "-f", "body=" + body}
+	for _, label := range labels {
+		args = append(args, "-f", "labels[]="+label)
+	}
+	for _, assignee := range assignees {
+		args = append(args, "-f", "assignees[]="+assignee)
+	}
+	output, err := runner.Run(ctx, "", args[0], args[1:]...)
+	if err != nil {
+		return nil, fmt.Errorf("create issue: %w", err)
+	}
+	var created CreatedIssue
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &created); err != nil {
+		return nil, fmt.Errorf("parse created issue: %w", err)
+	}
+	return &created, nil
+}
+
+func CloseIssueNotPlanned(ctx context.Context, runner environment.Runner, repo string, number int) error {
+	_, err := runner.Run(ctx, "", "gh", "api", "--method", "PATCH", "-H", "Accept: application/vnd.github+json",
+		issueAPIPath(repo, number), "-f", "state=closed", "-f", "state_reason=not_planned")
+	return err
+}
+
+func ClosePullRequest(ctx context.Context, runner environment.Runner, repo string, number int) error {
+	_, err := runner.Run(ctx, "", "gh", "pr", "close", "--repo", repo, fmt.Sprintf("%d", number))
+	return err
+}
+
+func DeleteRemoteBranch(ctx context.Context, runner environment.Runner, repoPath string, branch string) error {
+	_, err := runner.Run(ctx, repoPath, "git", "push", "origin", "--delete", branch)
 	return err
 }
 

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -428,6 +428,31 @@ func TestFindCleanupComment(t *testing.T) {
 	}
 }
 
+func TestFindRecreateComment(t *testing.T) {
+	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	comments := []IssueComment{
+		{ID: 10, Body: "hello", CreatedAt: now.Add(-2 * time.Minute)},
+		{ID: 11, Body: "@vigilanteai recreate", CreatedAt: now.Add(-1 * time.Minute)},
+	}
+
+	comment := FindRecreateComment(comments, 0)
+	if comment == nil || comment.ID != 11 {
+		t.Fatalf("expected recreate comment to be found, got: %#v", comment)
+	}
+	if comment := FindRecreateComment(comments, 11); comment != nil {
+		t.Fatalf("expected claimed recreate comment to be ignored, got: %#v", comment)
+	}
+}
+
+func TestIsKnownVigilanteCommandCommentIncludesRecreate(t *testing.T) {
+	if !IsKnownVigilanteCommandComment("@vigilanteai recreate") {
+		t.Fatal("expected @vigilanteai recreate to be a known command")
+	}
+	if !IsKnownVigilanteCommandComment("  @vigilanteai   recreate  ") {
+		t.Fatal("expected whitespace-padded @vigilanteai recreate to be a known command")
+	}
+}
+
 func TestFindIterationCommentSkipsKnownCommands(t *testing.T) {
 	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
 	comments := []IssueComment{

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -123,6 +123,11 @@ type Session struct {
 	LastCleanupSource              string        `json:"last_cleanup_source,omitempty"`
 	LastCleanupCommentID           int64         `json:"last_cleanup_comment_id,omitempty"`
 	LastCleanupCommentAt           string        `json:"last_cleanup_comment_at,omitempty"`
+	LastRecreateSource             string        `json:"last_recreate_source,omitempty"`
+	LastRecreateCommentID          int64         `json:"last_recreate_comment_id,omitempty"`
+	LastRecreateCommentAt          string        `json:"last_recreate_comment_at,omitempty"`
+	RecreatedAsIssue               int           `json:"recreated_as_issue,omitempty"`
+	RecreatedAsIssueURL            string        `json:"recreated_as_issue_url,omitempty"`
 	StaleAutoRestartAttempts       int           `json:"stale_auto_restart_attempts,omitempty"`
 	StaleAutoRestartPendingSince   string        `json:"stale_auto_restart_pending_since,omitempty"`
 	StaleAutoRestartStoppedAt      string        `json:"stale_auto_restart_stopped_at,omitempty"`


### PR DESCRIPTION
## Summary

- Adds `vigilante recreate --repo <owner/name> --issue <n>` CLI command and `@vigilanteai recreate` GitHub comment command to duplicate a stuck issue as a fresh one, close the original as `not planned`, and clean up stale PR/branch/session artifacts.
- Adds GitHub API helpers for issue creation, issue closure with `not_planned` reason, PR closure, and remote branch deletion.
- Integrates recreate comment detection into the daemon scan loop alongside existing cleanup and resume processing.
- Updates help text and shell completions (bash, fish, zsh) with the new command.

## Validation

- All existing tests pass (`go test ./...`, `gofmt`, `go vet`).
- 9 new tests cover: CLI parsing/help, comment detection (`FindRecreateComment`, `IsKnownVigilanteCommandComment`), successful recreation, unwatched repo failure, issue details failure, partial cleanup errors, and recreation without an existing session.

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)