### PR TITLE
Recover stale sessions from GitHub state

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -174,6 +174,107 @@ func (a *App) loadIssueDetailsForScan(ctx context.Context, cache scanIssueDetail
 	return details, nil
 }
 
+func (a *App) loadPullRequestForSession(ctx context.Context, session state.Session) (*ghcli.PullRequest, error) {
+	if session.PullRequestNumber > 0 {
+		return ghcli.GetPullRequestDetails(ctx, a.env.Runner, session.Repo, session.PullRequestNumber)
+	}
+	if strings.TrimSpace(session.Branch) == "" {
+		return nil, nil
+	}
+	pr, err := ghcli.FindPullRequestForBranch(ctx, a.env.Runner, session.Repo, session.Branch)
+	if err != nil || pr == nil {
+		return pr, err
+	}
+	return ghcli.GetPullRequestDetails(ctx, a.env.Runner, session.Repo, pr.Number)
+}
+
+func (a *App) reconcileStaleRunningSession(ctx context.Context, session *state.Session, issueCache scanIssueDetailsCache, reason string, commentOnRecovery bool) (bool, error) {
+	issue, err := a.loadIssueDetailsForScan(ctx, issueCache, session.Repo, session.IssueNumber)
+	if err != nil {
+		if ghcli.IsIssueUnavailableError(err) {
+			a.stopMonitoringUnavailableIssueSession(ctx, session, "issue_deleted", err)
+			resetStaleAutoRestartState(session)
+			return true, nil
+		}
+		return false, err
+	}
+
+	pr, err := a.loadPullRequestForSession(ctx, *session)
+	if err != nil {
+		return false, err
+	}
+
+	nowText := a.clock().Format(time.RFC3339)
+	recover := func(nextStatus state.SessionStatus) {
+		previousStatus := session.Status
+		session.Status = nextStatus
+		session.ProcessID = 0
+		session.LastHeartbeatAt = ""
+		session.EndedAt = nowText
+		session.UpdatedAt = nowText
+		session.RecoveredAt = nowText
+		session.LastError = ""
+		resetStaleAutoRestartState(session)
+		a.emitSessionTransition(previousStatus, *session, "stale_github_reconciliation")
+	}
+
+	if pr != nil {
+		switch {
+		case strings.EqualFold(strings.TrimSpace(pr.State), "OPEN"):
+			recover(state.SessionStatusSuccess)
+			updatePullRequestMaintenanceSnapshot(session, *pr)
+			session.LastMaintainedAt = nowText
+			session.LastMaintenanceError = ""
+			a.logger.Info("stale running session recovered to pr maintenance", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "reason", reason, "pr", pr.Number)
+			if commentOnRecovery {
+				body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+					Stage:      "Implementation In Progress",
+					Emoji:      "🔄",
+					Percent:    70,
+					ETAMinutes: 10,
+					Items: []string{
+						fmt.Sprintf("The previous local session on `%s` stalled (%s).", session.Branch, reason),
+						fmt.Sprintf("An existing PR #%d was found, so Vigilante recovered this issue into PR maintenance.", pr.Number),
+						"Next step: keep the PR merge-ready instead of redispatching a new implementation session.",
+					},
+					Tagline: "Fall seven times, stand up eight.",
+				})
+				if err := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "progress", "stalled_recovery"); err != nil {
+					session.LastError = err.Error()
+					session.UpdatedAt = a.clock().Format(time.RFC3339)
+					a.logger.Error("stalled session recovery comment failed", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "err", err)
+				}
+			}
+			return true, nil
+		case pr.MergedAt != nil:
+			recover(state.SessionStatusSuccess)
+			updatePullRequestMaintenanceSnapshot(session, *pr)
+			session.LastMaintainedAt = nowText
+			session.LastMaintenanceError = ""
+			a.logger.Info("stale running session reconciled to merged pull request", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "pr", pr.Number)
+			return true, nil
+		default:
+			recover(state.SessionStatusClosed)
+			updatePullRequestTrackingFromLookup(session, *pr)
+			session.MonitoringStoppedAt = nowText
+			session.LastMaintainedAt = nowText
+			session.LastMaintenanceError = ""
+			a.logger.Info("stale running session reconciled to closed pull request", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "pr", pr.Number, "state", pr.State)
+			return true, nil
+		}
+	}
+
+	if strings.EqualFold(strings.TrimSpace(issue.State), "closed") || ghcli.HasAnyLabel(issue.Labels, labelDone) {
+		recover(state.SessionStatusClosed)
+		session.MonitoringStoppedAt = nowText
+		session.LastMaintenanceError = ""
+		a.logger.Info("stale running session reconciled to closed issue", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "issue_state", issue.State)
+		return true, nil
+	}
+
+	return false, nil
+}
+
 func (a *App) emitSessionTransition(previous state.SessionStatus, session state.Session, source string) {
 	if previous == session.Status {
 		return
@@ -1112,7 +1213,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		sessions, err = a.recoverStalledSessions(ctx, sessions)
+		sessions, err = a.recoverStalledSessions(ctx, sessions, issueDetailsCache)
 		if err != nil {
 			return err
 		}
@@ -1322,7 +1423,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 	return nil
 }
 
-func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Session) ([]state.Session, error) {
+func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Session, issueCache scanIssueDetailsCache) ([]state.Session, error) {
 	threshold := stalledSessionThreshold()
 	restartDelay := defaultStaleAutoRestartDelay
 
@@ -1342,41 +1443,14 @@ func (a *App) recoverStalledSessions(ctx context.Context, sessions []state.Sessi
 			continue
 		}
 
-		pr, err := ghcli.FindPullRequestForBranch(ctx, a.env.Runner, session.Repo, session.Branch)
+		recovered, err := a.reconcileStaleRunningSession(ctx, session, issueCache, reason, true)
 		if err != nil {
-			a.recordSessionFailure(session, "issue_execution", "gh pr list", err)
-			a.logger.Error("stalled session pr lookup failed", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "err", err)
+			a.recordSessionFailure(session, "issue_execution", "github stale-session reconciliation", err)
+			a.logger.Error("stalled session github reconciliation failed", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "err", err)
 			continue
 		}
-		if pr != nil {
-			previousStatus := session.Status
-			session.Status = state.SessionStatusSuccess
-			session.ProcessID = 0
-			session.LastHeartbeatAt = ""
-			clearStaleAutoRestartPending(session)
-			updatePullRequestTrackingFromLookup(session, *pr)
-			session.LastError = ""
-			session.UpdatedAt = a.clock().Format(time.RFC3339)
-			a.emitSessionTransition(previousStatus, *session, "stalled_recovery")
-			a.logger.Info("stalled session recovered to pr maintenance", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "reason", reason, "pr", pr.Number)
-			body := ghcli.FormatProgressComment(ghcli.ProgressComment{
-				Stage:      "Implementation In Progress",
-				Emoji:      "🔄",
-				Percent:    70,
-				ETAMinutes: 10,
-				Items: []string{
-					fmt.Sprintf("The previous local session on `%s` stalled (%s).", session.Branch, reason),
-					fmt.Sprintf("An existing PR #%d was found, so Vigilante recovered this issue into PR maintenance.", pr.Number),
-					"Next step: keep the PR merge-ready instead of redispatching a new implementation session.",
-				},
-				Tagline: "Fall seven times, stand up eight.",
-			})
-			if err := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "progress", "stalled_recovery"); err != nil {
-				session.LastError = err.Error()
-				session.UpdatedAt = a.clock().Format(time.RFC3339)
-				a.logger.Error("stalled session recovery comment failed", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "err", err)
-			}
-			a.syncSessionIssueLabelsBestEffort(ctx, session, pr, nil, nil)
+		if recovered {
+			a.syncSessionIssueLabelsBestEffort(ctx, session, nil, nil, issueCache)
 			continue
 		}
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -6445,6 +6445,7 @@ func TestScanOnceMarksStaleSessionPendingAutoRestart(t *testing.T) {
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1": `{"title":"first","body":"Issue body","html_url":"https://github.com/owner/repo/issues/1","state":"open","labels":[]}`,
 			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": "[]",
 			"gh api user --jq .login": "nicobistolfi\n",
 			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]}]`,
@@ -6519,6 +6520,7 @@ func TestScanOnceAutoRestartsStaleSessionAfterDelay(t *testing.T) {
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: mergeStringMaps(freshBaseBranchOutputs(filepath.Join(home, "repo"), "main"), map[string]string{
+			"gh api repos/owner/repo/issues/1": `{"title":"first","body":"Issue body","html_url":"https://github.com/owner/repo/issues/1","state":"open","labels":[]}`,
 			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": "[]",
 			"git worktree prune":                                         "ok",
 			"git worktree list --porcelain":                              "worktree /tmp/repo\nHEAD abcdef\nbranch refs/heads/main\n",
@@ -6626,6 +6628,7 @@ func TestScanOnceStopsAutoRestartAfterAttemptLimit(t *testing.T) {
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1": `{"title":"first","body":"Issue body","html_url":"https://github.com/owner/repo/issues/1","state":"open","labels":[]}`,
 			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": "[]",
 			"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
 				Stage:      "Manual Intervention Required",
@@ -6712,6 +6715,7 @@ func TestScanOnceRecoversStalledSessionIntoPRMaintenance(t *testing.T) {
 	app.env.Runner = testutil.FakeRunner{
 		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
 		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1": `{"title":"first","body":"Issue body","html_url":"https://github.com/owner/repo/issues/1","state":"open","labels":[]}`,
 			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
 			"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
 				Stage:      "Implementation In Progress",
@@ -6775,6 +6779,140 @@ func TestScanOnceRecoversStalledSessionIntoPRMaintenance(t *testing.T) {
 	}
 	if sessions[0].PullRequestNumber != 31 || sessions[0].LastMaintainedAt == "" {
 		t.Fatalf("expected PR maintenance tracking after recovery: %#v", sessions[0])
+	}
+}
+
+func TestScanOnceReconcilesStaleRunningSessionAgainstClosedIssueAndMergedPullRequest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	var stdout bytes.Buffer
+	app := New()
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	now := time.Date(2026, 3, 26, 18, 0, 0, 0, time.UTC)
+	app.clock = func() time.Time { return now }
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1": `{"title":"first","body":"Issue body","html_url":"https://github.com/owner/repo/issues/1","state":"closed","labels":[{"name":"vigilante:done"}]}`,
+			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt":                                                                 `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"MERGED","mergedAt":"2026-03-26T17:30:00Z"}]`,
+			"gh pr view --repo owner/repo 31 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,baseRefName": `{"number":31,"title":"Test PR","body":"Body","url":"https://github.com/owner/repo/pull/31","state":"MERGED","mergedAt":"2026-03-26T17:30:00Z","labels":[],"isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[],"baseRefName":"main"}`,
+			"git worktree prune":                                         "ok",
+			"git worktree list --porcelain":                              "worktree /tmp/repo\nHEAD abcdef\nbranch refs/heads/main\n",
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": "ok",
+			"git branch -D vigilante/issue-1":                            "Deleted branch vigilante/issue-1\n",
+			"gh api user --jq .login":                                    "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:        "/tmp/repo",
+		Repo:            "owner/repo",
+		IssueNumber:     1,
+		IssueTitle:      "first",
+		IssueURL:        "https://github.com/owner/repo/issues/1",
+		Branch:          "vigilante/issue-1",
+		WorktreePath:    filepath.Join("/tmp/repo", ".worktrees", "vigilante", "issue-1"),
+		Status:          state.SessionStatusRunning,
+		ProcessID:       999999,
+		StartedAt:       now.Add(-2 * time.Hour).Format(time.RFC3339),
+		LastHeartbeatAt: now.Add(-2 * time.Hour).Format(time.RFC3339),
+		UpdatedAt:       now.Add(-2 * time.Hour).Format(time.RFC3339),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if sessions[0].Status != state.SessionStatusClosed {
+		t.Fatalf("expected closed session after reconciliation and cleanup: %#v", sessions[0])
+	}
+	if sessions[0].PullRequestState != "MERGED" || sessions[0].PullRequestMergedAt != "2026-03-26T17:30:00Z" {
+		t.Fatalf("expected merged pull request state to be tracked: %#v", sessions[0])
+	}
+	if sessions[0].CleanupCompletedAt == "" || sessions[0].LastCleanupSource != "issue_closed" {
+		t.Fatalf("expected closed-issue cleanup after recovery: %#v", sessions[0])
+	}
+}
+
+func TestScanOnceStopsMonitoringStaleRunningSessionWhenIssueIsUnavailable(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	now := time.Date(2026, 3, 26, 18, 0, 0, 0, time.UTC)
+	app.clock = func() time.Time { return now }
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"git worktree prune":                                         "ok",
+			"git worktree list --porcelain":                              "worktree /tmp/repo\nHEAD abcdef\nbranch refs/heads/main\n",
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": "ok",
+			"git branch -D vigilante/issue-1":                            "Deleted branch vigilante/issue-1\n",
+			"gh api user --jq .login":                                    "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+		},
+		Errors: map[string]error{
+			"gh api repos/owner/repo/issues/1": errors.New("HTTP 404: Not Found"),
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:        "/tmp/repo",
+		Repo:            "owner/repo",
+		IssueNumber:     1,
+		Branch:          "vigilante/issue-1",
+		WorktreePath:    filepath.Join("/tmp/repo", ".worktrees", "vigilante", "issue-1"),
+		Status:          state.SessionStatusRunning,
+		ProcessID:       999999,
+		StartedAt:       now.Add(-2 * time.Hour).Format(time.RFC3339),
+		LastHeartbeatAt: now.Add(-2 * time.Hour).Format(time.RFC3339),
+		UpdatedAt:       now.Add(-2 * time.Hour).Format(time.RFC3339),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if sessions[0].Status != state.SessionStatusClosed || sessions[0].MonitoringStoppedAt == "" {
+		t.Fatalf("expected monitoring to stop for unavailable issue: %#v", sessions[0])
+	}
+	if sessions[0].CleanupCompletedAt == "" {
+		t.Fatalf("expected cleanup for unavailable issue: %#v", sessions[0])
 	}
 }
 

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -349,6 +349,33 @@ func (a *App) statusExpanded(ctx context.Context) error {
 	if err != nil {
 		sessions = nil
 	}
+	cfg, cfgErr := a.state.LoadServiceConfig()
+	inactivityTimeout := state.DefaultBlockedSessionInactivityTimeout
+	if cfgErr == nil {
+		if parsed, parseErr := time.ParseDuration(cfg.BlockedSessionInactivityTimeout); parseErr == nil && parsed > 0 {
+			inactivityTimeout = parsed
+		}
+	}
+	issueCache := make(scanIssueDetailsCache)
+	sessionsChanged := false
+	for i := range sessions {
+		if sessions[i].Status != state.SessionStatusRunning || !isStale(sessions[i], a.clock(), time.Duration(staleBlockedMultiplier)*inactivityTimeout) {
+			continue
+		}
+		recovered, err := a.reconcileStaleRunningSession(ctx, &sessions[i], issueCache, "heartbeat exceeded stale threshold", false)
+		if err != nil {
+			a.logger.Error("status stale-session reconciliation failed", "repo", sessions[i].Repo, "issue", sessions[i].IssueNumber, "branch", sessions[i].Branch, "err", err)
+			continue
+		}
+		if recovered {
+			sessionsChanged = true
+		}
+	}
+	if sessionsChanged {
+		if err := a.state.SaveSessions(sessions); err != nil {
+			a.logger.Error("status session save failed after stale-session reconciliation", "err", err)
+		}
+	}
 
 	visibleSessions := visibleStatusSessions(sessions)
 
@@ -359,14 +386,6 @@ func (a *App) statusExpanded(ctx context.Context) error {
 	fmt.Fprintf(a.stdout, "Sessions: %d total\n", len(visibleSessions))
 
 	if len(visibleSessions) > 0 {
-		cfg, cfgErr := a.state.LoadServiceConfig()
-		inactivityTimeout := state.DefaultBlockedSessionInactivityTimeout
-		if cfgErr == nil {
-			if parsed, parseErr := time.ParseDuration(cfg.BlockedSessionInactivityTimeout); parseErr == nil && parsed > 0 {
-				inactivityTimeout = parsed
-			}
-		}
-
 		groups := groupSessions(visibleSessions, a.clock(), inactivityTimeout)
 		if len(groups) > 0 {
 			fmt.Fprintln(a.stdout)

--- a/internal/app/status_test.go
+++ b/internal/app/status_test.go
@@ -815,6 +815,139 @@ func TestStatusCommandExcludesClosedSessionsFromCountsAndGroups(t *testing.T) {
 	}
 }
 
+func TestStatusCommandReconcilesStaleRunningSessionAgainstOpenPullRequest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "vigilante.service")
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unitPath, []byte("unit"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	vigilanteHome := filepath.Join(home, ".vigilante")
+	if err := os.MkdirAll(vigilanteHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 3, 26, 19, 0, 0, 0, time.UTC)
+	sessions := []state.Session{
+		{
+			Repo:            "owner/repo",
+			IssueNumber:     99,
+			IssueTitle:      "stale",
+			IssueURL:        "https://github.com/owner/repo/issues/99",
+			Branch:          "vigilante/issue-99",
+			Status:          state.SessionStatusRunning,
+			StartedAt:       now.Add(-2 * time.Hour).Format(time.RFC3339),
+			LastHeartbeatAt: now.Add(-2 * time.Hour).Format(time.RFC3339),
+			UpdatedAt:       now.Add(-2 * time.Hour).Format(time.RFC3339),
+		},
+	}
+	sessionData, _ := json.Marshal(sessions)
+	if err := os.WriteFile(filepath.Join(vigilanteHome, "sessions.json"), sessionData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.clock = func() time.Time { return now }
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.OS = "linux"
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"systemctl --user show --property=LoadState,ActiveState vigilante.service":                            "LoadState=loaded\nActiveState=active\n",
+			"gh api repos/owner/repo/issues/99":                                                                   `{"title":"stale","body":"body","html_url":"https://github.com/owner/repo/issues/99","state":"closed","labels":[{"name":"vigilante:done"}]}`,
+			"gh pr list --repo owner/repo --head vigilante/issue-99 --state all --json number,url,state,mergedAt": `[{"number":123,"url":"https://github.com/owner/repo/pull/123","state":"OPEN","mergedAt":null}]`,
+			"gh pr view --repo owner/repo 123 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,baseRefName": `{"number":123,"title":"Test PR","body":"Body","url":"https://github.com/owner/repo/pull/123","state":"OPEN","mergedAt":null,"labels":[],"isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[],"baseRefName":"main"}`,
+		},
+	}
+
+	exitCode := app.Run(context.Background(), []string{"status"})
+	if exitCode != 0 {
+		t.Fatalf("expected success, got %d", exitCode)
+	}
+	output := stdout.String()
+	if strings.Contains(output, "Stale sessions (1)") {
+		t.Fatalf("expected stale section to disappear after reconciliation, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Completed / failed (1)") {
+		t.Fatalf("expected reconciled session to move out of stale running, got:\n%s", output)
+	}
+
+	loaded, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded[0].Status != state.SessionStatusSuccess || loaded[0].PullRequestNumber != 123 {
+		t.Fatalf("expected reconciled success session with tracked PR: %#v", loaded[0])
+	}
+}
+
+func TestStatusCommandLeavesStaleRunningSessionWhenGitHubReconciliationFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	unitPath := filepath.Join(home, ".config", "systemd", "user", "vigilante.service")
+	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unitPath, []byte("unit"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	vigilanteHome := filepath.Join(home, ".vigilante")
+	if err := os.MkdirAll(vigilanteHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 3, 26, 19, 0, 0, 0, time.UTC)
+	sessions := []state.Session{
+		{Repo: "owner/repo", IssueNumber: 99, Branch: "vigilante/issue-99", Status: state.SessionStatusRunning, StartedAt: now.Add(-2 * time.Hour).Format(time.RFC3339), LastHeartbeatAt: now.Add(-2 * time.Hour).Format(time.RFC3339)},
+	}
+	sessionData, _ := json.Marshal(sessions)
+	if err := os.WriteFile(filepath.Join(vigilanteHome, "sessions.json"), sessionData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.clock = func() time.Time { return now }
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.OS = "linux"
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"systemctl --user show --property=LoadState,ActiveState vigilante.service": "LoadState=loaded\nActiveState=active\n",
+		},
+		Errors: map[string]error{
+			"gh api repos/owner/repo/issues/99": errors.New("gh unavailable"),
+		},
+	}
+
+	exitCode := app.Run(context.Background(), []string{"status"})
+	if exitCode != 0 {
+		t.Fatalf("expected success, got %d", exitCode)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "Stale sessions (1)") {
+		t.Fatalf("expected stale section when github reconciliation fails, got:\n%s", output)
+	}
+
+	loaded, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded[0].Status != state.SessionStatusRunning {
+		t.Fatalf("expected session to remain running after reconciliation failure: %#v", loaded[0])
+	}
+}
+
 func TestWriteStatusRefreshFrameClearsBeforeRendering(t *testing.T) {
 	var buf bytes.Buffer
 	if err := writeStatusRefreshFrame(&buf, func() error {


### PR DESCRIPTION
## Summary
- reconcile stale local `running` sessions against live GitHub issue and PR state before keeping them in `running`
- reuse the reconciliation in both daemon stale-session recovery and `vigilante status`, persisting recovered session state
- add regression coverage for open PR recovery, closed issue plus merged PR, issue unavailable, and GitHub lookup failure

## Validation
- `go test ./internal/app/...`
- `go test ./...`

Closes #322
