### PR TITLE
Block automerge when comment-driven iteration is pending

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2149,6 +2149,22 @@ func (a *App) tryAutoSquashMerge(ctx context.Context, session *state.Session, pr
 		return nil
 	}
 
+	if session.IterationInProgress {
+		reason := fmt.Sprintf("automerge blocked: iteration is in progress for issue #%d", session.IssueNumber)
+		session.LastMaintenanceError = reason
+		a.logger.Info("automerge blocked by active iteration", "repo", session.Repo, "issue", session.IssueNumber, "pr", pr.Number, "branch", session.Branch)
+		return nil
+	}
+
+	if pending, err := a.hasPendingIterationComment(ctx, session); err != nil {
+		a.logger.Error("automerge pending-iteration check failed", "repo", session.Repo, "issue", session.IssueNumber, "pr", pr.Number, "err", err)
+	} else if pending {
+		reason := fmt.Sprintf("automerge blocked: unclaimed iteration comment pending for issue #%d", session.IssueNumber)
+		session.LastMaintenanceError = reason
+		a.logger.Info("automerge blocked by pending iteration comment", "repo", session.Repo, "issue", session.IssueNumber, "pr", pr.Number, "branch", session.Branch)
+		return nil
+	}
+
 	if err := ghcli.MergePullRequestSquash(ctx, a.env.Runner, session.Repo, pr.Number); err != nil {
 		return fmt.Errorf("squash automerge pr #%d: %w", pr.Number, err)
 	}
@@ -4186,6 +4202,26 @@ func sessionSupportsIteration(session state.Session) bool {
 	default:
 		return false
 	}
+}
+
+func (a *App) hasPendingIterationComment(ctx context.Context, session *state.Session) (bool, error) {
+	if session.Repo == "" || session.IssueNumber <= 0 {
+		return false, nil
+	}
+	comments, err := ghcli.ListIssueCommentsForPolling(ctx, a.env.Runner, session.Repo, session.IssueNumber, "automerge_iteration_gate", a.logger)
+	if err != nil {
+		return false, err
+	}
+	comment := ghcli.FindIterationComment(comments, session.LastIterationCommentID, session.LastIterationCommentAt)
+	if comment == nil {
+		return false, nil
+	}
+	details, err := ghcli.GetIssueDetails(ctx, a.env.Runner, session.Repo, session.IssueNumber)
+	if err != nil {
+		return false, err
+	}
+	assignees := assigneeLogins(details.Assignees)
+	return loginMatchesAssignee(comment.User.Login, assignees), nil
 }
 
 func assigneeLogins(assignees []ghcli.IssueUserRef) []string {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -6497,6 +6497,145 @@ func TestScanOnceDoesNotAutomergeUnlabeledPullRequest(t *testing.T) {
 	}
 }
 
+func TestScanOnceAutomergeBlockedByActiveIteration(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
+			"git fetch origin main":  "ok",
+			"git status --porcelain": "",
+			"git rebase origin/main": "Current branch vigilante/issue-1 is up to date.\n",
+			"gh pr view --repo owner/repo 31 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,baseRefName": automergePRDetailsJSON("vigilante:automerge", "MERGEABLE", "CLEAN", "APPROVED", "COMPLETED", "SUCCESS"),
+			"gh api repos/owner/repo/issues/1":          `{"title":"first","body":"Issue body","html_url":"https://github.com/owner/repo/issues/1","state":"open","labels":[{"name":"vigilante:automerge"}]}`,
+			"gh api repos/owner/repo/issues/1/comments": "[]",
+			"gh api user --jq .login":                   "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:            "/tmp/repo",
+		Repo:                "owner/repo",
+		IssueNumber:         1,
+		IssueTitle:          "first",
+		IssueURL:            "https://github.com/owner/repo/issues/1",
+		Branch:              "vigilante/issue-1",
+		WorktreePath:        filepath.Join("/tmp/repo", ".worktrees", "vigilante", "issue-1"),
+		Status:              state.SessionStatusSuccess,
+		IterationInProgress: true,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	app.waitForSessions()
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(sessions[0].LastMaintenanceError, "iteration is in progress") {
+		t.Fatalf("expected automerge to be blocked by active iteration, got: %q", sessions[0].LastMaintenanceError)
+	}
+}
+
+func TestScanOnceAutomergeBlockedByPendingIterationComment(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	runner := &countingRunner{
+		base: testutil.FakeRunner{
+			LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+			Outputs: map[string]string{
+				"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
+				"git fetch origin main":  "ok",
+				"git status --porcelain": "",
+				"git rebase origin/main": "Current branch vigilante/issue-1 is up to date.\n",
+				"gh pr view --repo owner/repo 31 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,baseRefName": automergePRDetailsJSON("vigilante:automerge", "MERGEABLE", "CLEAN", "APPROVED", "COMPLETED", "SUCCESS"),
+				"gh pr merge --repo owner/repo 31 --squash --delete-branch": "ok",
+				"gh api repos/owner/repo/issues/1":                          `{"title":"first","body":"Issue body","html_url":"https://github.com/owner/repo/issues/1","state":"open","labels":[{"name":"vigilante:automerge"}],"assignees":[{"login":"nicobistolfi"}]}`,
+				"gh api repos/owner/repo/issues/1/comments":                 `[{"id":200,"body":"@vigilanteai please also fix the edge case","created_at":"2026-03-19T12:00:00Z","user":{"login":"nicobistolfi"}}]`,
+				"gh api --method POST -H Accept: application/vnd.github+json repos/owner/repo/issues/comments/200/reactions -f content=eyes": "ok",
+				"gh api user --jq .login": "nicobistolfi\n",
+				"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+			},
+		},
+	}
+	app.env.Runner = runner
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:     "/tmp/repo",
+		Repo:         "owner/repo",
+		IssueNumber:  1,
+		IssueTitle:   "first",
+		IssueURL:     "https://github.com/owner/repo/issues/1",
+		Branch:       "vigilante/issue-1",
+		WorktreePath: filepath.Join("/tmp/repo", ".worktrees", "vigilante", "issue-1"),
+		Status:       state.SessionStatusSuccess,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	app.waitForSessions()
+
+	mergeCount := runner.counts["gh pr merge --repo owner/repo 31 --squash --delete-branch"]
+	if mergeCount != 0 {
+		t.Fatalf("expected automerge to be blocked by pending iteration comment, but merge was called %d time(s)", mergeCount)
+	}
+}
+
+func TestScanOnceAutomergeProceedsAfterIterationCompletes(t *testing.T) {
+	app, _ := newPullRequestMaintenanceTestApp(t, map[string]string{
+		"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
+		"git fetch origin main":  "ok",
+		"git status --porcelain": "",
+		"git rebase origin/main": "Current branch vigilante/issue-1 is up to date.\n",
+		"gh pr view --repo owner/repo 31 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,baseRefName": automergePRDetailsJSON("vigilante:automerge", "MERGEABLE", "CLEAN", "APPROVED", "COMPLETED", "SUCCESS"),
+		"gh pr merge --repo owner/repo 31 --squash --delete-branch": "ok",
+		"gh api user --jq .login":                                   "nicobistolfi\n",
+		"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+	})
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	app.waitForSessions()
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions[0].LastMaintenanceError != "" {
+		t.Fatalf("expected automerge to proceed when no iteration is pending, got: %q", sessions[0].LastMaintenanceError)
+	}
+}
+
 func newPullRequestMaintenanceTestApp(t *testing.T, outputs map[string]string) (*App, *bytes.Buffer) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- Adds a pending-iteration gate in `tryAutoSquashMerge` that checks for unclaimed assignee `@vigilanteai` iteration comments before allowing automerge.
- Also blocks automerge when `IterationInProgress` is already true on the session.
- Prevents the race where `maintainPullRequests` could merge a PR before `processGitHubIterationRequestsForTarget` dispatches the requested follow-up iteration in the same scan cycle.

## Test plan

- [x] `TestScanOnceAutomergeBlockedByActiveIteration` — verifies automerge is blocked when `IterationInProgress` is true
- [x] `TestScanOnceAutomergeBlockedByPendingIterationComment` — verifies automerge is blocked when an unclaimed assignee iteration comment exists (uses counting runner to confirm merge was never attempted)
- [x] `TestScanOnceAutomergeProceedsAfterIterationCompletes` — verifies automerge proceeds normally when no iteration is pending
- [x] Full test suite passes (`go test ./...`)
- [x] `go build ./...` and `go vet ./...` pass

Closes #335