### PR TITLE
Add watch mode and pretty structured rendering for access logs

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -373,7 +373,7 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 	case "status":
 		return a.runStatusCommand(ctx, args[1:])
 	case "logs":
-		return a.runLogsCommand(args[1:])
+		return a.runLogsCommand(ctx, args[1:])
 	case "cleanup":
 		return a.runCleanupCommand(ctx, args[1:])
 	case "redispatch":
@@ -625,10 +625,10 @@ func (a *App) runCompletionCommand(args []string) error {
 	return err
 }
 
-func (a *App) runLogsCommand(args []string) error {
+func (a *App) runLogsCommand(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("logs", flag.ContinueOnError)
 	configureFlagSet(fs, func(w io.Writer) {
-		fmt.Fprintln(w, "usage: vigilante logs [--access] [--repo <owner/name>] [--issue <n>]")
+		fmt.Fprintln(w, "usage: vigilante logs [--access [-w]] [--repo <owner/name>] [--issue <n>]")
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, "List daemon, access, and session log files or show a specific log.")
 		fmt.Fprintln(w)
@@ -636,6 +636,8 @@ func (a *App) runLogsCommand(args []string) error {
 		fs.PrintDefaults()
 	})
 	accessFlag := fs.Bool("access", false, "show the structured access log")
+	watchFlag := fs.Bool("w", false, "follow the access log and show new entries as they arrive")
+	fs.BoolVar(watchFlag, "watch", false, "follow the access log and show new entries as they arrive")
 	repoFlag := fs.String("repo", "", "repository slug")
 	issueFlag := fs.Int("issue", 0, "issue number")
 	if err := parseFlagSet(fs, args, a.stdout); err != nil {
@@ -644,16 +646,21 @@ func (a *App) runLogsCommand(args []string) error {
 		}
 		return err
 	}
+	if *watchFlag && !*accessFlag {
+		return errors.New("-w is only supported with --access")
+	}
 	if *accessFlag {
 		if *repoFlag != "" || *issueFlag > 0 {
 			return errors.New("--access cannot be combined with --repo or --issue")
+		}
+		if *watchFlag {
+			return a.watchAccessLog(ctx, a.state.AccessLogPath())
 		}
 		content, err := os.ReadFile(a.state.AccessLogPath())
 		if err != nil {
 			return errors.New("no access log found")
 		}
-		_, err = fmt.Fprint(a.stdout, string(content))
-		return err
+		return renderAccessLogLines(a.stdout, content)
 	}
 
 	if *repoFlag != "" && *issueFlag > 0 {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -7352,8 +7352,12 @@ func TestLogsCommandShowsAccessLog(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("expected success exit code, got %d", exitCode)
 	}
-	if stdout.String() != logContent {
-		t.Fatalf("expected access log content %q, got %q", logContent, stdout.String())
+	output := stdout.String()
+	if !strings.Contains(output, "[daemon]") {
+		t.Fatalf("expected formatted output with context, got %q", output)
+	}
+	if !strings.Contains(output, "gh") {
+		t.Fatalf("expected formatted output with tool name, got %q", output)
 	}
 }
 

--- a/internal/app/logs.go
+++ b/internal/app/logs.go
@@ -1,0 +1,129 @@
+package app
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/nicobistolfi/vigilante/internal/environment"
+)
+
+func formatAccessLogEntry(e environment.AccessLogEntry) string {
+	var b strings.Builder
+
+	ts := e.Timestamp
+	if t, err := time.Parse(time.RFC3339Nano, e.Timestamp); err == nil {
+		ts = t.Local().Format("2006-01-02 15:04:05")
+	}
+
+	status := "✗"
+	if e.Success {
+		status = "✓"
+	}
+
+	cmd := e.Tool
+	if len(e.Argv) > 0 {
+		cmd += " " + strings.Join(e.Argv, " ")
+	}
+
+	dur := formatDuration(e.DurationMs)
+
+	fmt.Fprintf(&b, "%s  %s  [%s]  %s  (%s)", ts, status, e.ExecutionContext, cmd, dur)
+
+	var details []string
+	if e.Repo != "" {
+		detail := "repo: " + e.Repo
+		if e.IssueNumber > 0 {
+			detail += fmt.Sprintf(" #%d", e.IssueNumber)
+		}
+		details = append(details, detail)
+	}
+	if !e.Success {
+		details = append(details, fmt.Sprintf("exit: %d", e.ExitCode))
+	}
+
+	if len(details) > 0 {
+		b.WriteString("\n")
+		padding := strings.Repeat(" ", len(ts)+2+len(status)+2)
+		b.WriteString(padding)
+		b.WriteString(strings.Join(details, "  "))
+	}
+
+	return b.String()
+}
+
+func formatDuration(ms int64) string {
+	if ms < 1000 {
+		return fmt.Sprintf("%dms", ms)
+	}
+	if ms < 60000 {
+		return fmt.Sprintf("%.1fs", float64(ms)/1000)
+	}
+	return fmt.Sprintf("%.1fm", float64(ms)/60000)
+}
+
+func renderAccessLogLines(w io.Writer, data []byte) error {
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var entry environment.AccessLogEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			fmt.Fprintf(w, "[malformed] %s\n", line)
+			continue
+		}
+		fmt.Fprintln(w, formatAccessLogEntry(entry))
+	}
+	return scanner.Err()
+}
+
+func (a *App) watchAccessLog(ctx context.Context, path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("no access log found")
+	}
+	defer f.Close()
+
+	// Print existing entries first.
+	if err := renderAccessLogStream(a.stdout, f); err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := renderAccessLogStream(a.stdout, f); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func renderAccessLogStream(w io.Writer, f *os.File) error {
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var entry environment.AccessLogEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			fmt.Fprintf(w, "[malformed] %s\n", line)
+			continue
+		}
+		fmt.Fprintln(w, formatAccessLogEntry(entry))
+	}
+	return scanner.Err()
+}

--- a/internal/app/logs_test.go
+++ b/internal/app/logs_test.go
@@ -1,0 +1,286 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nicobistolfi/vigilante/internal/environment"
+	"github.com/nicobistolfi/vigilante/internal/testutil"
+)
+
+func TestFormatAccessLogEntry(t *testing.T) {
+	entry := environment.AccessLogEntry{
+		Timestamp:        "2026-03-26T17:42:36.123456789Z",
+		CompletedAt:      "2026-03-26T17:42:36.200000000Z",
+		ExecutionContext: "daemon",
+		Repo:             "owner/repo",
+		IssueNumber:      42,
+		Tool:             "gh",
+		Argv:             []string{"api", "repos/owner/repo/issues"},
+		ExitCode:         0,
+		DurationMs:       77,
+		Success:          true,
+	}
+	out := formatAccessLogEntry(entry)
+	if !strings.Contains(out, "[daemon]") {
+		t.Errorf("expected context in output, got %q", out)
+	}
+	if !strings.Contains(out, "gh api repos/owner/repo/issues") {
+		t.Errorf("expected command in output, got %q", out)
+	}
+	if !strings.Contains(out, "77ms") {
+		t.Errorf("expected duration in output, got %q", out)
+	}
+	if !strings.Contains(out, "✓") {
+		t.Errorf("expected success indicator, got %q", out)
+	}
+	if !strings.Contains(out, "repo: owner/repo #42") {
+		t.Errorf("expected repo and issue detail, got %q", out)
+	}
+}
+
+func TestFormatAccessLogEntryFailure(t *testing.T) {
+	entry := environment.AccessLogEntry{
+		Timestamp:        "2026-03-26T10:00:00Z",
+		CompletedAt:      "2026-03-26T10:00:01Z",
+		ExecutionContext: "session",
+		Tool:             "go",
+		Argv:             []string{"test", "./..."},
+		ExitCode:         1,
+		DurationMs:       1200,
+		Success:          false,
+	}
+	out := formatAccessLogEntry(entry)
+	if !strings.Contains(out, "✗") {
+		t.Errorf("expected failure indicator, got %q", out)
+	}
+	if !strings.Contains(out, "[session]") {
+		t.Errorf("expected session context, got %q", out)
+	}
+	if !strings.Contains(out, "1.2s") {
+		t.Errorf("expected duration in seconds, got %q", out)
+	}
+	if !strings.Contains(out, "exit: 1") {
+		t.Errorf("expected exit code detail, got %q", out)
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	tests := []struct {
+		ms   int64
+		want string
+	}{
+		{42, "42ms"},
+		{999, "999ms"},
+		{1000, "1.0s"},
+		{1500, "1.5s"},
+		{59999, "60.0s"},
+		{60000, "1.0m"},
+		{120000, "2.0m"},
+	}
+	for _, tt := range tests {
+		got := formatDuration(tt.ms)
+		if got != tt.want {
+			t.Errorf("formatDuration(%d) = %q, want %q", tt.ms, got, tt.want)
+		}
+	}
+}
+
+func TestRenderAccessLogLines(t *testing.T) {
+	data := `{"timestamp":"2026-03-26T10:00:00Z","completed_at":"2026-03-26T10:00:00.050Z","context":"daemon","tool":"gh","argv":["api"],"exit_code":0,"duration_ms":50,"success":true}
+{"timestamp":"2026-03-26T10:00:01Z","completed_at":"2026-03-26T10:00:02Z","context":"session","repo":"owner/repo","issue_number":7,"tool":"git","argv":["status"],"exit_code":0,"duration_ms":120,"success":true}
+`
+	var buf bytes.Buffer
+	if err := renderAccessLogLines(&buf, []byte(data)); err != nil {
+		t.Fatal(err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "[daemon]") {
+		t.Errorf("expected daemon context, got %q", output)
+	}
+	if !strings.Contains(output, "[session]") {
+		t.Errorf("expected session context, got %q", output)
+	}
+	if !strings.Contains(output, "gh api") {
+		t.Errorf("expected gh command, got %q", output)
+	}
+	if !strings.Contains(output, "git status") {
+		t.Errorf("expected git command, got %q", output)
+	}
+}
+
+func TestRenderAccessLogLinesMalformed(t *testing.T) {
+	data := `{"timestamp":"2026-03-26T10:00:00Z","context":"daemon","tool":"gh","argv":[],"exit_code":0,"duration_ms":10,"success":true}
+not valid json at all
+{"timestamp":"2026-03-26T10:00:01Z","context":"daemon","tool":"git","argv":["status"],"exit_code":0,"duration_ms":20,"success":true}
+`
+	var buf bytes.Buffer
+	if err := renderAccessLogLines(&buf, []byte(data)); err != nil {
+		t.Fatal(err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "[malformed]") {
+		t.Errorf("expected malformed marker for bad line, got %q", output)
+	}
+	if !strings.Contains(output, "not valid json at all") {
+		t.Errorf("expected malformed line content preserved, got %q", output)
+	}
+	if !strings.Contains(output, "git status") {
+		t.Errorf("expected valid entries after malformed line, got %q", output)
+	}
+}
+
+func TestRenderAccessLogLinesEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderAccessLogLines(&buf, []byte("")); err != nil {
+		t.Fatal(err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected empty output for empty input, got %q", buf.String())
+	}
+}
+
+func TestWatchAccessLogStopsOnContextCancellation(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	logsDir := filepath.Join(home, ".vigilante", "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logContent := `{"timestamp":"2026-03-26T10:00:00Z","context":"daemon","tool":"gh","argv":["api"],"exit_code":0,"duration_ms":50,"success":true}
+`
+	logPath := filepath.Join(logsDir, "access.jsonl")
+	if err := os.WriteFile(logPath, []byte(logContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+
+	if err := app.watchAccessLog(ctx, logPath); err != nil {
+		t.Fatalf("expected watch mode to stop cleanly, got %v", err)
+	}
+	if !strings.Contains(stdout.String(), "[daemon]") {
+		t.Errorf("expected existing entries to be rendered, got %q", stdout.String())
+	}
+}
+
+func TestWatchAccessLogMissingFile(t *testing.T) {
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+
+	err := app.watchAccessLog(context.Background(), "/nonexistent/path/access.jsonl")
+	if err == nil || !strings.Contains(err.Error(), "no access log found") {
+		t.Fatalf("expected 'no access log found' error, got %v", err)
+	}
+}
+
+func TestLogsWatchFlagRequiresAccess(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	app := New()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = &stderr
+
+	exitCode := app.Run(context.Background(), []string{"logs", "-w"})
+	if exitCode != 1 {
+		t.Fatalf("expected failure exit code, got %d", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "-w is only supported with --access") {
+		t.Fatalf("expected flag validation error, got %q", stderr.String())
+	}
+}
+
+func TestLogsAccessWatchFlag(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	logsDir := filepath.Join(home, ".vigilante", "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logContent := `{"timestamp":"2026-03-26T10:00:00Z","context":"daemon","tool":"gh","argv":["api"],"exit_code":0,"duration_ms":50,"success":true}
+`
+	if err := os.WriteFile(filepath.Join(logsDir, "access.jsonl"), []byte(logContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+
+	exitCode := app.Run(ctx, []string{"logs", "--access", "-w"})
+	if exitCode != 0 {
+		t.Fatalf("expected success exit code, got %d", exitCode)
+	}
+	if !strings.Contains(stdout.String(), "[daemon]") {
+		t.Errorf("expected formatted output, got %q", stdout.String())
+	}
+}
+
+func TestWatchAccessLogPicksUpNewEntries(t *testing.T) {
+	home := t.TempDir()
+	logsDir := filepath.Join(home, ".vigilante", "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(logsDir, "access.jsonl")
+	if err := os.WriteFile(logPath, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- app.watchAccessLog(ctx, logPath)
+	}()
+
+	// Give the watcher time to start.
+	time.Sleep(100 * time.Millisecond)
+
+	// Append a new entry to the log file.
+	entry := `{"timestamp":"2026-03-26T12:00:00Z","context":"session","tool":"make","argv":["build"],"exit_code":0,"duration_ms":300,"success":true}` + "\n"
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(entry); err != nil {
+		f.Close()
+		t.Fatal(err)
+	}
+	f.Close()
+
+	// Wait for the watcher to pick up the new entry.
+	time.Sleep(700 * time.Millisecond)
+	cancel()
+	<-done
+
+	output := stdout.String()
+	if !strings.Contains(output, "make build") {
+		t.Errorf("expected appended entry to appear in output, got %q", output)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `-w`/`--watch` flag to `vigilante logs --access` that tails `access.jsonl` and renders new entries as they arrive
- Decode each JSON line into a human-readable structured format: timestamp, ✓/✗ status, execution context, command + args, duration, and optional repo/issue/exit details
- Malformed lines are surfaced with a `[malformed]` prefix instead of crashing the viewer
- The `-w` flag is scoped to `--access` only — using it without `--access` produces a clear validation error
- The persisted `access.jsonl` format remains unchanged

## Changed files

- `internal/app/logs.go` — new file with access log renderer, watch mode, and duration formatting
- `internal/app/app.go` — wire `-w`/`--watch` flag, use pretty rendering for `--access`, pass context to logs command
- `internal/app/logs_test.go` — new tests for renderer, watch/follow, malformed lines, flag validation
- `internal/app/app_test.go` — update existing access log test for pretty output format

## Test plan

- [x] `TestFormatAccessLogEntry` — verifies structured rendering of a successful entry with repo/issue details
- [x] `TestFormatAccessLogEntryFailure` — verifies failure indicator and exit code display
- [x] `TestFormatDuration` — verifies ms/s/m formatting thresholds
- [x] `TestRenderAccessLogLines` — verifies multi-entry JSONL rendering
- [x] `TestRenderAccessLogLinesMalformed` — verifies graceful handling of bad JSON lines
- [x] `TestRenderAccessLogLinesEmpty` — verifies empty input produces no output
- [x] `TestWatchAccessLogStopsOnContextCancellation` — verifies clean shutdown
- [x] `TestWatchAccessLogMissingFile` — verifies error for nonexistent log
- [x] `TestLogsWatchFlagRequiresAccess` — verifies `-w` without `--access` is rejected
- [x] `TestLogsAccessWatchFlag` — verifies end-to-end via `app.Run`
- [x] `TestWatchAccessLogPicksUpNewEntries` — verifies tail behavior picks up appended entries
- [x] Full test suite passes with no regressions

Closes #320