### PR TITLE
Prevent coding-agent attribution in published text

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -512,7 +512,11 @@ func isSupportedProxyTool(name string) bool {
 }
 
 func (a *App) runProxyCommand(ctx context.Context, tool string, args []string) error {
-	exitCode, err := a.proxyExec(ctx, a.stdin, a.stdout, a.stderr, tool, args...)
+	sanitizedArgs, sanitizedStdin, err := ghcli.SanitizeProxyInvocation(tool, args, a.stdin)
+	if err != nil {
+		return err
+	}
+	exitCode, err := a.proxyExec(ctx, sanitizedStdin, a.stdout, a.stderr, tool, sanitizedArgs...)
 	if err != nil {
 		return err
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -169,6 +169,42 @@ func TestRunProxiesSupportedToolCommands(t *testing.T) {
 	}
 }
 
+func TestRunSanitizesProxyBodyContent(t *testing.T) {
+	app := New()
+	app.stdin = strings.NewReader("PR body\n\nGenerated with Claude Code")
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+
+	var gotName string
+	var gotArgs []string
+	var gotStdin string
+	app.proxyExec = func(_ context.Context, in io.Reader, _ io.Writer, _ io.Writer, name string, args ...string) (int, error) {
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		if in != nil {
+			body, err := io.ReadAll(in)
+			if err != nil {
+				t.Fatalf("read proxy stdin: %v", err)
+			}
+			gotStdin = string(body)
+		}
+		return 0, nil
+	}
+
+	if exitCode := app.Run(context.Background(), []string{"gh", "pr", "create", "--body-file", "-"}); exitCode != 0 {
+		t.Fatalf("expected success exit code, got %d", exitCode)
+	}
+	if gotName != "gh" {
+		t.Fatalf("proxy tool = %q, want %q", gotName, "gh")
+	}
+	if got, want := strings.Join(gotArgs, " "), "pr create --body-file -"; got != want {
+		t.Fatalf("proxy args = %q, want %q", got, want)
+	}
+	if got, want := gotStdin, "PR body"; got != want {
+		t.Fatalf("proxy stdin = %q, want %q", got, want)
+	}
+}
+
 func TestRunReturnsUnderlyingProxyExitCode(t *testing.T) {
 	app := New()
 	app.stdout = testutil.IODiscard{}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -226,7 +226,7 @@ func matchesLabelAllowlist(issue Issue, allowlist []string) bool {
 }
 
 func CommentOnIssue(ctx context.Context, runner environment.Runner, repo string, number int, body string) error {
-	_, err := runner.Run(ctx, "", "gh", "issue", "comment", "--repo", repo, fmt.Sprintf("%d", number), "--body", body)
+	_, err := runner.Run(ctx, "", "gh", "issue", "comment", "--repo", repo, fmt.Sprintf("%d", number), "--body", SanitizeGitHubVisibleText(body))
 	return err
 }
 
@@ -653,7 +653,7 @@ type CreatedIssue struct {
 }
 
 func CreateIssue(ctx context.Context, runner environment.Runner, repo string, title string, body string, labels []string, assignees []string) (*CreatedIssue, error) {
-	args := []string{"gh", "api", "--method", "POST", "-H", "Accept: application/vnd.github+json", "repos/" + repo + "/issues", "-f", "title=" + title, "-f", "body=" + body}
+	args := []string{"gh", "api", "--method", "POST", "-H", "Accept: application/vnd.github+json", "repos/" + repo + "/issues", "-f", "title=" + title, "-f", "body=" + SanitizeGitHubVisibleText(body)}
 	for _, label := range labels {
 		args = append(args, "-f", "labels[]="+label)
 	}

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -412,6 +412,19 @@ func TestMergePullRequestSquash(t *testing.T) {
 	}
 }
 
+func TestCommentOnIssueSanitizesAgentBranding(t *testing.T) {
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh issue comment --repo owner/repo 17 --body Clean summary": "ok",
+		},
+	}
+
+	body := "Clean summary\n\nGenerated with Claude Code"
+	if err := CommentOnIssue(context.Background(), runner, "owner/repo", 17, body); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestFindCleanupComment(t *testing.T) {
 	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
 	comments := []IssueComment{

--- a/internal/github/sanitize.go
+++ b/internal/github/sanitize.go
@@ -1,0 +1,272 @@
+package ghcli
+
+import (
+	"io"
+	"os"
+	"strings"
+)
+
+var prohibitedAttributionPhrases = []string{
+	"generated with",
+	"created with",
+	"written by",
+	"authored by",
+	"co-authored by",
+}
+
+var prohibitedAgentNames = []string{
+	"claude code",
+	"claude",
+	"codex",
+	"gemini cli",
+	"gemini",
+}
+
+func SanitizeGitHubVisibleText(text string) string {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	if strings.TrimSpace(text) == "" {
+		return strings.TrimSpace(text)
+	}
+
+	lines := strings.Split(text, "\n")
+	sanitized := make([]string, 0, len(lines))
+	blankRun := 0
+	for _, line := range lines {
+		if isProhibitedAttributionLine(line) {
+			continue
+		}
+		if strings.TrimSpace(line) == "" {
+			blankRun++
+			if blankRun > 1 {
+				continue
+			}
+		} else {
+			blankRun = 0
+		}
+		sanitized = append(sanitized, line)
+	}
+	return strings.TrimSpace(strings.Join(sanitized, "\n"))
+}
+
+func SanitizeProxyInvocation(tool string, args []string, stdin io.Reader) ([]string, io.Reader, error) {
+	sanitizedArgs := append([]string(nil), args...)
+	currentStdin := stdin
+
+	switch tool {
+	case "gh":
+		if isGitHubBodyCommand(sanitizedArgs) {
+			return sanitizeBodyFlags(sanitizedArgs, currentStdin, []string{"--body"}, []string{"--body-file"})
+		}
+		if isGitHubAPIBodyCommand(sanitizedArgs) {
+			return sanitizeAPIBodyFields(sanitizedArgs), currentStdin, nil
+		}
+	case "git":
+		if isGitCommitCommand(sanitizedArgs) {
+			return sanitizeBodyFlags(sanitizedArgs, currentStdin, []string{"-m", "--message"}, []string{"-F", "--file"})
+		}
+	}
+
+	return sanitizedArgs, currentStdin, nil
+}
+
+func isProhibitedAttributionLine(line string) bool {
+	normalized := normalizeAttributionLine(line)
+	if normalized == "" {
+		return false
+	}
+	hasPhrase := false
+	for _, phrase := range prohibitedAttributionPhrases {
+		if strings.Contains(normalized, phrase) {
+			hasPhrase = true
+			break
+		}
+	}
+	if !hasPhrase {
+		return false
+	}
+	for _, agent := range prohibitedAgentNames {
+		if strings.Contains(normalized, agent) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeAttributionLine(line string) string {
+	line = strings.TrimSpace(strings.ToLower(line))
+	replacer := strings.NewReplacer("`", "", "*", "", "_", "", "#", "", ">", "", "-", " ", ":", " ", "\t", " ")
+	line = replacer.Replace(line)
+	return strings.Join(strings.Fields(line), " ")
+}
+
+func sanitizeBodyFlags(args []string, stdin io.Reader, inlineFlags []string, fileFlags []string) ([]string, io.Reader, error) {
+	sanitizedArgs := make([]string, 0, len(args))
+	currentStdin := stdin
+
+	for i := 0; i < len(args); i++ {
+		token := args[i]
+
+		if flag, value, ok := splitInlineFlag(token, inlineFlags); ok {
+			sanitizedArgs = append(sanitizedArgs, flag+"="+SanitizeGitHubVisibleText(value))
+			continue
+		}
+		if matchesFlag(token, inlineFlags) && i+1 < len(args) {
+			sanitizedArgs = append(sanitizedArgs, token, SanitizeGitHubVisibleText(args[i+1]))
+			i++
+			continue
+		}
+
+		if flag, value, ok := splitInlineFlag(token, fileFlags); ok {
+			content, nextStdin, err := sanitizeFileOrStdinValue(value, currentStdin)
+			if err != nil {
+				return nil, nil, err
+			}
+			currentStdin = nextStdin
+			sanitizedArgs = append(sanitizedArgs, flag, "-")
+			if content != nil {
+				currentStdin = content
+			}
+			continue
+		}
+		if matchesFlag(token, fileFlags) && i+1 < len(args) {
+			content, nextStdin, err := sanitizeFileOrStdinValue(args[i+1], currentStdin)
+			if err != nil {
+				return nil, nil, err
+			}
+			currentStdin = nextStdin
+			sanitizedArgs = append(sanitizedArgs, token, "-")
+			if content != nil {
+				currentStdin = content
+			}
+			i++
+			continue
+		}
+
+		sanitizedArgs = append(sanitizedArgs, token)
+	}
+
+	return sanitizedArgs, currentStdin, nil
+}
+
+func sanitizeFileOrStdinValue(value string, currentStdin io.Reader) (io.Reader, io.Reader, error) {
+	if strings.TrimSpace(value) == "-" {
+		if currentStdin == nil {
+			return strings.NewReader(""), strings.NewReader(""), nil
+		}
+		body, err := io.ReadAll(currentStdin)
+		if err != nil {
+			return nil, nil, err
+		}
+		sanitized := SanitizeGitHubVisibleText(string(body))
+		reader := strings.NewReader(sanitized)
+		return reader, reader, nil
+	}
+
+	body, err := os.ReadFile(value)
+	if err != nil {
+		return nil, nil, err
+	}
+	return strings.NewReader(SanitizeGitHubVisibleText(string(body))), currentStdin, nil
+}
+
+func sanitizeAPIBodyFields(args []string) []string {
+	sanitized := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		token := args[i]
+		sanitized = append(sanitized, token)
+		if !matchesFlag(token, []string{"-f", "--field", "-F", "--raw-field"}) || i+1 >= len(args) {
+			continue
+		}
+		value := args[i+1]
+		if strings.HasPrefix(value, "body=") {
+			value = "body=" + SanitizeGitHubVisibleText(strings.TrimPrefix(value, "body="))
+		}
+		sanitized = append(sanitized, value)
+		i++
+	}
+	return sanitized
+}
+
+func isGitHubBodyCommand(args []string) bool {
+	tokens := proxyCommandTokens("gh", args)
+	if len(tokens) < 2 {
+		return false
+	}
+	return (tokens[0] == "issue" && tokens[1] == "comment") ||
+		(tokens[0] == "pr" && (tokens[1] == "create" || tokens[1] == "edit"))
+}
+
+func isGitHubAPIBodyCommand(args []string) bool {
+	tokens := proxyCommandTokens("gh", args)
+	if len(tokens) == 0 || tokens[0] != "api" {
+		return false
+	}
+	for _, token := range args {
+		token = strings.TrimSpace(token)
+		if strings.HasPrefix(token, "repos/") && (strings.Contains(token, "/issues") || strings.Contains(token, "/pulls")) {
+			return true
+		}
+	}
+	return false
+}
+
+func isGitCommitCommand(args []string) bool {
+	tokens := proxyCommandTokens("git", args)
+	return len(tokens) > 0 && tokens[0] == "commit"
+}
+
+func proxyCommandTokens(tool string, args []string) []string {
+	tokens := make([]string, 0, 3)
+	for i := 0; i < len(args); i++ {
+		token := strings.TrimSpace(args[i])
+		if token == "" {
+			continue
+		}
+		if strings.HasPrefix(token, "-") {
+			if proxyFlagNeedsValue(tool, token) && i+1 < len(args) && !strings.HasPrefix(strings.TrimSpace(args[i+1]), "-") {
+				i++
+			}
+			continue
+		}
+		tokens = append(tokens, token)
+		if len(tokens) == 3 {
+			return tokens
+		}
+	}
+	return tokens
+}
+
+func proxyFlagNeedsValue(tool string, flag string) bool {
+	if strings.Contains(flag, "=") {
+		return false
+	}
+	switch tool {
+	case "gh":
+		return flag == "-R" || flag == "--repo" || flag == "--hostname"
+	case "git":
+		switch flag {
+		case "-C", "-c", "--git-dir", "--work-tree", "--namespace", "--super-prefix", "--exec-path", "--config-env":
+			return true
+		}
+	}
+	return false
+}
+
+func matchesFlag(token string, flags []string) bool {
+	for _, flag := range flags {
+		if token == flag {
+			return true
+		}
+	}
+	return false
+}
+
+func splitInlineFlag(token string, flags []string) (string, string, bool) {
+	for _, flag := range flags {
+		prefix := flag + "="
+		if strings.HasPrefix(token, prefix) {
+			return flag, strings.TrimPrefix(token, prefix), true
+		}
+	}
+	return "", "", false
+}

--- a/internal/github/sanitize_test.go
+++ b/internal/github/sanitize_test.go
@@ -1,0 +1,68 @@
+package ghcli
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeGitHubVisibleTextRemovesAgentAttribution(t *testing.T) {
+	input := strings.Join([]string{
+		"Summary line",
+		"",
+		"Generated with Codex",
+		"Co-authored by: Claude Code <bot@example.com>",
+		"",
+		"Validation: `go test ./...`",
+	}, "\n")
+
+	got := SanitizeGitHubVisibleText(input)
+	want := "Summary line\n\nValidation: `go test ./...`"
+	if got != want {
+		t.Fatalf("SanitizeGitHubVisibleText() = %q, want %q", got, want)
+	}
+}
+
+func TestSanitizeGitHubVisibleTextPreservesOperationalProviderMentions(t *testing.T) {
+	input := "## 🕹️ Coding Agent Launched: Codex\n\n- Provider routing selected `Codex` for this issue."
+	if got := SanitizeGitHubVisibleText(input); got != input {
+		t.Fatalf("expected operational provider mention to remain intact, got %q", got)
+	}
+}
+
+func TestSanitizeProxyInvocationRewritesIssueCommentBodyFileFromStdin(t *testing.T) {
+	args, stdin, err := SanitizeProxyInvocation("gh", []string{"issue", "comment", "7", "--body-file", "-"}, strings.NewReader("Done\n\nGenerated with Gemini CLI"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.Join(args, " "), "issue comment 7 --body-file -"; got != want {
+		t.Fatalf("args = %q, want %q", got, want)
+	}
+	body, err := io.ReadAll(stdin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(body), "Done"; got != want {
+		t.Fatalf("stdin = %q, want %q", got, want)
+	}
+}
+
+func TestSanitizeProxyInvocationRewritesCommitMessageFlags(t *testing.T) {
+	args, _, err := SanitizeProxyInvocation("git", []string{"commit", "-m", "Fix bug\n\nGenerated with Codex", "--amend"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.Join(args, " "), "commit -m Fix bug --amend"; got != want {
+		t.Fatalf("args = %q, want %q", got, want)
+	}
+}
+
+func TestSanitizeProxyInvocationSanitizesGitHubAPIBodyField(t *testing.T) {
+	args, _, err := SanitizeProxyInvocation("gh", []string{"api", "--method", "POST", "repos/owner/repo/issues/7/comments", "-f", "body=Ready\n\nGenerated with Claude Code"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := strings.Join(args, " "), "api --method POST repos/owner/repo/issues/7/comments -f body=Ready"; got != want {
+		t.Fatalf("args = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Closes #327

## Summary
- add a shared sanitizer for GitHub-visible text that removes coding-agent attribution lines
- apply the sanitizer to app-owned issue comments and `vigilante gh` / `vigilante git` proxy publish paths
- add regression tests for issue comments, PR/comment body proxying, and commit messages

## Validation
- `go test ./...`
