### PR TITLE
Make iteration comment claiming monotonic

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4097,7 +4097,7 @@ func (a *App) processGitHubIterationRequestsForTarget(ctx context.Context, targe
 			continue
 		}
 
-		comment := ghcli.FindIterationComment(comments, session.LastIterationCommentID)
+		comment := ghcli.FindIterationComment(comments, session.LastIterationCommentID, session.LastIterationCommentAt)
 		if comment == nil {
 			continue
 		}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -425,6 +425,82 @@ func TestProcessGitHubIterationRequestsForTargetRejectsNonAssignee(t *testing.T)
 	}
 }
 
+func TestProcessGitHubIterationRequestsForTargetDoesNotReplayHistoricalRejectedIteration(t *testing.T) {
+	now := time.Date(2026, 3, 19, 12, 0, 0, 0, time.UTC)
+	repoPath := t.TempDir()
+	stateRoot := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", stateRoot)
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.clock = func() time.Time { return now }
+	app.state = state.NewStore()
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1":          `{"title":"first","body":"Issue body","html_url":"https://github.com/owner/repo/issues/1","labels":[{"name":"vigilante:ready-for-review"}],"assignees":[{"login":"nicobistolfi"}]}`,
+			"gh api repos/owner/repo/issues/1/comments": `[{"id":100,"body":"@vigilanteai stale request","created_at":"2026-03-19T11:58:00Z","user":{"login":"someoneelse"}},{"id":101,"body":"@vigilanteai latest invalid request","created_at":"2026-03-19T11:59:00Z","user":{"login":"someoneelse"}}]`,
+			"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Iteration Ignored",
+				Emoji:      "🛂",
+				Percent:    100,
+				ETAMinutes: 1,
+				Items: []string{
+					"Ignored the latest `@vigilanteai` iteration request from `@someoneelse`.",
+					"Only a current issue assignee can request another implementation iteration for this issue.",
+					"Next step: ask an assignee to post the follow-up request if another pass is needed.",
+				},
+				Tagline: "Hands on the wheel, one driver at a time.",
+			}): "ok",
+		},
+	}
+
+	sessions := []state.Session{{
+		RepoPath:     repoPath,
+		Repo:         "owner/repo",
+		Provider:     "codex",
+		IssueNumber:  1,
+		IssueTitle:   "first",
+		IssueURL:     "https://github.com/owner/repo/issues/1",
+		Status:       state.SessionStatusSuccess,
+		Branch:       "vigilante/issue-1-first",
+		WorktreePath: filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1"),
+	}}
+
+	updated, started, err := app.processGitHubIterationRequestsForTarget(context.Background(), state.WatchTarget{
+		Path:   repoPath,
+		Repo:   "owner/repo",
+		Branch: "main",
+	}, sessions, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if started != 0 {
+		t.Fatalf("expected no iteration dispatches on first scan, got %d", started)
+	}
+	if updated[0].LastIterationCommentID != 101 {
+		t.Fatalf("expected latest rejected iteration comment to be recorded, got %#v", updated[0])
+	}
+
+	updated, started, err = app.processGitHubIterationRequestsForTarget(context.Background(), state.WatchTarget{
+		Path:   repoPath,
+		Repo:   "owner/repo",
+		Branch: "main",
+	}, updated, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if started != 0 {
+		t.Fatalf("expected no iteration dispatches on replay scan, got %d", started)
+	}
+	if updated[0].LastIterationCommentID != 101 {
+		t.Fatalf("expected the stored iteration cursor to remain on the latest rejected comment, got %#v", updated[0])
+	}
+}
+
 func TestProcessGitHubIterationRequestsForTargetDispatchesAssigneeComment(t *testing.T) {
 	now := time.Date(2026, 3, 19, 12, 0, 0, 0, time.UTC)
 	repoPath := t.TempDir()
@@ -550,6 +626,120 @@ func TestProcessGitHubIterationRequestsForTargetDispatchesAssigneeComment(t *tes
 	}
 	if updated[0].Status != state.SessionStatusRunning {
 		t.Fatalf("expected in-memory session to be redispatched before completion, got %#v", updated[0])
+	}
+}
+
+func TestProcessGitHubIterationRequestsForTargetAcceptsNewCommentAfterStoredCursor(t *testing.T) {
+	now := time.Date(2026, 3, 19, 12, 0, 0, 0, time.UTC)
+	repoPath := t.TempDir()
+	stateRoot := t.TempDir()
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	t.Setenv("VIGILANTE_HOME", stateRoot)
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.clock = func() time.Time { return now }
+	app.state = state.NewStore()
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	app.repoLabelsProvisionedOnce["owner/repo"] = true
+
+	iterationContext := buildIterationPromptContext([]ghcli.IssueComment{
+		{
+			ID:        101,
+			Body:      "@vigilanteai current follow-up",
+			CreatedAt: now.Add(-1 * time.Minute),
+			User: struct {
+				Login string `json:"login"`
+			}{Login: "nicobistolfi"},
+		},
+	})
+	startSession := state.Session{
+		RepoPath:               repoPath,
+		Repo:                   "owner/repo",
+		Provider:               "codex",
+		IssueNumber:            1,
+		IssueTitle:             "first",
+		IssueURL:               "https://github.com/owner/repo/issues/1",
+		Status:                 state.SessionStatusSuccess,
+		Branch:                 "vigilante/issue-1-first",
+		WorktreePath:           worktreePath,
+		IssueBody:              "Original body",
+		IterationPromptContext: iterationContext,
+		IterationInProgress:    true,
+		LastIterationCommentID: 100,
+		LastIterationCommentAt: now.Add(-2 * time.Minute).Format(time.RFC3339),
+	}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1":          `{"title":"first","body":"Issue body","html_url":"https://github.com/owner/repo/issues/1","labels":[{"name":"vigilante:ready-for-review"}],"assignees":[{"login":"nicobistolfi"}]}`,
+			"gh api repos/owner/repo/issues/1/comments": `[{"id":99,"body":"@vigilanteai old history","created_at":"2026-03-19T11:57:00Z","user":{"login":"nicobistolfi"}},{"id":100,"body":"@vigilanteai already handled","created_at":"2026-03-19T11:58:00Z","user":{"login":"nicobistolfi"}},{"id":101,"body":"@vigilanteai current follow-up","created_at":"2026-03-19T11:59:00Z","user":{"login":"nicobistolfi"}}]`,
+			"gh api --method POST -H Accept: application/vnd.github+json repos/owner/repo/issues/comments/101/reactions -f content=eyes": "ok",
+			"git worktree prune":                          "ok",
+			"git fetch origin main":                       "ok",
+			"git worktree list --porcelain":               "",
+			"git branch -f main refs/remotes/origin/main": "ok",
+			"git worktree add -b vigilante/issue-1-first " + worktreePath + " origin/main":                                                              "ok",
+			"gh issue edit --repo owner/repo 1 --add-label vigilante:iterating --add-label vigilante:running --remove-label vigilante:ready-for-review": "ok",
+			sessionStartCommentCommand("owner/repo", 1, worktreePath, state.Session{
+				Repo:                   "owner/repo",
+				IssueNumber:            1,
+				IssueTitle:             "first",
+				IssueBody:              "Issue body",
+				IssueURL:               "https://github.com/owner/repo/issues/1",
+				BaseBranch:             "main",
+				Branch:                 "vigilante/issue-1-first",
+				WorktreePath:           worktreePath,
+				Status:                 state.SessionStatusRunning,
+				Provider:               "codex",
+				IterationInProgress:    true,
+				IterationPromptContext: iterationContext,
+				LastIterationCommentID: 100,
+				LastIterationCommentAt: now.Add(-2 * time.Minute).Format(time.RFC3339),
+			}): "ok",
+			preflightPromptCommand(worktreePath, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1-first"): "ok",
+			issuePromptCommandForSession(worktreePath, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", state.Session{
+				WorktreePath:           worktreePath,
+				Branch:                 "vigilante/issue-1-first",
+				Provider:               "codex",
+				IssueBody:              "Issue body",
+				IterationPromptContext: iterationContext,
+				LastIterationCommentID: 100,
+				LastIterationCommentAt: now.Add(-2 * time.Minute).Format(time.RFC3339),
+			}): "done",
+			"gh issue edit --repo owner/repo 1 --add-label vigilante:ready-for-review --remove-label vigilante:iterating --remove-label vigilante:running": "ok",
+		},
+		Errors: map[string]error{
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1-first": errors.New("exit status 1"),
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1":       errors.New("exit status 1"),
+		},
+	}
+
+	sessions := []state.Session{startSession}
+	_, started, err := app.processGitHubIterationRequestsForTarget(context.Background(), state.WatchTarget{
+		Path:   repoPath,
+		Repo:   "owner/repo",
+		Branch: "main",
+	}, sessions, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if started != 1 {
+		t.Fatalf("expected one iteration dispatch for the new comment, got %d", started)
+	}
+	app.waitForSessions()
+
+	saved, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(saved) != 1 {
+		t.Fatalf("expected one saved session, got %#v", saved)
+	}
+	if saved[0].LastIterationCommentID != 101 {
+		t.Fatalf("expected the new iteration comment to advance the cursor, got %#v", saved[0])
 	}
 }
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -490,9 +490,10 @@ func FindRecreateComment(comments []IssueComment, claimedCommentID int64) *Issue
 	return findCommandComment(comments, "@vigilanteai recreate", claimedCommentID)
 }
 
-func FindIterationComment(comments []IssueComment, claimedCommentID int64) *IssueComment {
+func FindIterationComment(comments []IssueComment, claimedCommentID int64, claimedCommentAt string) *IssueComment {
+	claimedAt := parseClaimedCommentTime(claimedCommentAt)
 	for i := len(comments) - 1; i >= 0; i-- {
-		if claimedCommentID != 0 && comments[i].ID == claimedCommentID {
+		if !isCommentNewerThanClaim(comments[i], claimedAt, claimedCommentID) {
 			continue
 		}
 		if !IsIterationComment(comments[i]) {
@@ -586,6 +587,34 @@ func findCommandComment(comments []IssueComment, command string, claimedCommentI
 func normalizeVigilanteComment(body string) string {
 	fields := strings.Fields(strings.ToLower(strings.TrimSpace(body)))
 	return strings.Join(fields, " ")
+}
+
+func parseClaimedCommentTime(raw string) time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}
+	}
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}
+	}
+	return parsed.UTC()
+}
+
+func isCommentNewerThanClaim(comment IssueComment, claimedAt time.Time, claimedCommentID int64) bool {
+	if claimedCommentID == 0 && claimedAt.IsZero() {
+		return true
+	}
+	commentAt := comment.CreatedAt.UTC()
+	if !claimedAt.IsZero() {
+		if commentAt.Before(claimedAt) {
+			return false
+		}
+		if commentAt.After(claimedAt) {
+			return true
+		}
+	}
+	return comment.ID > claimedCommentID
 }
 
 func FindPullRequestForBranch(ctx context.Context, runner environment.Runner, repo string, branch string) (*PullRequest, error) {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -473,12 +473,44 @@ func TestFindIterationCommentSkipsKnownCommands(t *testing.T) {
 		{ID: 11, Body: "@vigilanteai please adjust the copy", CreatedAt: now.Add(-1 * time.Minute)},
 	}
 
-	comment := FindIterationComment(comments, 0)
+	comment := FindIterationComment(comments, 0, "")
 	if comment == nil || comment.ID != 11 {
 		t.Fatalf("expected iteration comment to be found, got: %#v", comment)
 	}
-	if comment := FindIterationComment(comments, 11); comment != nil {
+	if comment := FindIterationComment(comments, 11, now.Add(-1*time.Minute).Format(time.RFC3339)); comment != nil {
 		t.Fatalf("expected claimed iteration comment to be ignored, got: %#v", comment)
+	}
+}
+
+func TestFindIterationCommentTreatsOlderHistoryAsConsumed(t *testing.T) {
+	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	comments := []IssueComment{
+		{ID: 10, Body: "@vigilanteai older request", CreatedAt: now.Add(-3 * time.Minute)},
+		{ID: 11, Body: "@vigilanteai claimed request", CreatedAt: now.Add(-2 * time.Minute)},
+		{ID: 12, Body: "@vigilanteai newer request", CreatedAt: now.Add(-1 * time.Minute)},
+	}
+
+	comment := FindIterationComment(comments, 11, now.Add(-2*time.Minute).Format(time.RFC3339))
+	if comment == nil || comment.ID != 12 {
+		t.Fatalf("expected only the newer iteration comment to be eligible, got %#v", comment)
+	}
+
+	if comment := FindIterationComment(comments[:2], 11, now.Add(-2*time.Minute).Format(time.RFC3339)); comment != nil {
+		t.Fatalf("expected historical iteration comments to stay consumed, got %#v", comment)
+	}
+}
+
+func TestFindIterationCommentUsesIDTieBreakerAtClaimTimestamp(t *testing.T) {
+	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	claimedAt := now.Add(-1 * time.Minute)
+	comments := []IssueComment{
+		{ID: 10, Body: "@vigilanteai already consumed", CreatedAt: claimedAt},
+		{ID: 11, Body: "@vigilanteai newer same-second request", CreatedAt: claimedAt},
+	}
+
+	comment := FindIterationComment(comments, 10, claimedAt.Format(time.RFC3339))
+	if comment == nil || comment.ID != 11 {
+		t.Fatalf("expected newer same-timestamp iteration comment to be eligible, got %#v", comment)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make iteration comment selection monotonic by treating the stored timestamp and comment ID as a claim cursor
- stop replaying older ignored iteration comments while still accepting genuinely new follow-up requests
- add regression coverage for historical replay and new-comment detection

## Validation
- `go test ./internal/github ./internal/app`
- `go test ./...`

Closes #332