### PR TITLE
Improve access log context and diagnostics

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -159,6 +159,7 @@ func New() *App {
 }
 
 func (a *App) loadIssueDetailsForScan(ctx context.Context, cache scanIssueDetailsCache, repo string, issueNumber int) (*ghcli.IssueDetails, error) {
+	ctx = a.withIssueAccessLogContext(ctx, "", repo, issueNumber, "", "")
 	if cache != nil {
 		if details, ok := cache[sessionKey(repo, issueNumber)]; ok {
 			return details, nil
@@ -347,11 +348,59 @@ func (a *App) emitGitHubRateLimitEvent(state string, snapshot ghcli.RateLimitSna
 }
 
 func (a *App) commentOnIssue(ctx context.Context, repo string, issue int, body string, commentType string, source string) error {
+	ctx = a.withIssueAccessLogContext(ctx, "", repo, issue, "", "")
 	if err := ghcli.CommentOnIssue(ctx, a.env.Runner, repo, issue, body); err != nil {
 		return err
 	}
 	a.emitCommentEvent(commentType, source)
 	return nil
+}
+
+func (a *App) withIssueAccessLogContext(ctx context.Context, executionContext string, repo string, issue int, branch string, worktreePath string) context.Context {
+	return environment.WithAccessLogContext(ctx, environment.AccessLogContext{
+		ExecutionContext: executionContext,
+		Repo:             strings.TrimSpace(repo),
+		IssueNumber:      issue,
+		Branch:           strings.TrimSpace(branch),
+		WorktreePath:     strings.TrimSpace(worktreePath),
+		CorrelationID:    accessLogCorrelationID(executionContext, repo, issue),
+	})
+}
+
+func (a *App) withWatchTargetAccessLogContext(ctx context.Context, executionContext string, target state.WatchTarget) context.Context {
+	return environment.WithAccessLogContext(ctx, environment.AccessLogContext{
+		ExecutionContext: executionContext,
+		Repo:             strings.TrimSpace(target.Repo),
+		Branch:           strings.TrimSpace(target.Branch),
+		CorrelationID:    accessLogCorrelationID(executionContext, target.Repo, 0),
+	})
+}
+
+func withSessionAccessLogContext(ctx context.Context, executionContext string, session state.Session) context.Context {
+	return environment.WithAccessLogContext(ctx, environment.AccessLogContext{
+		ExecutionContext: executionContext,
+		Repo:             strings.TrimSpace(session.Repo),
+		IssueNumber:      session.IssueNumber,
+		Branch:           strings.TrimSpace(session.Branch),
+		WorktreePath:     strings.TrimSpace(session.WorktreePath),
+		CorrelationID:    accessLogCorrelationID(executionContext, session.Repo, session.IssueNumber),
+	})
+}
+
+func accessLogCorrelationID(executionContext string, repo string, issue int) string {
+	executionContext = strings.TrimSpace(executionContext)
+	repo = strings.TrimSpace(repo)
+	if executionContext == "" {
+		return ""
+	}
+	switch {
+	case repo == "" && issue <= 0:
+		return executionContext
+	case issue > 0:
+		return fmt.Sprintf("%s:%s#%d", executionContext, repo, issue)
+	default:
+		return fmt.Sprintf("%s:%s", executionContext, repo)
+	}
 }
 
 func (a *App) Run(ctx context.Context, args []string) int {
@@ -1186,6 +1235,10 @@ func daemonMode(once bool) string {
 }
 
 func (a *App) ScanOnce(ctx context.Context) error {
+	ctx = environment.WithAccessLogContext(ctx, environment.AccessLogContext{
+		ExecutionContext: "scan",
+		CorrelationID:    accessLogCorrelationID("scan", "all", 0),
+	})
 	a.logger.Info("scan start")
 	locked, err := a.state.TryWithScanLock(func() error {
 		if err := a.state.EnsureLayout(); err != nil {
@@ -1251,6 +1304,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 
 		for i := range targets {
 			target := &targets[i]
+			targetCtx := a.withWatchTargetAccessLogContext(ctx, "scan", *target)
 			target.Assignee = assigneeOrDefault(target.Assignee)
 			if strings.TrimSpace(target.Provider) == "" {
 				target.Provider = provider.DefaultID
@@ -1258,7 +1312,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 			target.MaxParallel = configuredMaxParallel(target.MaxParallel)
 			target.Classification = repo.Classify(target.Path)
 			if target.EffectiveBranchMode() == state.BranchModeAuto {
-				resolvedBranch, err := repo.ResolveBranch(ctx, a.env.Runner, target.Path, string(target.EffectiveBranchMode()), target.Branch)
+				resolvedBranch, err := repo.ResolveBranch(targetCtx, a.env.Runner, target.Path, string(target.EffectiveBranchMode()), target.Branch)
 				if err != nil {
 					return err
 				}
@@ -1268,7 +1322,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 				}
 			}
 			var started int
-			sessions, started, err = a.processGitHubIterationRequestsForTarget(ctx, *target, sessions, issueDetailsCache)
+			sessions, started, err = a.processGitHubIterationRequestsForTarget(targetCtx, *target, sessions, issueDetailsCache)
 			if err != nil {
 				return err
 			}
@@ -1277,7 +1331,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 			a.logger.Info("scan repo start", "repo", target.Repo, "path", target.Path, "max_parallel", target.MaxParallel)
 			resolvedAssignee, ok := resolvedAssignees[target.Assignee]
 			if !ok {
-				resolvedAssignee, err = ghcli.ResolveAssignee(ctx, a.env.Runner, target.Assignee)
+				resolvedAssignee, err = ghcli.ResolveAssignee(targetCtx, a.env.Runner, target.Assignee)
 				if err == nil {
 					resolvedAssignees[target.Assignee] = resolvedAssignee
 				}
@@ -1288,7 +1342,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 				fmt.Fprintf(a.stdout, "repo: %s scan failed: %s\n", target.Repo, summarizeText(err.Error()))
 				continue
 			}
-			issues, err := ghcli.ListOpenIssuesForAssignee(ctx, a.env.Runner, target.Repo, resolvedAssignee)
+			issues, err := ghcli.ListOpenIssuesForAssignee(targetCtx, a.env.Runner, target.Repo, resolvedAssignee)
 			target.LastScanAt = a.clock().Format(time.RFC3339)
 			if err != nil {
 				a.logger.Error("scan repo issues failed", "repo", target.Repo, "err", err)
@@ -1328,7 +1382,8 @@ func (a *App) ScanOnce(ctx context.Context) error {
 					a.logger.Info("scan repo issue provider override", "repo", target.Repo, "issue", next.Number, "provider", selectedProvider)
 				}
 				a.logger.Info("scan repo issue skill", "repo", target.Repo, "issue", next.Number, "skill", skill.IssueImplementationSkill(*target), "shape", target.Classification.Shape)
-				resolvedBranch, err := repo.ResolveBranch(ctx, a.env.Runner, target.Path, string(target.EffectiveBranchMode()), target.Branch)
+				issueCtx := a.withIssueAccessLogContext(targetCtx, "scan", target.Repo, next.Number, target.Branch, "")
+				resolvedBranch, err := repo.ResolveBranch(issueCtx, a.env.Runner, target.Path, string(target.EffectiveBranchMode()), target.Branch)
 				if err != nil {
 					session := blockedIssueSessionForDispatchFailure(*target, next, selectedProvider, err, a.clock())
 					previous, _ := findSession(sessions, target.Repo, next.Number)
@@ -1345,7 +1400,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 				}
 				target.Branch = resolvedBranch
 
-				wt, err := worktree.CreateIssueWorktree(ctx, a.env.Runner, *target, next.Number, next.Title)
+				wt, err := worktree.CreateIssueWorktree(issueCtx, a.env.Runner, *target, next.Number, next.Title)
 				if err != nil {
 					session := blockedIssueSessionForDispatchFailure(*target, next, selectedProvider, err, a.clock())
 					previous, _ := findSession(sessions, target.Repo, next.Number)
@@ -1364,9 +1419,9 @@ func (a *App) ScanOnce(ctx context.Context) error {
 
 				diffSummary := ""
 				if strings.TrimSpace(wt.ReusedRemoteBranch) != "" {
-					diffSummary, err = summarizeIssueBranchDiff(ctx, a.env.Runner, target.Path, target.Branch, wt.Branch)
+					diffSummary, err = summarizeIssueBranchDiff(issueCtx, a.env.Runner, target.Path, target.Branch, wt.Branch)
 					if err != nil {
-						_ = worktree.CleanupIssueArtifacts(ctx, a.env.Runner, target.Path, wt.Path, wt.Branch)
+						_ = worktree.CleanupIssueArtifacts(issueCtx, a.env.Runner, target.Path, wt.Path, wt.Branch)
 						session := blockedIssueSessionForDispatchFailure(*target, next, selectedProvider, fmt.Errorf("analyze reused remote issue branch %q against %q: %w", wt.Branch, target.Branch, err), a.clock())
 						session.Branch = wt.Branch
 						session.BaseBranch = target.Branch
@@ -1719,6 +1774,7 @@ func sessionAffectedByGitHubRateLimitPause(session state.Session) bool {
 func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session, issueCache scanIssueDetailsCache) ([]state.Session, error) {
 	for i := range sessions {
 		session := &sessions[i]
+		sessionCtx := withSessionAccessLogContext(ctx, "maintenance", *session)
 		if session.Status != state.SessionStatusSuccess || session.CleanupCompletedAt != "" || session.MonitoringStoppedAt != "" {
 			continue
 		}
@@ -1726,7 +1782,7 @@ func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session
 			continue
 		}
 
-		pr, err := ghcli.FindPullRequestForBranch(ctx, a.env.Runner, session.Repo, session.Branch)
+		pr, err := ghcli.FindPullRequestForBranch(sessionCtx, a.env.Runner, session.Repo, session.Branch)
 		if err != nil {
 			session.LastMaintenanceError = err.Error()
 			session.UpdatedAt = a.clock().Format(time.RFC3339)
@@ -1740,7 +1796,7 @@ func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session
 		updatePullRequestTrackingFromLookup(session, *pr)
 		if pr.MergedAt == nil {
 			if pr.State != "OPEN" {
-				if err := a.cleanupSessionArtifacts(ctx, session, "pull_request_closed"); err != nil {
+				if err := a.cleanupSessionArtifacts(sessionCtx, session, "pull_request_closed"); err != nil {
 					a.logger.Error("cleanup failed", "repo", session.Repo, "issue", session.IssueNumber, "pr", pr.Number, "branch", session.Branch, "worktree", session.WorktreePath, "state", pr.State, "err", err)
 					continue
 				}
@@ -1748,7 +1804,7 @@ func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session
 				a.syncSessionIssueLabelsBestEffort(ctx, session, pr, nil, issueCache)
 				continue
 			}
-			detailedPR, issueDetails, err := a.maintainOpenPullRequest(ctx, session, *pr, issueCache)
+			detailedPR, issueDetails, err := a.maintainOpenPullRequest(sessionCtx, session, *pr, issueCache)
 			if err != nil {
 				session.UpdatedAt = a.clock().Format(time.RFC3339)
 				a.logger.Error("pr maintenance failed", "repo", session.Repo, "issue", session.IssueNumber, "pr", pr.Number, "branch", session.Branch, "err", err)
@@ -1769,7 +1825,7 @@ func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session
 						},
 						Tagline: "Difficulties strengthen the mind, as labor does the body.",
 					})
-					if commentErr := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "blocked", "pr_maintenance"); commentErr != nil {
+					if commentErr := a.commentOnIssue(sessionCtx, session.Repo, session.IssueNumber, body, "blocked", "pr_maintenance"); commentErr != nil {
 						a.logger.Error("pr maintenance failure comment failed", "repo", session.Repo, "issue", session.IssueNumber, "pr", pr.Number, "err", commentErr)
 					}
 					session.LastMaintenanceError = err.Error()
@@ -1782,7 +1838,7 @@ func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session
 		}
 
 		session.PullRequestMergedAt = pr.MergedAt.UTC().Format(time.RFC3339)
-		if err := a.cleanupSessionArtifacts(ctx, session, "pull_request_merged"); err != nil {
+		if err := a.cleanupSessionArtifacts(sessionCtx, session, "pull_request_merged"); err != nil {
 			a.logger.Error("cleanup failed", "repo", session.Repo, "issue", session.IssueNumber, "pr", session.PullRequestNumber, "branch", session.Branch, "worktree", session.WorktreePath, "merged_at", session.PullRequestMergedAt, "err", err)
 			continue
 		}
@@ -1797,6 +1853,7 @@ func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session
 func (a *App) cleanupClosedIssueSessions(ctx context.Context, sessions []state.Session, issueCache scanIssueDetailsCache) ([]state.Session, error) {
 	for i := range sessions {
 		session := &sessions[i]
+		sessionCtx := withSessionAccessLogContext(ctx, "maintenance", *session)
 		if session.Status != state.SessionStatusSuccess || session.CleanupCompletedAt != "" || session.MonitoringStoppedAt != "" {
 			continue
 		}
@@ -1804,10 +1861,10 @@ func (a *App) cleanupClosedIssueSessions(ctx context.Context, sessions []state.S
 			continue
 		}
 
-		issue, err := a.loadIssueDetailsForScan(ctx, issueCache, session.Repo, session.IssueNumber)
+		issue, err := a.loadIssueDetailsForScan(sessionCtx, issueCache, session.Repo, session.IssueNumber)
 		if err != nil {
 			if ghcli.IsIssueUnavailableError(err) {
-				a.stopMonitoringUnavailableIssueSession(ctx, session, "issue_deleted", err)
+				a.stopMonitoringUnavailableIssueSession(sessionCtx, session, "issue_deleted", err)
 				continue
 			}
 			session.LastMaintenanceError = err.Error()
@@ -1819,7 +1876,7 @@ func (a *App) cleanupClosedIssueSessions(ctx context.Context, sessions []state.S
 			continue
 		}
 
-		if err := a.cleanupSessionArtifacts(ctx, session, "issue_closed"); err != nil {
+		if err := a.cleanupSessionArtifacts(sessionCtx, session, "issue_closed"); err != nil {
 			a.logger.Error("cleanup failed", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "worktree", session.WorktreePath, "err", err)
 			continue
 		}
@@ -1834,6 +1891,7 @@ func (a *App) cleanupClosedIssueSessions(ctx context.Context, sessions []state.S
 }
 
 func (a *App) cleanupSessionArtifacts(ctx context.Context, session *state.Session, source string) error {
+	ctx = withSessionAccessLogContext(ctx, "maintenance", *session)
 	now := a.clock().Format(time.RFC3339)
 	session.LastCleanupSource = source
 	if err := worktree.CleanupIssueArtifacts(ctx, a.env.Runner, session.RepoPath, session.WorktreePath, session.Branch); err != nil {
@@ -1902,6 +1960,7 @@ func (a *App) waitForSessions() {
 }
 
 func (a *App) maintainOpenPullRequest(ctx context.Context, session *state.Session, pr ghcli.PullRequest, issueCache scanIssueDetailsCache) (*ghcli.PullRequest, *ghcli.IssueDetails, error) {
+	ctx = withSessionAccessLogContext(ctx, "maintenance", *session)
 	previousMaintenanceError := session.LastMaintenanceError
 	session.LastMaintenanceError = ""
 	fallbackTarget := a.fallbackWatchTargetForSession(*session)
@@ -3165,6 +3224,7 @@ func (a *App) resumeBlockedSession(ctx context.Context, session *state.Session, 
 }
 
 func (a *App) preflightResume(ctx context.Context, session state.Session) error {
+	ctx = withSessionAccessLogContext(ctx, "maintenance", session)
 	selectedProvider, err := provider.Resolve(session.Provider)
 	if err != nil {
 		return err
@@ -3199,6 +3259,7 @@ func (a *App) preflightResume(ctx context.Context, session state.Session) error 
 }
 
 func (a *App) resumeBlockedMaintenance(ctx context.Context, session *state.Session) error {
+	ctx = withSessionAccessLogContext(ctx, "maintenance", *session)
 	pr, err := ghcli.FindPullRequestForBranch(ctx, a.env.Runner, session.Repo, session.Branch)
 	if err != nil {
 		return err

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -50,6 +50,72 @@ func (r *countingRunner) LookPath(file string) (string, error) {
 	return r.base.LookPath(file)
 }
 
+func TestMaintainOpenPullRequestPropagatesAccessLogContext(t *testing.T) {
+	t.Setenv("VIGILANTE_HOME", t.TempDir())
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	var entries []environment.AccessLogEntry
+	runner := environment.LoggingRunner{
+		Base: testutil.FakeRunner{
+			Outputs: map[string]string{
+				"git fetch origin main":  "ok\n",
+				"git status --porcelain": "",
+				"gh pr view --repo owner/repo 12 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,baseRefName": `{"number":12,"title":"PR","body":"","url":"https://example.test/pr/12","state":"OPEN","mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"","statusCheckRollup":[],"baseRefName":"main"}`,
+				"git rebase origin/main":           "Current branch is up to date.\n",
+				"gh api repos/owner/repo/issues/7": `{"title":"Issue","body":"Body","html_url":"https://example.test/issues/7","state":"open","labels":[],"assignees":[]}`,
+			},
+		},
+		AccessLog: func(entry environment.AccessLogEntry) {
+			entries = append(entries, entry)
+		},
+	}
+	app := &App{
+		stdout: testutil.IODiscard{},
+		stderr: testutil.IODiscard{},
+		clock:  func() time.Time { return time.Date(2026, 3, 26, 20, 0, 0, 0, time.UTC) },
+		state:  store,
+		env: &environment.Environment{
+			OS:     "linux",
+			Runner: runner,
+		},
+	}
+	session := &state.Session{
+		Repo:         "owner/repo",
+		IssueNumber:  7,
+		Branch:       "vigilante/issue-7",
+		WorktreePath: "/tmp/worktree",
+	}
+	pr := ghcli.PullRequest{
+		Number:      12,
+		State:       "OPEN",
+		BaseRefName: "main",
+		Mergeable:   "MERGEABLE",
+	}
+
+	if _, _, err := app.maintainOpenPullRequest(context.Background(), session, pr, nil); err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected access log entries")
+	}
+	for _, entry := range entries {
+		if got, want := entry.ExecutionContext, "maintenance"; got != want {
+			t.Fatalf("context = %q, want %q", got, want)
+		}
+		if got, want := entry.Repo, "owner/repo"; got != want {
+			t.Fatalf("repo = %q, want %q", got, want)
+		}
+		if got, want := entry.IssueNumber, 7; got != want {
+			t.Fatalf("issue = %d, want %d", got, want)
+		}
+		if got, want := entry.CorrelationID, "maintenance:owner/repo#7"; got != want {
+			t.Fatalf("correlation_id = %q, want %q", got, want)
+		}
+	}
+}
+
 func setupTelemetryCapture(t *testing.T) (*analyticsBatchCapture, func() error) {
 	t.Helper()
 

--- a/internal/environment/accesslog.go
+++ b/internal/environment/accesslog.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"os/exec"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -14,6 +16,7 @@ type AccessLogContext struct {
 	IssueNumber      int    `json:"issue_number,omitempty"`
 	Branch           string `json:"branch,omitempty"`
 	WorktreePath     string `json:"worktree_path,omitempty"`
+	CorrelationID    string `json:"correlation_id,omitempty"`
 }
 
 type AccessLogEntry struct {
@@ -24,15 +27,21 @@ type AccessLogEntry struct {
 	IssueNumber      int      `json:"issue_number,omitempty"`
 	Branch           string   `json:"branch,omitempty"`
 	WorktreePath     string   `json:"worktree_path,omitempty"`
+	CorrelationID    string   `json:"correlation_id,omitempty"`
 	Dir              string   `json:"dir,omitempty"`
 	Tool             string   `json:"tool"`
+	ToolPath         string   `json:"tool_path,omitempty"`
 	Argv             []string `json:"argv"`
 	ExitCode         int      `json:"exit_code"`
 	DurationMs       int64    `json:"duration_ms"`
 	Success          bool     `json:"success"`
+	FailureKind      string   `json:"failure_kind,omitempty"`
+	Error            string   `json:"error,omitempty"`
 }
 
 type accessLogContextKey struct{}
+
+var shellWrappedToolPattern = regexp.MustCompile(`(?:^|\s)(?:command -v\s+)?'([^']+)'`)
 
 func WithAccessLogContext(ctx context.Context, meta AccessLogContext) context.Context {
 	if ctx == nil {
@@ -54,10 +63,13 @@ func WithAccessLogContext(ctx context.Context, meta AccessLogContext) context.Co
 	if strings.TrimSpace(meta.WorktreePath) != "" {
 		current.WorktreePath = strings.TrimSpace(meta.WorktreePath)
 	}
+	if strings.TrimSpace(meta.CorrelationID) != "" {
+		current.CorrelationID = strings.TrimSpace(meta.CorrelationID)
+	}
 	return context.WithValue(ctx, accessLogContextKey{}, current)
 }
 
-func buildAccessLogEntry(ctx context.Context, dir string, name string, args []string, startedAt time.Time, endedAt time.Time, err error) AccessLogEntry {
+func buildAccessLogEntry(ctx context.Context, dir string, name string, args []string, startedAt time.Time, endedAt time.Time, output string, err error) AccessLogEntry {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -66,6 +78,12 @@ func buildAccessLogEntry(ctx context.Context, dir string, name string, args []st
 	if executionContext == "" {
 		executionContext = "daemon"
 	}
+	if executionContext == "daemon" && isHealthcheckCommand(name, args) {
+		executionContext = "healthcheck"
+	}
+	toolPath := strings.TrimSpace(name)
+	tool := normalizeAccessLogTool(name, args)
+	failureKind, failureDetail := accessLogFailureDetails(output, err)
 	return AccessLogEntry{
 		Timestamp:        startedAt.UTC().Format(time.RFC3339Nano),
 		CompletedAt:      endedAt.UTC().Format(time.RFC3339Nano),
@@ -74,12 +92,16 @@ func buildAccessLogEntry(ctx context.Context, dir string, name string, args []st
 		IssueNumber:      meta.IssueNumber,
 		Branch:           strings.TrimSpace(meta.Branch),
 		WorktreePath:     strings.TrimSpace(meta.WorktreePath),
+		CorrelationID:    strings.TrimSpace(meta.CorrelationID),
 		Dir:              strings.TrimSpace(dir),
-		Tool:             strings.TrimSpace(name),
+		Tool:             tool,
+		ToolPath:         toolPath,
 		Argv:             sanitizeAccessLogArgs(args),
 		ExitCode:         exitCodeForError(err),
 		DurationMs:       endedAt.Sub(startedAt).Milliseconds(),
 		Success:          err == nil,
+		FailureKind:      failureKind,
+		Error:            failureDetail,
 	}
 }
 
@@ -128,6 +150,126 @@ func sanitizeAccessLogArgs(args []string) []string {
 		}
 	}
 	return sanitized
+}
+
+func sanitizeAccessLogText(text string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	for _, token := range []string{"ghp_", "github_pat_"} {
+		if index := strings.Index(strings.ToLower(text), strings.ToLower(token)); index >= 0 {
+			end := index + len(token)
+			for end < len(text) {
+				ch := text[end]
+				if (ch < 'a' || ch > 'z') && (ch < 'A' || ch > 'Z') && (ch < '0' || ch > '9') && ch != '_' && ch != '-' {
+					break
+				}
+				end++
+			}
+			text = text[:index] + "<redacted>" + text[end:]
+		}
+	}
+	lower := strings.ToLower(text)
+	for _, prefix := range []string{"authorization:", "bearer ", "token "} {
+		searchStart := 0
+		for searchStart < len(lower) {
+			index := strings.Index(lower[searchStart:], prefix)
+			if index < 0 {
+				break
+			}
+			index += searchStart
+			end := index + len(prefix)
+			for end < len(text) && text[end] != '\n' && text[end] != '\r' && text[end] != '"' && text[end] != '\'' && text[end] != ' ' {
+				end++
+			}
+			text = text[:index] + "<redacted>" + text[end:]
+			lower = strings.ToLower(text)
+			searchStart = index + len("<redacted>")
+		}
+	}
+	return text
+}
+
+func accessLogFailureDetails(output string, err error) (string, string) {
+	if err == nil {
+		return "", ""
+	}
+	kind := "runtime_error"
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		kind = "timeout"
+	case errors.Is(err, context.Canceled):
+		kind = "canceled"
+	default:
+		var exitErr *exec.ExitError
+		switch {
+		case errors.As(err, &exitErr):
+			kind = "exit_error"
+		case strings.Contains(strings.ToLower(err.Error()), "executable file not found") || strings.Contains(strings.ToLower(err.Error()), "no such file or directory"):
+			kind = "not_found"
+		}
+	}
+	detail := sanitizeAccessLogText(strings.TrimSpace(output))
+	if detail == "" {
+		detail = sanitizeAccessLogText(strings.TrimSpace(err.Error()))
+	}
+	if len(detail) > 240 {
+		detail = detail[:240] + "...(truncated)"
+	}
+	return kind, detail
+}
+
+func normalizeAccessLogTool(name string, args []string) string {
+	base := strings.TrimSpace(filepath.Base(strings.TrimSpace(name)))
+	if base == "." || base == string(filepath.Separator) {
+		base = strings.TrimSpace(name)
+	}
+	if base == "sh" || base == "bash" || base == "zsh" {
+		if wrapped := shellWrappedTool(args); wrapped != "" {
+			return wrapped
+		}
+	}
+	if base == "" {
+		return strings.TrimSpace(name)
+	}
+	return base
+}
+
+func shellWrappedTool(args []string) string {
+	if len(args) < 2 {
+		return ""
+	}
+	if args[0] != "-lc" && args[0] != "-lic" {
+		return ""
+	}
+	matches := shellWrappedToolPattern.FindStringSubmatch(args[1])
+	if len(matches) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(filepath.Base(matches[1]))
+}
+
+func isHealthcheckCommand(name string, args []string) bool {
+	tool := normalizeAccessLogTool(name, args)
+	rawTool := strings.TrimSpace(filepath.Base(strings.TrimSpace(name)))
+	if len(args) == 1 && args[0] == "--version" {
+		return true
+	}
+	if len(args) >= 2 && tool == "launchctl" && args[0] == "print" {
+		return true
+	}
+	if len(args) >= 3 && tool == "systemctl" && args[0] == "--user" && args[1] == "show" {
+		return true
+	}
+	if len(args) >= 2 && tool == "gh" && args[0] == "auth" && args[1] == "status" {
+		return true
+	}
+	if len(args) >= 3 && (rawTool == "sh" || rawTool == "bash" || rawTool == "zsh") && (args[0] == "-lc" || args[0] == "-lic") {
+		command := strings.TrimSpace(args[1])
+		return strings.Contains(command, "command -v ") || strings.Contains(command, " --version")
+	}
+	return false
 }
 
 func isHeaderFlag(arg string) bool {

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -62,7 +62,7 @@ func (r LoggingRunner) Run(ctx context.Context, dir string, name string, args ..
 		r.CaptureCommand(ctx, name, args, exitCode, endedAt.Sub(startedAt).Milliseconds())
 	}
 	if r.AccessLog != nil {
-		r.AccessLog(buildAccessLogEntry(ctx, dir, name, args, startedAt, endedAt, err))
+		r.AccessLog(buildAccessLogEntry(ctx, dir, name, args, startedAt, endedAt, output, err))
 	}
 	if r.Logger != nil {
 		if err != nil {

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -171,6 +171,9 @@ func TestLoggingRunnerAccessLogDefaultsToDaemonContext(t *testing.T) {
 	if got, want := entries[0].ExecutionContext, "daemon"; got != want {
 		t.Fatalf("context = %q, want %q", got, want)
 	}
+	if got, want := entries[0].Tool, "gh"; got != want {
+		t.Fatalf("tool = %q, want %q", got, want)
+	}
 	if got := strings.Join(entries[0].Argv, " "); strings.Contains(got, "super-secret") {
 		t.Fatalf("expected sanitized argv, got %q", got)
 	}
@@ -197,6 +200,7 @@ func TestLoggingRunnerAccessLogIncludesSessionContext(t *testing.T) {
 		IssueNumber:      7,
 		Branch:           "vigilante/issue-7",
 		WorktreePath:     "/tmp/worktree",
+		CorrelationID:    "session:owner/repo#7",
 	})
 
 	if _, err := runner.Run(ctx, "/tmp/worktree", "git", "status", "--short"); err != nil {
@@ -213,6 +217,72 @@ func TestLoggingRunnerAccessLogIncludesSessionContext(t *testing.T) {
 	}
 	if got, want := entries[0].IssueNumber, 7; got != want {
 		t.Fatalf("issue = %d, want %d", got, want)
+	}
+	if got, want := entries[0].CorrelationID, "session:owner/repo#7"; got != want {
+		t.Fatalf("correlation_id = %q, want %q", got, want)
+	}
+}
+
+func TestLoggingRunnerAccessLogNormalizesToolNamesAndClassifiesHealthchecks(t *testing.T) {
+	var entries []AccessLogEntry
+	runner := LoggingRunner{
+		Base: testutil.FakeRunner{
+			Outputs: map[string]string{
+				"/home/test/.local/bin/vigilante --version": "vigilante 1.2.3\n",
+			},
+		},
+		AccessLog: func(entry AccessLogEntry) {
+			entries = append(entries, entry)
+		},
+	}
+
+	if _, err := runner.Run(context.Background(), "", "/home/test/.local/bin/vigilante", "--version"); err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 access log entry, got %d", len(entries))
+	}
+	if got, want := entries[0].ExecutionContext, "healthcheck"; got != want {
+		t.Fatalf("context = %q, want %q", got, want)
+	}
+	if got, want := entries[0].Tool, "vigilante"; got != want {
+		t.Fatalf("tool = %q, want %q", got, want)
+	}
+	if got, want := entries[0].ToolPath, "/home/test/.local/bin/vigilante"; got != want {
+		t.Fatalf("tool_path = %q, want %q", got, want)
+	}
+}
+
+func TestLoggingRunnerAccessLogCapturesSanitizedFailureDiagnostics(t *testing.T) {
+	var entries []AccessLogEntry
+	runner := LoggingRunner{
+		Base: testutil.FakeRunner{
+			ErrorOutputs: map[string]string{
+				"gh api /user": "Authorization: Bearer super-secret\n",
+			},
+			Errors: map[string]error{
+				"gh api /user": fmt.Errorf("gh api failed"),
+			},
+		},
+		AccessLog: func(entry AccessLogEntry) {
+			entries = append(entries, entry)
+		},
+	}
+
+	if _, err := runner.Run(context.Background(), "", "gh", "api", "/user"); err == nil {
+		t.Fatal("expected error")
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 access log entry, got %d", len(entries))
+	}
+	if got, want := entries[0].FailureKind, "runtime_error"; got != want {
+		t.Fatalf("failure_kind = %q, want %q", got, want)
+	}
+	if strings.Contains(entries[0].Error, "super-secret") {
+		t.Fatalf("expected sanitized error detail, got %q", entries[0].Error)
+	}
+	if !strings.Contains(entries[0].Error, "<redacted>") {
+		t.Fatalf("expected redacted error detail, got %q", entries[0].Error)
 	}
 }
 


### PR DESCRIPTION
## Summary
- normalize access-log tool identity, add correlation IDs, raw tool paths, and sanitized failure diagnostics
- classify low-signal version and status probes as `healthcheck` traffic instead of mixing them into general daemon activity
- propagate access-log context through repo scan and PR-maintenance paths and add regression coverage

## Validation
- `go test ./internal/environment ./internal/service ./internal/app -count=1 -timeout=90s`

Closes #326
