### PR TITLE
Introduce project-management backend abstractions beyond GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 [![License](https://img.shields.io/github/license/aliengiraffe/vigilante)](https://github.com/aliengiraffe/vigilante/blob/main/LICENSE)
 [![Release Workflow](https://img.shields.io/github/actions/workflow/status/aliengiraffe/vigilante/release.yml?label=release)](https://github.com/aliengiraffe/vigilante/actions/workflows/release.yml)
 
-`vigilante` is a GitHub-native control plane for autonomous software delivery. It watches repositories, selects executable issues, prepares isolated implementation environments, dispatches headless coding agents, keeps GitHub updated with progress, and maintains the delivery loop around pull requests.
+`vigilante` is a control plane for autonomous software delivery, extensible to multiple project-management backends. It watches repositories, selects executable work items, prepares isolated implementation environments, dispatches headless coding agents, keeps the issue-tracking system updated with progress, and maintains the delivery loop around pull requests.
+
+GitHub is the only fully implemented backend today, but the architecture supports additional backends such as Linear and Jira for issue tracking while retaining GitHub for git hosting and pull-request management.
 
 It is a Go CLI and background service that runs locally on top of the tools teams already use: `git`, `gh`, and a supported coding-agent CLI such as `codex`, `claude`, or `gemini`. The current target platforms are macOS and Ubuntu.
 
@@ -20,7 +22,7 @@ Want to see that workflow on this repository? Browse [Vigilante's closed issues]
 
 `vigilante` is the orchestration layer around coding agents. It is responsible for:
 
-- treating GitHub issues as the work queue
+- treating project-management work items as the work queue (GitHub issues today; Linear and Jira planned)
 - selecting eligible work based on labels, assignees, and repository limits
 - creating dedicated git worktrees and issue branches for each session
 - choosing the right execution playbook from repository classification
@@ -30,17 +32,36 @@ Want to see that workflow on this repository? Browse [Vigilante's closed issues]
 
 ## What Vigilante Is Not
 
-`vigilante` is not the code-generating model itself. Tools such as Codex, Claude Code, and Gemini are the execution engines that read prompts, edit code, run validation, and prepare pull requests. Keeping orchestration separate from code generation lets Vigilante stay provider-neutral while owning scheduling, worktree isolation, GitHub coordination, and PR maintenance.
+`vigilante` is not the code-generating model itself. Tools such as Codex, Claude Code, and Gemini are the execution engines that read prompts, edit code, run validation, and prepare pull requests. Keeping orchestration separate from code generation lets Vigilante stay provider-neutral while owning scheduling, worktree isolation, project-management coordination, and PR maintenance.
 
 ## Why Use Vigilante
 
 Vigilante turns a repository checkout into a controlled autonomous worker instead of a loose collection of scripts.
 
-- GitHub stays the operator surface for issue intake, progress, resume commands, cleanup, and PR visibility.
+- The project-management backend (GitHub today; Linear and Jira planned) stays the operator surface for issue intake, progress, resume commands, cleanup, and PR visibility.
 - Each issue runs in an isolated worktree, which keeps the main checkout stable and makes unattended execution safer.
 - Repository-aware skills let the same control plane adapt to standard repositories, monorepos, and supported build systems.
 - Session state persists locally, so Vigilante can recover from failures, clean up stalled work, and avoid duplicate dispatch.
 - Provider support is pluggable, so the orchestration layer remains stable even when teams change coding-agent runtimes.
+
+## Project-Management Backend Architecture
+
+Vigilante separates orchestration from backend-specific APIs through a provider abstraction layer. The core orchestration loop depends on backend interfaces rather than calling GitHub APIs directly:
+
+- **Issue Tracker** (`IssueTracker`): work item listing, details, comments, and operator commands
+- **Pull Request Manager** (`PullRequestManager`): PR discovery, status, merge, and branch lifecycle
+- **Label Manager** (`LabelManager`): label provisioning and synchronization
+- **Rate Limiter** (`RateLimiter`): optional API quota awareness
+
+The issue-tracking backend is allowed to differ from the git-hosting and pull-request backends. A watch target can combine:
+
+- GitHub issues + GitHub git remote + GitHub pull requests (current default)
+- Linear issues + GitHub git remote + GitHub pull requests (planned)
+- Jira issues + GitHub git remote + GitHub pull requests (planned)
+
+GitHub is the only fully implemented backend. The `internal/backend/` package defines the interfaces and neutral types, while `internal/backend/github/` provides the GitHub implementation. Adding a new backend requires implementing the relevant interfaces without restructuring the core dispatch or session lifecycle.
+
+Watch targets carry explicit backend identity fields (`issue_backend`, `git_backend`, `pr_backend`) that default to `"github"` when not set, preserving backward compatibility with existing configurations.
 
 ## Quickstart
 
@@ -652,16 +673,16 @@ The agent invocation remains a subprocess wrapper around an installed coding CLI
 
 ## GitHub Integration
 
-GitHub access should use `gh` rather than direct API client dependencies.
+GitHub access uses `gh` rather than direct API client dependencies, routed through the `IssueTracker`, `PullRequestManager`, `LabelManager`, and `RateLimiter` backend interfaces.
 
-Expected `gh` responsibilities:
+Expected `gh` responsibilities (for the GitHub backend):
 
 - detect authentication state
 - list open issues for a repository
 - post start/progress/error comments
 - optionally inspect issue metadata needed for scheduling
 
-This keeps the Go code smaller and delegates auth/session handling to the installed GitHub CLI.
+This keeps the Go code smaller and delegates auth/session handling to the installed GitHub CLI. Future backends (Linear, Jira) will use their own API clients behind the same interfaces.
 
 ## Worktree Strategy
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -19,6 +19,8 @@ import (
 
 	"log/slog"
 
+	"github.com/nicobistolfi/vigilante/internal/backend"
+	githubbackend "github.com/nicobistolfi/vigilante/internal/backend/github"
 	"github.com/nicobistolfi/vigilante/internal/blocking"
 	"github.com/nicobistolfi/vigilante/internal/environment"
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
@@ -88,6 +90,11 @@ type App struct {
 	clock  func() time.Time
 	env    *environment.Environment
 
+	issueTracker backend.IssueTracker
+	labelManager backend.LabelManager
+	prManager    backend.PullRequestManager
+	rateLimiter  backend.RateLimiter
+
 	sessionMu                 sync.Mutex
 	sessionWG                 sync.WaitGroup
 	cancelMu                  sync.Mutex
@@ -135,6 +142,18 @@ func New() *App {
 	if err != nil {
 		logger = logging.Discard()
 	}
+	runner := environment.LoggingRunner{
+		Base:             environment.ExecRunner{},
+		CaptureCommand:   telemetry.CaptureInternalCommand,
+		AccessLog:        store.AppendAccessLogEntry,
+		Logger:           logger,
+		LogSuccessOutput: os.Getenv("VIGILANTE_DEBUG_COMMAND_OUTPUT") == "1",
+	}
+	env := &environment.Environment{
+		OS:     runtime.GOOS,
+		Runner: runner,
+	}
+	ghBackend := githubbackend.NewBackend(&env.Runner)
 	return &App{
 		stdin:                     os.Stdin,
 		stdout:                    os.Stdout,
@@ -142,19 +161,14 @@ func New() *App {
 		state:                     store,
 		logger:                    logger,
 		clock:                     time.Now().UTC,
+		issueTracker:              ghBackend,
+		labelManager:              ghBackend,
+		prManager:                 ghBackend,
+		rateLimiter:               ghBackend,
 		cancels:                   make(map[string]context.CancelFunc),
 		repoLabelsProvisionedOnce: make(map[string]bool),
 		proxyExec:                 runProxyBinary,
-		env: &environment.Environment{
-			OS: runtime.GOOS,
-			Runner: environment.LoggingRunner{
-				Base:             environment.ExecRunner{},
-				CaptureCommand:   telemetry.CaptureInternalCommand,
-				AccessLog:        store.AppendAccessLogEntry,
-				Logger:           logger,
-				LogSuccessOutput: os.Getenv("VIGILANTE_DEBUG_COMMAND_OUTPUT") == "1",
-			},
-		},
+		env:                       env,
 	}
 }
 
@@ -165,7 +179,7 @@ func (a *App) loadIssueDetailsForScan(ctx context.Context, cache scanIssueDetail
 			return details, nil
 		}
 	}
-	details, err := ghcli.GetIssueDetails(ctx, a.env.Runner, repo, issueNumber)
+	details, err := a.issueTracker.GetWorkItemDetails(ctx, repo, issueNumber)
 	if err != nil {
 		return nil, err
 	}
@@ -177,16 +191,16 @@ func (a *App) loadIssueDetailsForScan(ctx context.Context, cache scanIssueDetail
 
 func (a *App) loadPullRequestForSession(ctx context.Context, session state.Session) (*ghcli.PullRequest, error) {
 	if session.PullRequestNumber > 0 {
-		return ghcli.GetPullRequestDetails(ctx, a.env.Runner, session.Repo, session.PullRequestNumber)
+		return a.prManager.GetPullRequestDetails(ctx, session.Repo, session.PullRequestNumber)
 	}
 	if strings.TrimSpace(session.Branch) == "" {
 		return nil, nil
 	}
-	pr, err := ghcli.FindPullRequestForBranch(ctx, a.env.Runner, session.Repo, session.Branch)
+	pr, err := a.prManager.FindPullRequestForBranch(ctx, session.Repo, session.Branch)
 	if err != nil || pr == nil {
 		return pr, err
 	}
-	return ghcli.GetPullRequestDetails(ctx, a.env.Runner, session.Repo, pr.Number)
+	return a.prManager.GetPullRequestDetails(ctx, session.Repo, pr.Number)
 }
 
 func (a *App) reconcileStaleRunningSession(ctx context.Context, session *state.Session, issueCache scanIssueDetailsCache, reason string, commentOnRecovery bool) (bool, error) {
@@ -349,7 +363,7 @@ func (a *App) emitGitHubRateLimitEvent(state string, snapshot ghcli.RateLimitSna
 
 func (a *App) commentOnIssue(ctx context.Context, repo string, issue int, body string, commentType string, source string) error {
 	ctx = a.withIssueAccessLogContext(ctx, "", repo, issue, "", "")
-	if err := ghcli.CommentOnIssue(ctx, a.env.Runner, repo, issue, body); err != nil {
+	if err := a.issueTracker.CommentOnWorkItem(ctx, repo, issue, body); err != nil {
 		return err
 	}
 	a.emitCommentEvent(commentType, source)
@@ -1331,7 +1345,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 			a.logger.Info("scan repo start", "repo", target.Repo, "path", target.Path, "max_parallel", target.MaxParallel)
 			resolvedAssignee, ok := resolvedAssignees[target.Assignee]
 			if !ok {
-				resolvedAssignee, err = ghcli.ResolveAssignee(targetCtx, a.env.Runner, target.Assignee)
+				resolvedAssignee, err = a.issueTracker.ResolveAssignee(targetCtx, target.Assignee)
 				if err == nil {
 					resolvedAssignees[target.Assignee] = resolvedAssignee
 				}
@@ -1342,7 +1356,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 				fmt.Fprintf(a.stdout, "repo: %s scan failed: %s\n", target.Repo, summarizeText(err.Error()))
 				continue
 			}
-			issues, err := ghcli.ListOpenIssuesForAssignee(targetCtx, a.env.Runner, target.Repo, resolvedAssignee)
+			issues, err := a.issueTracker.ListOpenWorkItems(targetCtx, target.Repo, resolvedAssignee)
 			target.LastScanAt = a.clock().Format(time.RFC3339)
 			if err != nil {
 				a.logger.Error("scan repo issues failed", "repo", target.Repo, "err", err)
@@ -1637,7 +1651,7 @@ func (a *App) enforceGitHubRateLimit(ctx context.Context, sessions []state.Sessi
 		a.logger.Info("github rate limit pause expired; refreshing snapshot")
 	}
 
-	snapshot, err := ghcli.GetRateLimitSnapshot(ctx, a.env.Runner)
+	snapshot, err := a.rateLimiter.GetRateLimitSnapshot(ctx)
 	if err != nil {
 		a.logger.Error("github rate limit fetch failed", "err", err)
 		if cachedActive {
@@ -1782,7 +1796,7 @@ func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session
 			continue
 		}
 
-		pr, err := ghcli.FindPullRequestForBranch(sessionCtx, a.env.Runner, session.Repo, session.Branch)
+		pr, err := a.prManager.FindPullRequestForBranch(sessionCtx, session.Repo, session.Branch)
 		if err != nil {
 			session.LastMaintenanceError = err.Error()
 			session.UpdatedAt = a.clock().Format(time.RFC3339)
@@ -1919,7 +1933,7 @@ func (a *App) launchIssueSession(ctx context.Context, target state.WatchTarget, 
 		defer a.sessionWG.Done()
 		defer a.clearSessionCancel(key)
 
-		result := issuerunner.RunIssueSession(runCtx, a.env, a.state, target, issue, session)
+		result := issuerunner.RunIssueSession(runCtx, a.env, a.state, a.issueTracker, target, issue, session)
 
 		a.sessionMu.Lock()
 		defer a.sessionMu.Unlock()
@@ -1985,7 +1999,7 @@ func (a *App) maintainOpenPullRequest(ctx context.Context, session *state.Sessio
 		return nil, nil, errors.New("worktree is not clean before PR maintenance")
 	}
 
-	details, err := ghcli.GetPullRequestDetails(ctx, a.env.Runner, session.Repo, pr.Number)
+	details, err := a.prManager.GetPullRequestDetails(ctx, session.Repo, pr.Number)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2073,7 +2087,7 @@ func (a *App) maintainOpenPullRequest(ctx context.Context, session *state.Sessio
 func (a *App) dispatchConflictResolution(ctx context.Context, session *state.Session, pr ghcli.PullRequest, issueDetails *ghcli.IssueDetails) error {
 	if issueDetails == nil {
 		var err error
-		issueDetails, err = ghcli.GetIssueDetails(ctx, a.env.Runner, session.Repo, session.IssueNumber)
+		issueDetails, err = a.issueTracker.GetWorkItemDetails(ctx, session.Repo, session.IssueNumber)
 		if err != nil {
 			return err
 		}
@@ -2104,7 +2118,7 @@ func (a *App) dispatchConflictResolution(ctx context.Context, session *state.Ses
 	}
 
 	target := watchTargetForSession(*session, a.fallbackWatchTargetForSession(*session))
-	if conflictErr := issuerunner.RunConflictResolutionSession(ctx, a.env, a.state, target, *session, pr); conflictErr != nil {
+	if conflictErr := issuerunner.RunConflictResolutionSession(ctx, a.env, a.state, a.issueTracker, target, *session, pr); conflictErr != nil {
 		return conflictErr
 	}
 
@@ -2149,7 +2163,7 @@ func (a *App) tryAutoSquashMerge(ctx context.Context, session *state.Session, pr
 		return nil
 	}
 
-	if err := ghcli.MergePullRequestSquash(ctx, a.env.Runner, session.Repo, pr.Number); err != nil {
+	if err := a.prManager.MergePullRequest(ctx, session.Repo, pr.Number); err != nil {
 		return fmt.Errorf("squash automerge pr #%d: %w", pr.Number, err)
 	}
 
@@ -2279,7 +2293,7 @@ func (a *App) handleFailingPullRequestChecks(ctx context.Context, session *state
 	a.commentOnIssueBestEffort(ctx, session.Repo, session.IssueNumber, startBody, "ci remediation start")
 
 	target := watchTargetForSession(*session, a.fallbackWatchTargetForSession(*session))
-	if err := issuerunner.RunCIRemediationSession(ctx, a.env, a.state, target, *session, pr, failingChecks); err != nil {
+	if err := issuerunner.RunCIRemediationSession(ctx, a.env, a.state, a.issueTracker, target, *session, pr, failingChecks); err != nil {
 		blocked := classifyBlockedReason("ci_remediation", "coding agent remediation", err)
 		markSessionBlocked(session, "ci_remediation", blocked, a.clock())
 		session.LastMaintenanceError = err.Error()
@@ -2358,7 +2372,7 @@ func (a *App) processGitHubCleanupRequests(ctx context.Context, sessions []state
 			continue
 		}
 
-		comments, err := ghcli.ListIssueCommentsForPolling(ctx, a.env.Runner, session.Repo, session.IssueNumber, "cleanup", a.logger)
+		comments, err := a.issueTracker.ListWorkItemCommentsForPolling(ctx, session.Repo, session.IssueNumber, "cleanup", a.logger)
 		if err != nil {
 			a.logger.Error("cleanup comment lookup failed", "repo", session.Repo, "issue", session.IssueNumber, "err", err)
 			session.LastError = err.Error()
@@ -2369,7 +2383,7 @@ func (a *App) processGitHubCleanupRequests(ctx context.Context, sessions []state
 		if comment == nil {
 			continue
 		}
-		if err := ghcli.AddIssueCommentReaction(ctx, a.env.Runner, session.Repo, comment.ID, "+1"); err != nil {
+		if err := a.issueTracker.AddCommentReaction(ctx, session.Repo, comment.ID, "+1"); err != nil {
 			a.logger.Error("cleanup reaction failed", "repo", session.Repo, "issue", session.IssueNumber, "comment", comment.ID, "err", err)
 			session.LastError = err.Error()
 			session.UpdatedAt = a.clock().Format(time.RFC3339)
@@ -2420,7 +2434,7 @@ func (a *App) processGitHubRecreateRequests(ctx context.Context, sessions []stat
 			continue
 		}
 
-		comments, err := ghcli.ListIssueCommentsForPolling(ctx, a.env.Runner, session.Repo, session.IssueNumber, "recreate", a.logger)
+		comments, err := a.issueTracker.ListWorkItemCommentsForPolling(ctx, session.Repo, session.IssueNumber, "recreate", a.logger)
 		if err != nil {
 			a.logger.Error("recreate comment lookup failed", "repo", session.Repo, "issue", session.IssueNumber, "err", err)
 			session.LastError = err.Error()
@@ -2431,7 +2445,7 @@ func (a *App) processGitHubRecreateRequests(ctx context.Context, sessions []stat
 		if comment == nil {
 			continue
 		}
-		if err := ghcli.AddIssueCommentReaction(ctx, a.env.Runner, session.Repo, comment.ID, "eyes"); err != nil {
+		if err := a.issueTracker.AddCommentReaction(ctx, session.Repo, comment.ID, "eyes"); err != nil {
 			a.logger.Error("recreate reaction failed", "repo", session.Repo, "issue", session.IssueNumber, "comment", comment.ID, "err", err)
 			session.LastError = err.Error()
 			session.UpdatedAt = a.clock().Format(time.RFC3339)
@@ -2473,7 +2487,7 @@ func (a *App) recreateSessionInline(ctx context.Context, session *state.Session,
 	repoSlug := session.Repo
 	issue := session.IssueNumber
 
-	details, err := ghcli.GetIssueDetails(ctx, a.env.Runner, repoSlug, issue)
+	details, err := a.issueTracker.GetWorkItemDetails(ctx, repoSlug, issue)
 	if err != nil {
 		return fmt.Errorf("get issue details: %w", err)
 	}
@@ -2491,7 +2505,7 @@ func (a *App) recreateSessionInline(ctx context.Context, session *state.Session,
 	}
 
 	newBody := details.Body + fmt.Sprintf("\n\n---\n_Recreated from #%d by Vigilante._", issue)
-	created, err := ghcli.CreateIssue(ctx, a.env.Runner, repoSlug, details.Title, newBody, labelNames, assigneeLogins)
+	created, err := a.issueTracker.CreateWorkItem(ctx, repoSlug, details.Title, newBody, labelNames, assigneeLogins)
 	if err != nil {
 		return fmt.Errorf("create replacement issue: %w", err)
 	}
@@ -2499,7 +2513,7 @@ func (a *App) recreateSessionInline(ctx context.Context, session *state.Session,
 	crossLinkBody := fmt.Sprintf("## ♻️ Issue Recreated\n\nThis issue has been recreated as #%d.\n\nThe original issue is being closed as `not planned` and stale artifacts are being cleaned up.\n\nSource: `%s`.", created.Number, source)
 	a.commentOnIssueBestEffort(ctx, repoSlug, issue, crossLinkBody, "recreate cross-link")
 
-	if err := ghcli.CloseIssueNotPlanned(ctx, a.env.Runner, repoSlug, issue); err != nil {
+	if err := a.issueTracker.CloseWorkItem(ctx, repoSlug, issue); err != nil {
 		return fmt.Errorf("close original issue: %w", err)
 	}
 
@@ -2508,13 +2522,13 @@ func (a *App) recreateSessionInline(ctx context.Context, session *state.Session,
 	var cleanupErrors []string
 
 	if session.PullRequestNumber > 0 {
-		if err := ghcli.ClosePullRequest(ctx, a.env.Runner, repoSlug, session.PullRequestNumber); err != nil {
+		if err := a.prManager.ClosePullRequest(ctx, repoSlug, session.PullRequestNumber); err != nil {
 			cleanupErrors = append(cleanupErrors, fmt.Sprintf("close PR #%d: %s", session.PullRequestNumber, err))
 		}
 	}
 
 	if session.Branch != "" {
-		if err := ghcli.DeleteRemoteBranch(ctx, a.env.Runner, session.RepoPath, session.Branch); err != nil {
+		if err := a.prManager.DeleteRemoteBranch(ctx, session.RepoPath, session.Branch); err != nil {
 			cleanupErrors = append(cleanupErrors, fmt.Sprintf("delete remote branch %s: %s", session.Branch, err))
 		}
 	}
@@ -2570,7 +2584,7 @@ func (a *App) processGitHubResumeRequests(ctx context.Context, sessions []state.
 			labelRemovalFailed := false
 			for _, label := range []string{"resume", "vigilante:resume"} {
 				if ghcli.HasAnyLabel(details.Labels, label) {
-					if err := ghcli.RemoveIssueLabel(ctx, a.env.Runner, session.Repo, session.IssueNumber, label); err != nil {
+					if err := a.labelManager.RemoveWorkItemLabel(ctx, session.Repo, session.IssueNumber, label); err != nil {
 						a.recordSessionFailure(session, fallbackText(session.BlockedStage, "issue_execution"), "gh issue edit --remove-label", err)
 						a.logger.Error("resume label removal failed", "repo", session.Repo, "issue", session.IssueNumber, "label", label, "err", err)
 						labelRemovalFailed = true
@@ -2590,7 +2604,7 @@ func (a *App) processGitHubResumeRequests(ctx context.Context, sessions []state.
 			continue
 		}
 
-		comments, err := ghcli.ListIssueCommentsForPolling(ctx, a.env.Runner, session.Repo, session.IssueNumber, "resume", a.logger)
+		comments, err := a.issueTracker.ListWorkItemCommentsForPolling(ctx, session.Repo, session.IssueNumber, "resume", a.logger)
 		if err != nil {
 			a.recordSessionFailure(session, fallbackText(session.BlockedStage, "issue_execution"), "gh issue comments", err)
 			a.logger.Error("resume comment lookup failed", "repo", session.Repo, "issue", session.IssueNumber, "err", err)
@@ -2600,7 +2614,7 @@ func (a *App) processGitHubResumeRequests(ctx context.Context, sessions []state.
 		if comment == nil {
 			continue
 		}
-		if err := ghcli.AddIssueCommentReaction(ctx, a.env.Runner, session.Repo, comment.ID, "eyes"); err != nil {
+		if err := a.issueTracker.AddCommentReaction(ctx, session.Repo, comment.ID, "eyes"); err != nil {
 			a.recordSessionFailure(session, fallbackText(session.BlockedStage, "issue_execution"), "gh api issue comment reactions", err)
 			a.logger.Error("resume reaction failed", "repo", session.Repo, "issue", session.IssueNumber, "comment", comment.ID, "err", err)
 			continue
@@ -2786,7 +2800,11 @@ func (a *App) RedispatchSession(ctx context.Context, repoSlug string, issue int,
 		break
 	}
 
-	issues, err := ghcli.ListOpenIssues(ctx, a.env.Runner, target.Repo, target.Assignee)
+	resolvedAssignee, err := a.issueTracker.ResolveAssignee(ctx, target.Assignee)
+	if err != nil {
+		return err
+	}
+	issues, err := a.issueTracker.ListOpenWorkItems(ctx, target.Repo, resolvedAssignee)
 	if err != nil {
 		return err
 	}
@@ -2873,7 +2891,7 @@ func (a *App) RecreateSession(ctx context.Context, repoSlug string, issue int, s
 		return fmt.Errorf("watch target not found for %s", repoSlug)
 	}
 
-	details, err := ghcli.GetIssueDetails(ctx, a.env.Runner, repoSlug, issue)
+	details, err := a.issueTracker.GetWorkItemDetails(ctx, repoSlug, issue)
 	if err != nil {
 		return fmt.Errorf("get issue details: %w", err)
 	}
@@ -2892,7 +2910,7 @@ func (a *App) RecreateSession(ctx context.Context, repoSlug string, issue int, s
 	}
 
 	newBody := details.Body + fmt.Sprintf("\n\n---\n_Recreated from #%d by Vigilante._", issue)
-	created, err := ghcli.CreateIssue(ctx, a.env.Runner, repoSlug, details.Title, newBody, labelNames, assigneeLogins)
+	created, err := a.issueTracker.CreateWorkItem(ctx, repoSlug, details.Title, newBody, labelNames, assigneeLogins)
 	if err != nil {
 		return fmt.Errorf("create replacement issue: %w", err)
 	}
@@ -2901,7 +2919,7 @@ func (a *App) RecreateSession(ctx context.Context, repoSlug string, issue int, s
 	crossLinkBody := fmt.Sprintf("## ♻️ Issue Recreated\n\nThis issue has been recreated as #%d.\n\nThe original issue is being closed as `not planned` and stale artifacts are being cleaned up.\n\nSource: `%s`.", created.Number, source)
 	a.commentOnIssueBestEffort(ctx, repoSlug, issue, crossLinkBody, "recreate cross-link")
 
-	if err := ghcli.CloseIssueNotPlanned(ctx, a.env.Runner, repoSlug, issue); err != nil {
+	if err := a.issueTracker.CloseWorkItem(ctx, repoSlug, issue); err != nil {
 		return fmt.Errorf("close original issue: %w", err)
 	}
 
@@ -2923,14 +2941,14 @@ func (a *App) RecreateSession(ctx context.Context, repoSlug string, issue int, s
 
 		// Close PR if one exists.
 		if session.PullRequestNumber > 0 {
-			if err := ghcli.ClosePullRequest(ctx, a.env.Runner, repoSlug, session.PullRequestNumber); err != nil {
+			if err := a.prManager.ClosePullRequest(ctx, repoSlug, session.PullRequestNumber); err != nil {
 				cleanupErrors = append(cleanupErrors, fmt.Sprintf("close PR #%d: %s", session.PullRequestNumber, err))
 			}
 		}
 
 		// Delete remote branch.
 		if session.Branch != "" {
-			if err := ghcli.DeleteRemoteBranch(ctx, a.env.Runner, session.RepoPath, session.Branch); err != nil {
+			if err := a.prManager.DeleteRemoteBranch(ctx, session.RepoPath, session.Branch); err != nil {
 				cleanupErrors = append(cleanupErrors, fmt.Sprintf("delete remote branch %s: %s", session.Branch, err))
 			}
 		}
@@ -3242,7 +3260,7 @@ func (a *App) preflightResume(ctx context.Context, session state.Session) error 
 		if _, err := a.env.Runner.Run(ctx, "", "gh", "auth", "status"); err != nil {
 			return err
 		}
-		_, err = ghcli.GetIssueDetails(ctx, a.env.Runner, session.Repo, session.IssueNumber)
+		_, err = a.issueTracker.GetWorkItemDetails(ctx, session.Repo, session.IssueNumber)
 		return err
 	case "provider_missing":
 		_, err = a.env.Runner.LookPath(tool)
@@ -3260,7 +3278,7 @@ func (a *App) preflightResume(ctx context.Context, session state.Session) error 
 
 func (a *App) resumeBlockedMaintenance(ctx context.Context, session *state.Session) error {
 	ctx = withSessionAccessLogContext(ctx, "maintenance", *session)
-	pr, err := ghcli.FindPullRequestForBranch(ctx, a.env.Runner, session.Repo, session.Branch)
+	pr, err := a.prManager.FindPullRequestForBranch(ctx, session.Repo, session.Branch)
 	if err != nil {
 		return err
 	}
@@ -3325,7 +3343,7 @@ func (a *App) resumeBlockedIssueExecution(ctx context.Context, session *state.Se
 }
 
 func (a *App) resumeBlockedConflictResolution(ctx context.Context, session *state.Session) error {
-	pr, err := ghcli.FindPullRequestForBranch(ctx, a.env.Runner, session.Repo, session.Branch)
+	pr, err := a.prManager.FindPullRequestForBranch(ctx, session.Repo, session.Branch)
 	if err != nil {
 		return err
 	}
@@ -3336,7 +3354,7 @@ func (a *App) resumeBlockedConflictResolution(ctx context.Context, session *stat
 		session.PullRequestBaseBranch = strings.TrimSpace(pr.BaseRefName)
 	}
 	target := watchTargetForSession(*session, a.fallbackWatchTargetForSession(*session))
-	if err := issuerunner.RunConflictResolutionSession(ctx, a.env, a.state, target, *session, *pr); err != nil {
+	if err := issuerunner.RunConflictResolutionSession(ctx, a.env, a.state, a.issueTracker, target, *session, *pr); err != nil {
 		return err
 	}
 	session.Status = state.SessionStatusSuccess
@@ -3420,7 +3438,7 @@ func maintenanceAutoRecoveryTimeout(config state.ServiceConfig) time.Duration {
 }
 
 func (a *App) blockedSessionExceededInactivityTimeout(ctx context.Context, session state.Session, timeout time.Duration) (bool, error) {
-	comments, err := ghcli.ListIssueCommentsForPolling(ctx, a.env.Runner, session.Repo, session.IssueNumber, "blocked-inactivity", a.logger)
+	comments, err := a.issueTracker.ListWorkItemCommentsForPolling(ctx, session.Repo, session.IssueNumber, "blocked-inactivity", a.logger)
 	if err != nil {
 		return false, err
 	}
@@ -3490,7 +3508,7 @@ func shouldAutoRecoverBlockedSession(session state.Session) bool {
 }
 
 func (a *App) autoRecoverBlockedMaintenanceSession(ctx context.Context, session *state.Session, timeout time.Duration) error {
-	pr, err := ghcli.FindPullRequestForBranch(ctx, a.env.Runner, session.Repo, session.Branch)
+	pr, err := a.prManager.FindPullRequestForBranch(ctx, session.Repo, session.Branch)
 	if err != nil {
 		return err
 	}
@@ -4088,7 +4106,7 @@ func (a *App) processGitHubIterationRequestsForTarget(ctx context.Context, targe
 			continue
 		}
 
-		comments, err := ghcli.ListIssueCommentsForPolling(ctx, a.env.Runner, session.Repo, session.IssueNumber, "iteration", a.logger)
+		comments, err := a.issueTracker.ListWorkItemCommentsForPolling(ctx, session.Repo, session.IssueNumber, "iteration", a.logger)
 		if err != nil {
 			a.logger.Error("iteration comment lookup failed", "repo", session.Repo, "issue", session.IssueNumber, "err", err)
 			session.LastError = err.Error()
@@ -4127,7 +4145,7 @@ func (a *App) processGitHubIterationRequestsForTarget(ctx context.Context, targe
 			continue
 		}
 
-		if err := ghcli.AddIssueCommentReaction(ctx, a.env.Runner, session.Repo, comment.ID, "eyes"); err != nil {
+		if err := a.issueTracker.AddCommentReaction(ctx, session.Repo, comment.ID, "eyes"); err != nil {
 			a.logger.Error("iteration reaction failed", "repo", session.Repo, "issue", session.IssueNumber, "comment", comment.ID, "err", err)
 		}
 
@@ -4381,13 +4399,13 @@ func (a *App) syncSessionIssueLabels(ctx context.Context, session *state.Session
 		return nil
 	}
 	if pr == nil && session.PullRequestNumber > 0 && strings.TrimSpace(session.PullRequestMergedAt) == "" {
-		details, err := ghcli.GetPullRequestDetails(ctx, a.env.Runner, session.Repo, session.PullRequestNumber)
+		details, err := a.prManager.GetPullRequestDetails(ctx, session.Repo, session.PullRequestNumber)
 		if err == nil {
 			pr = details
 		}
 	}
 	if pr != nil && pr.MergedAt == nil && pr.Number > 0 && len(pr.Labels) == 0 && pr.ReviewDecision == "" && !pr.IsDraft && pr.MergeStateStatus == "" && len(pr.StatusCheckRollup) == 0 {
-		details, err := ghcli.GetPullRequestDetails(ctx, a.env.Runner, session.Repo, pr.Number)
+		details, err := a.prManager.GetPullRequestDetails(ctx, session.Repo, pr.Number)
 		if err == nil {
 			pr = details
 		}
@@ -4415,7 +4433,7 @@ func (a *App) syncIssueManagedLabels(ctx context.Context, repo string, issueNumb
 		issueDetails = details
 	}
 	toAdd, toRemove := ghcli.PlanIssueLabelSync(issueDetails.Labels, desired, managedIssueLabels)
-	if err := ghcli.SyncIssueLabels(ctx, a.env.Runner, repo, issueNumber, issueDetails.Labels, desired, managedIssueLabels); err != nil {
+	if err := a.labelManager.SyncWorkItemLabels(ctx, repo, issueNumber, issueDetails.Labels, desired, managedIssueLabels); err != nil {
 		return err
 	}
 	a.emitLabelSyncEvent(toAdd, toRemove)
@@ -4439,7 +4457,7 @@ func (a *App) ensureRepositoryLabelsProvisioned(ctx context.Context, repo string
 	if err != nil {
 		return fmt.Errorf("load Vigilante label manifest: %w", err)
 	}
-	if err := ghcli.EnsureRepositoryLabels(ctx, a.env.Runner, repo, labels); err != nil {
+	if err := a.labelManager.EnsureProjectLabels(ctx, repo, labels); err != nil {
 		return fmt.Errorf("provision Vigilante labels for repo %s: %w", repo, err)
 	}
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	githubbackend "github.com/nicobistolfi/vigilante/internal/backend/github"
 	"github.com/nicobistolfi/vigilante/internal/environment"
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
 	"github.com/nicobistolfi/vigilante/internal/repo"
@@ -71,15 +72,21 @@ func TestMaintainOpenPullRequestPropagatesAccessLogContext(t *testing.T) {
 			entries = append(entries, entry)
 		},
 	}
+	env := &environment.Environment{
+		OS:     "linux",
+		Runner: runner,
+	}
+	ghBackend := githubbackend.NewBackend(&env.Runner)
 	app := &App{
-		stdout: testutil.IODiscard{},
-		stderr: testutil.IODiscard{},
-		clock:  func() time.Time { return time.Date(2026, 3, 26, 20, 0, 0, 0, time.UTC) },
-		state:  store,
-		env: &environment.Environment{
-			OS:     "linux",
-			Runner: runner,
-		},
+		stdout:       testutil.IODiscard{},
+		stderr:       testutil.IODiscard{},
+		clock:        func() time.Time { return time.Date(2026, 3, 26, 20, 0, 0, 0, time.UTC) },
+		state:        store,
+		issueTracker: ghBackend,
+		labelManager: ghBackend,
+		prManager:    ghBackend,
+		rateLimiter:  ghBackend,
+		env:          env,
 	}
 	session := &state.Session{
 		Repo:         "owner/repo",

--- a/internal/backend/backend_test.go
+++ b/internal/backend/backend_test.go
@@ -1,0 +1,84 @@
+package backend
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBackendIDConstants(t *testing.T) {
+	if BackendGitHub != "github" {
+		t.Fatalf("unexpected GitHub backend ID: %q", BackendGitHub)
+	}
+	if BackendLinear != "linear" {
+		t.Fatalf("unexpected Linear backend ID: %q", BackendLinear)
+	}
+	if BackendJira != "jira" {
+		t.Fatalf("unexpected Jira backend ID: %q", BackendJira)
+	}
+}
+
+func TestWorkItemTypeCompatibility(t *testing.T) {
+	item := WorkItem{
+		Number:    42,
+		Title:     "Test issue",
+		CreatedAt: time.Date(2026, 3, 10, 12, 0, 0, 0, time.UTC),
+		URL:       "https://example.com/issues/42",
+		Labels:    []Label{{Name: "bug"}},
+	}
+	if item.Number != 42 {
+		t.Fatal("WorkItem.Number mismatch")
+	}
+	if item.Labels[0].Name != "bug" {
+		t.Fatal("WorkItem.Labels mismatch")
+	}
+}
+
+func TestPullRequestTypeCompatibility(t *testing.T) {
+	merged := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	pr := PullRequest{
+		Number:           1,
+		Title:            "Fix bug",
+		State:            "MERGED",
+		MergedAt:         &merged,
+		Mergeable:        "MERGEABLE",
+		MergeStateStatus: "CLEAN",
+		ReviewDecision:   "APPROVED",
+		StatusCheckRollup: []StatusCheck{
+			{Name: "ci", State: "SUCCESS", Conclusion: "success"},
+		},
+	}
+	if pr.Number != 1 {
+		t.Fatal("PullRequest.Number mismatch")
+	}
+	if pr.MergedAt == nil {
+		t.Fatal("PullRequest.MergedAt should not be nil")
+	}
+	if len(pr.StatusCheckRollup) != 1 {
+		t.Fatal("PullRequest.StatusCheckRollup length mismatch")
+	}
+}
+
+func TestWorkItemDetailsContainsExpectedFields(t *testing.T) {
+	details := WorkItemDetails{
+		Title:     "Test",
+		Body:      "body",
+		URL:       "url",
+		State:     "open",
+		Labels:    []Label{{Name: "enhancement"}},
+		Assignees: []UserRef{{Login: "user1"}},
+	}
+	if details.Title != "Test" || len(details.Assignees) != 1 {
+		t.Fatal("WorkItemDetails field mismatch")
+	}
+}
+
+func TestWorkItemCommentHasNestedUserField(t *testing.T) {
+	comment := WorkItemComment{
+		ID:   123,
+		Body: "test comment",
+	}
+	comment.User.Login = "testuser"
+	if comment.User.Login != "testuser" {
+		t.Fatal("WorkItemComment.User.Login mismatch")
+	}
+}

--- a/internal/backend/github/github.go
+++ b/internal/backend/github/github.go
@@ -1,0 +1,125 @@
+package github
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/nicobistolfi/vigilante/internal/backend"
+	"github.com/nicobistolfi/vigilante/internal/environment"
+	ghcli "github.com/nicobistolfi/vigilante/internal/github"
+)
+
+// Backend implements the backend interfaces for GitHub using the gh CLI.
+// It wraps the existing internal/github (ghcli) functions to provide
+// a clean interface boundary for the orchestration loop.
+type Backend struct {
+	runnerRef *environment.Runner
+}
+
+// NewBackend creates a GitHub backend that reads the runner from the given
+// pointer on each call. This allows the runner to be replaced after creation
+// (e.g., in tests) without rebuilding the backend.
+func NewBackend(runner *environment.Runner) *Backend {
+	return &Backend{runnerRef: runner}
+}
+
+func (b *Backend) runner() environment.Runner {
+	return *b.runnerRef
+}
+
+// Verify interface compliance at compile time.
+var (
+	_ backend.IssueTracker       = (*Backend)(nil)
+	_ backend.LabelManager       = (*Backend)(nil)
+	_ backend.PullRequestManager = (*Backend)(nil)
+	_ backend.RateLimiter        = (*Backend)(nil)
+)
+
+// ID returns the GitHub backend identifier.
+func (b *Backend) ID() backend.BackendID {
+	return backend.BackendGitHub
+}
+
+// --- IssueTracker ---
+
+func (b *Backend) ResolveAssignee(ctx context.Context, assignee string) (string, error) {
+	return ghcli.ResolveAssignee(ctx, b.runner(), assignee)
+}
+
+func (b *Backend) ListOpenWorkItems(ctx context.Context, project string, assignee string) ([]backend.WorkItem, error) {
+	return ghcli.ListOpenIssuesForAssignee(ctx, b.runner(), project, assignee)
+}
+
+func (b *Backend) GetWorkItemDetails(ctx context.Context, project string, number int) (*backend.WorkItemDetails, error) {
+	return ghcli.GetIssueDetails(ctx, b.runner(), project, number)
+}
+
+func (b *Backend) ListWorkItemComments(ctx context.Context, project string, number int) ([]backend.WorkItemComment, error) {
+	return ghcli.ListIssueComments(ctx, b.runner(), project, number)
+}
+
+func (b *Backend) ListWorkItemCommentsForPolling(ctx context.Context, project string, number int, purpose string, logger *slog.Logger) ([]backend.WorkItemComment, error) {
+	return ghcli.ListIssueCommentsForPolling(ctx, b.runner(), project, number, purpose, logger)
+}
+
+func (b *Backend) CommentOnWorkItem(ctx context.Context, project string, number int, body string) error {
+	return ghcli.CommentOnIssue(ctx, b.runner(), project, number, body)
+}
+
+func (b *Backend) AddCommentReaction(ctx context.Context, project string, commentID int64, content string) error {
+	return ghcli.AddIssueCommentReaction(ctx, b.runner(), project, commentID, content)
+}
+
+func (b *Backend) CreateWorkItem(ctx context.Context, project string, title string, body string, labels []string, assignees []string) (*backend.CreatedWorkItem, error) {
+	return ghcli.CreateIssue(ctx, b.runner(), project, title, body, labels, assignees)
+}
+
+func (b *Backend) CloseWorkItem(ctx context.Context, project string, number int) error {
+	return ghcli.CloseIssueNotPlanned(ctx, b.runner(), project, number)
+}
+
+func (b *Backend) IsWorkItemUnavailable(err error) bool {
+	return ghcli.IsIssueUnavailableError(err)
+}
+
+// --- LabelManager ---
+
+func (b *Backend) EnsureProjectLabels(ctx context.Context, project string, desired []backend.RepositoryLabelSpec) error {
+	return ghcli.EnsureRepositoryLabels(ctx, b.runner(), project, desired)
+}
+
+func (b *Backend) SyncWorkItemLabels(ctx context.Context, project string, number int, current []backend.Label, desired []string, managed []string) error {
+	return ghcli.SyncIssueLabels(ctx, b.runner(), project, number, current, desired, managed)
+}
+
+func (b *Backend) RemoveWorkItemLabel(ctx context.Context, project string, number int, label string) error {
+	return ghcli.RemoveIssueLabel(ctx, b.runner(), project, number, label)
+}
+
+// --- PullRequestManager ---
+
+func (b *Backend) FindPullRequestForBranch(ctx context.Context, repo string, branch string) (*backend.PullRequest, error) {
+	return ghcli.FindPullRequestForBranch(ctx, b.runner(), repo, branch)
+}
+
+func (b *Backend) GetPullRequestDetails(ctx context.Context, repo string, number int) (*backend.PullRequest, error) {
+	return ghcli.GetPullRequestDetails(ctx, b.runner(), repo, number)
+}
+
+func (b *Backend) MergePullRequest(ctx context.Context, repo string, number int) error {
+	return ghcli.MergePullRequestSquash(ctx, b.runner(), repo, number)
+}
+
+func (b *Backend) ClosePullRequest(ctx context.Context, repo string, number int) error {
+	return ghcli.ClosePullRequest(ctx, b.runner(), repo, number)
+}
+
+func (b *Backend) DeleteRemoteBranch(ctx context.Context, repoPath string, branch string) error {
+	return ghcli.DeleteRemoteBranch(ctx, b.runner(), repoPath, branch)
+}
+
+// --- RateLimiter ---
+
+func (b *Backend) GetRateLimitSnapshot(ctx context.Context) (backend.RateLimitSnapshot, error) {
+	return ghcli.GetRateLimitSnapshot(ctx, b.runner())
+}

--- a/internal/backend/github/github_test.go
+++ b/internal/backend/github/github_test.go
@@ -1,0 +1,93 @@
+package github
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nicobistolfi/vigilante/internal/backend"
+	"github.com/nicobistolfi/vigilante/internal/environment"
+	"github.com/nicobistolfi/vigilante/internal/testutil"
+)
+
+func newTestBackend(runner environment.Runner) *Backend {
+	return NewBackend(&runner)
+}
+
+func TestBackendImplementsIssueTracker(t *testing.T) {
+	b := newTestBackend(testutil.FakeRunner{})
+	var _ backend.IssueTracker = b
+	if b.ID() != backend.BackendGitHub {
+		t.Fatalf("expected backend ID %q, got %q", backend.BackendGitHub, b.ID())
+	}
+}
+
+func TestBackendImplementsLabelManager(t *testing.T) {
+	b := newTestBackend(testutil.FakeRunner{})
+	var _ backend.LabelManager = b
+}
+
+func TestBackendImplementsPullRequestManager(t *testing.T) {
+	b := newTestBackend(testutil.FakeRunner{})
+	var _ backend.PullRequestManager = b
+}
+
+func TestBackendImplementsRateLimiter(t *testing.T) {
+	b := newTestBackend(testutil.FakeRunner{})
+	var _ backend.RateLimiter = b
+}
+
+func TestListOpenWorkItemsDelegatesToGhcli(t *testing.T) {
+	b := newTestBackend(testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh issue list --repo owner/repo --state open --assignee user --json number,title,createdAt,url,labels": `[{"number":1,"title":"test","createdAt":"2026-03-10T12:00:00Z","url":"u1","labels":[]}]`,
+		},
+	})
+	items, err := b.ListOpenWorkItems(context.Background(), "owner/repo", "user")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 || items[0].Number != 1 {
+		t.Fatalf("unexpected items: %#v", items)
+	}
+}
+
+func TestResolveAssigneeDelegatesToGhcli(t *testing.T) {
+	b := newTestBackend(testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api user --jq .login": "testuser\n",
+		},
+	})
+	login, err := b.ResolveAssignee(context.Background(), "me")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if login != "testuser" {
+		t.Fatalf("expected testuser, got %q", login)
+	}
+}
+
+func TestCommentOnWorkItemDelegatesToGhcli(t *testing.T) {
+	b := newTestBackend(testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh issue comment --repo owner/repo 42 --body hello": "",
+		},
+	})
+	if err := b.CommentOnWorkItem(context.Background(), "owner/repo", 42, "hello"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetRateLimitSnapshotDelegatesToGhcli(t *testing.T) {
+	b := newTestBackend(testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api /rate_limit": `{"resources":{"core":{"limit":5000,"remaining":4999,"reset":1700000000},"rate":{},"graphql":{"limit":5000,"remaining":5000,"reset":1700000000},"search":{"limit":30,"remaining":30,"reset":1700000000}}}`,
+		},
+	})
+	snapshot, err := b.GetRateLimitSnapshot(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Core.Remaining != 4999 {
+		t.Fatalf("unexpected core remaining: %d", snapshot.Core.Remaining)
+	}
+}

--- a/internal/backend/interfaces.go
+++ b/internal/backend/interfaces.go
@@ -1,0 +1,92 @@
+package backend
+
+import (
+	"context"
+	"log/slog"
+)
+
+// IssueTracker provides work item operations for a project management backend.
+// The orchestration loop depends on this interface instead of calling
+// GitHub-specific APIs directly.
+type IssueTracker interface {
+	// ID returns the backend identifier (e.g. "github", "linear", "jira").
+	ID() BackendID
+
+	// ResolveAssignee resolves a symbolic assignee reference to a concrete identity.
+	// For GitHub, this resolves "me" to the authenticated user login.
+	ResolveAssignee(ctx context.Context, assignee string) (string, error)
+
+	// ListOpenWorkItems returns open work items for a project, optionally filtered
+	// by assignee. Results are ordered by creation time ascending.
+	ListOpenWorkItems(ctx context.Context, project string, assignee string) ([]WorkItem, error)
+
+	// GetWorkItemDetails fetches the full details for a single work item.
+	GetWorkItemDetails(ctx context.Context, project string, number int) (*WorkItemDetails, error)
+
+	// ListWorkItemComments returns comments on a work item, ordered chronologically.
+	ListWorkItemComments(ctx context.Context, project string, number int) ([]WorkItemComment, error)
+
+	// ListWorkItemCommentsForPolling is a polling-safe variant of ListWorkItemComments
+	// that logs failures without propagating through access logging.
+	ListWorkItemCommentsForPolling(ctx context.Context, project string, number int, purpose string, logger *slog.Logger) ([]WorkItemComment, error)
+
+	// CommentOnWorkItem posts a comment on a work item.
+	CommentOnWorkItem(ctx context.Context, project string, number int, body string) error
+
+	// AddCommentReaction adds a reaction to a comment.
+	AddCommentReaction(ctx context.Context, project string, commentID int64, content string) error
+
+	// CreateWorkItem creates a new work item on the project.
+	CreateWorkItem(ctx context.Context, project string, title string, body string, labels []string, assignees []string) (*CreatedWorkItem, error)
+
+	// CloseWorkItem closes a work item as not planned.
+	CloseWorkItem(ctx context.Context, project string, number int) error
+
+	// IsWorkItemUnavailable checks if an error indicates the work item
+	// no longer exists (e.g. HTTP 404 or 410).
+	IsWorkItemUnavailable(err error) bool
+}
+
+// LabelManager provides label operations on a project management backend.
+// Not all backends support labels; backends that do not support labels
+// should not implement this interface.
+type LabelManager interface {
+	// EnsureProjectLabels creates any labels from desired that do not already
+	// exist on the project.
+	EnsureProjectLabels(ctx context.Context, project string, desired []RepositoryLabelSpec) error
+
+	// SyncWorkItemLabels synchronizes labels on a work item by adding desired
+	// labels and removing stale managed labels.
+	SyncWorkItemLabels(ctx context.Context, project string, number int, current []Label, desired []string, managed []string) error
+
+	// RemoveWorkItemLabel removes a single label from a work item.
+	RemoveWorkItemLabel(ctx context.Context, project string, number int, label string) error
+}
+
+// PullRequestManager provides pull request operations.
+// The issue-tracking backend is allowed to differ from the pull request backend.
+// For example, issues may come from Linear while pull requests remain on GitHub.
+type PullRequestManager interface {
+	// FindPullRequestForBranch finds a PR associated with a branch.
+	FindPullRequestForBranch(ctx context.Context, repo string, branch string) (*PullRequest, error)
+
+	// GetPullRequestDetails fetches full PR metadata by number.
+	GetPullRequestDetails(ctx context.Context, repo string, number int) (*PullRequest, error)
+
+	// MergePullRequest merges a PR using the backend default merge strategy.
+	MergePullRequest(ctx context.Context, repo string, number int) error
+
+	// ClosePullRequest closes a PR without merging.
+	ClosePullRequest(ctx context.Context, repo string, number int) error
+
+	// DeleteRemoteBranch deletes a remote branch from the repository.
+	DeleteRemoteBranch(ctx context.Context, repoPath string, branch string) error
+}
+
+// RateLimiter provides rate limit awareness for backends that enforce API quotas.
+// This is an optional capability. Backends that do not enforce rate limits
+// do not need to implement this interface.
+type RateLimiter interface {
+	// GetRateLimitSnapshot returns the current rate limit state.
+	GetRateLimitSnapshot(ctx context.Context) (RateLimitSnapshot, error)
+}

--- a/internal/backend/types.go
+++ b/internal/backend/types.go
@@ -1,0 +1,133 @@
+package backend
+
+import "time"
+
+// BackendID identifies a project management backend.
+type BackendID string
+
+const (
+	// BackendGitHub is the GitHub backend identifier.
+	BackendGitHub BackendID = "github"
+	// BackendLinear is the Linear backend identifier (not yet implemented).
+	BackendLinear BackendID = "linear"
+	// BackendJira is the Jira backend identifier (not yet implemented).
+	BackendJira BackendID = "jira"
+)
+
+// WorkItem represents a work item from any project management backend.
+// For GitHub this maps to an issue; for Linear it would map to an issue;
+// for Jira it would map to a ticket.
+type WorkItem struct {
+	Number    int       `json:"number"`
+	Title     string    `json:"title"`
+	CreatedAt time.Time `json:"createdAt"`
+	URL       string    `json:"url"`
+	Labels    []Label   `json:"labels"`
+}
+
+// Label represents a label or tag on a work item.
+type Label struct {
+	Name string `json:"name"`
+}
+
+// WorkItemDetails contains the full details of a work item.
+type WorkItemDetails struct {
+	Title     string    `json:"title"`
+	Body      string    `json:"body"`
+	URL       string    `json:"html_url"`
+	State     string    `json:"state"`
+	Labels    []Label   `json:"labels"`
+	Assignees []UserRef `json:"assignees"`
+}
+
+// UserRef is a reference to a user identity in a backend system.
+type UserRef struct {
+	Login string `json:"login"`
+}
+
+// WorkItemComment is a comment on a work item.
+type WorkItemComment struct {
+	ID        int64     `json:"id"`
+	Body      string    `json:"body"`
+	CreatedAt time.Time `json:"created_at"`
+	User      struct {
+		Login string `json:"login"`
+	} `json:"user"`
+}
+
+// PullRequest represents a pull request or merge request.
+type PullRequest struct {
+	Number            int           `json:"number"`
+	Title             string        `json:"title"`
+	Body              string        `json:"body"`
+	URL               string        `json:"url"`
+	State             string        `json:"state"`
+	BaseRefName       string        `json:"baseRefName"`
+	MergedAt          *time.Time    `json:"mergedAt"`
+	Labels            []Label       `json:"labels"`
+	IsDraft           bool          `json:"isDraft"`
+	Mergeable         string        `json:"mergeable"`
+	MergeStateStatus  string        `json:"mergeStateStatus"`
+	ReviewDecision    string        `json:"reviewDecision"`
+	StatusCheckRollup []StatusCheck `json:"statusCheckRollup"`
+}
+
+// StatusCheck represents a CI status check on a pull request.
+type StatusCheck struct {
+	Context    string `json:"context"`
+	Name       string `json:"name"`
+	State      string `json:"state"`
+	Conclusion string `json:"conclusion"`
+}
+
+// CreatedWorkItem is the result of creating a new work item.
+type CreatedWorkItem struct {
+	Number int    `json:"number"`
+	URL    string `json:"html_url"`
+}
+
+// RateLimitResource represents rate limit state for one API category.
+type RateLimitResource struct {
+	Limit     int
+	Remaining int
+	ResetAt   time.Time
+}
+
+// RateLimitSnapshot captures the current rate limit state across API categories.
+type RateLimitSnapshot struct {
+	Core    RateLimitResource
+	Rate    RateLimitResource
+	GraphQL RateLimitResource
+	Search  RateLimitResource
+}
+
+// RepositoryLabelSpec defines a label to be created on a project.
+type RepositoryLabelSpec struct {
+	Name        string `json:"name"`
+	Color       string `json:"color"`
+	Description string `json:"description"`
+}
+
+// RepositoryLabelDetails is a label that exists on a project.
+type RepositoryLabelDetails struct {
+	Name string `json:"name"`
+}
+
+// ProgressComment is a structured progress update for posting to a work item.
+type ProgressComment struct {
+	Stage      string
+	Emoji      string
+	Percent    int
+	ETAMinutes int
+	Items      []string
+	Tagline    string
+}
+
+// DispatchFailureComment is a structured dispatch failure update.
+type DispatchFailureComment struct {
+	Stage        string
+	Summary      string
+	Branch       string
+	WorktreePath string
+	NextStep     string
+}

--- a/internal/github/comment_format.go
+++ b/internal/github/comment_format.go
@@ -4,16 +4,11 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/nicobistolfi/vigilante/internal/backend"
 )
 
-type ProgressComment struct {
-	Stage      string
-	Emoji      string
-	Percent    int
-	ETAMinutes int
-	Items      []string
-	Tagline    string
-}
+type ProgressComment = backend.ProgressComment
 
 func FormatProgressComment(comment ProgressComment) string {
 	header := strings.TrimSpace(comment.Stage)
@@ -39,13 +34,7 @@ func FormatProgressComment(comment ProgressComment) string {
 	return strings.Join(lines, "\n")
 }
 
-type DispatchFailureComment struct {
-	Stage        string
-	Summary      string
-	Branch       string
-	WorktreePath string
-	NextStep     string
-}
+type DispatchFailureComment = backend.DispatchFailureComment
 
 func FormatDispatchFailureComment(comment DispatchFailureComment) string {
 	stage := strings.TrimSpace(comment.Stage)

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -9,83 +9,24 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nicobistolfi/vigilante/internal/backend"
 	"github.com/nicobistolfi/vigilante/internal/environment"
 	"github.com/nicobistolfi/vigilante/internal/state"
 )
 
-type Issue struct {
-	Number    int       `json:"number"`
-	Title     string    `json:"title"`
-	CreatedAt time.Time `json:"createdAt"`
-	URL       string    `json:"url"`
-	Labels    []Label   `json:"labels"`
-}
-
-type Label struct {
-	Name string `json:"name"`
-}
-
-type PullRequest struct {
-	Number            int               `json:"number"`
-	Title             string            `json:"title"`
-	Body              string            `json:"body"`
-	URL               string            `json:"url"`
-	State             string            `json:"state"`
-	BaseRefName       string            `json:"baseRefName"`
-	MergedAt          *time.Time        `json:"mergedAt"`
-	Labels            []Label           `json:"labels"`
-	IsDraft           bool              `json:"isDraft"`
-	Mergeable         string            `json:"mergeable"`
-	MergeStateStatus  string            `json:"mergeStateStatus"`
-	ReviewDecision    string            `json:"reviewDecision"`
-	StatusCheckRollup []StatusCheckRoll `json:"statusCheckRollup"`
-}
-
-type StatusCheckRoll struct {
-	Context    string `json:"context"`
-	Name       string `json:"name"`
-	State      string `json:"state"`
-	Conclusion string `json:"conclusion"`
-}
-
-type IssueComment struct {
-	ID        int64     `json:"id"`
-	Body      string    `json:"body"`
-	CreatedAt time.Time `json:"created_at"`
-	User      struct {
-		Login string `json:"login"`
-	} `json:"user"`
-}
-
-type IssueDetails struct {
-	Title     string         `json:"title"`
-	Body      string         `json:"body"`
-	URL       string         `json:"html_url"`
-	State     string         `json:"state"`
-	Labels    []Label        `json:"labels"`
-	Assignees []IssueUserRef `json:"assignees"`
-}
-
-type IssueUserRef struct {
-	Login string `json:"login"`
-}
-
-type RepositoryLabelDetails struct {
-	Name string `json:"name"`
-}
-
-type RateLimitResource struct {
-	Limit     int
-	Remaining int
-	ResetAt   time.Time
-}
-
-type RateLimitSnapshot struct {
-	Core    RateLimitResource
-	Rate    RateLimitResource
-	GraphQL RateLimitResource
-	Search  RateLimitResource
-}
+// Type aliases for backward compatibility. The canonical types live in
+// internal/backend so the orchestration loop can depend on backend-neutral
+// definitions while existing callers continue to use ghcli names.
+type Issue = backend.WorkItem
+type Label = backend.Label
+type PullRequest = backend.PullRequest
+type StatusCheckRoll = backend.StatusCheck
+type IssueComment = backend.WorkItemComment
+type IssueDetails = backend.WorkItemDetails
+type IssueUserRef = backend.UserRef
+type RepositoryLabelDetails = backend.RepositoryLabelDetails
+type RateLimitResource = backend.RateLimitResource
+type RateLimitSnapshot = backend.RateLimitSnapshot
 
 type rateLimitAPIResponse struct {
 	Resources struct {
@@ -676,10 +617,7 @@ func MergePullRequestSquash(ctx context.Context, runner environment.Runner, repo
 	return err
 }
 
-type CreatedIssue struct {
-	Number int    `json:"number"`
-	URL    string `json:"html_url"`
-}
+type CreatedIssue = backend.CreatedWorkItem
 
 func CreateIssue(ctx context.Context, runner environment.Runner, repo string, title string, body string, labels []string, assignees []string) (*CreatedIssue, error) {
 	args := []string{"gh", "api", "--method", "POST", "-H", "Accept: application/vnd.github+json", "repos/" + repo + "/issues", "-f", "title=" + title, "-f", "body=" + SanitizeGitHubVisibleText(body)}

--- a/internal/github/labels_manifest.go
+++ b/internal/github/labels_manifest.go
@@ -8,13 +8,10 @@ import (
 	"sync"
 
 	skillassets "github.com/nicobistolfi/vigilante"
+	"github.com/nicobistolfi/vigilante/internal/backend"
 )
 
-type RepositoryLabelSpec struct {
-	Name        string `json:"name"`
-	Color       string `json:"color"`
-	Description string `json:"description"`
-}
+type RepositoryLabelSpec = backend.RepositoryLabelSpec
 
 type labelsManifest struct {
 	Labels []RepositoryLabelSpec `json:"labels"`

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nicobistolfi/vigilante/internal/backend"
 	"github.com/nicobistolfi/vigilante/internal/blocking"
 	"github.com/nicobistolfi/vigilante/internal/environment"
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
@@ -17,7 +18,7 @@ import (
 	"github.com/nicobistolfi/vigilante/internal/telemetry"
 )
 
-func RunIssueSession(ctx context.Context, env *environment.Environment, store *state.Store, target state.WatchTarget, issue ghcli.Issue, session state.Session) state.Session {
+func RunIssueSession(ctx context.Context, env *environment.Environment, store *state.Store, issueTracker backend.IssueTracker, target state.WatchTarget, issue ghcli.Issue, session state.Session) state.Session {
 	if session.Repo == "" {
 		session.Repo = target.Repo
 	}
@@ -79,7 +80,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 		Tagline:    "Make it simple, but significant.",
 	})
 	appendSessionLog(logPath, "session started", session, "")
-	if err := ghcli.CommentOnIssue(ctx, env.Runner, target.Repo, issue.Number, startBody); err != nil {
+	if err := issueTracker.CommentOnWorkItem(ctx, target.Repo, issue.Number, startBody); err != nil {
 		session.Status = state.SessionStatusFailed
 		session.IterationInProgress = false
 		session.LastError = err.Error()
@@ -129,7 +130,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 			Items:      blockedPreflightItems(blocked, selectedProvider.ID(), preflightOutput, session.ResumeHint),
 			Tagline:    "Strong foundations make calm debugging sessions.",
 		})
-		_ = ghcli.CommentOnIssue(ctx, env.Runner, target.Repo, issue.Number, body)
+		_ = issueTracker.CommentOnWorkItem(ctx, target.Repo, issue.Number, body)
 		return session
 	}
 	appendSessionLog(logPath, fmt.Sprintf("issue preflight succeeded duration=%s output_bytes=%d", time.Since(preflightStart).Truncate(time.Second), len(preflightOutput)), session, preflightOutput)
@@ -174,7 +175,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 			},
 			Tagline: "Plans are only good intentions unless they immediately degenerate into hard work.",
 		})
-		_ = ghcli.CommentOnIssue(ctx, env.Runner, target.Repo, issue.Number, body)
+		_ = issueTracker.CommentOnWorkItem(ctx, target.Repo, issue.Number, body)
 		return session
 	}
 
@@ -191,7 +192,7 @@ func fallbackSessionText(value string, fallback string) string {
 	return value
 }
 
-func RunConflictResolutionSession(ctx context.Context, env *environment.Environment, store *state.Store, target state.WatchTarget, session state.Session, pr ghcli.PullRequest) error {
+func RunConflictResolutionSession(ctx context.Context, env *environment.Environment, store *state.Store, issueTracker backend.IssueTracker, target state.WatchTarget, session state.Session, pr ghcli.PullRequest) error {
 	repoSlug := session.Repo
 	if repoSlug == "" {
 		repoSlug = target.Repo
@@ -237,7 +238,7 @@ func RunConflictResolutionSession(ctx context.Context, env *environment.Environm
 			},
 			Tagline: "An obstacle is often a stepping stone.",
 		})
-		_ = ghcli.CommentOnIssue(ctx, env.Runner, target.Repo, session.IssueNumber, body)
+		_ = issueTracker.CommentOnWorkItem(ctx, target.Repo, session.IssueNumber, body)
 		return err
 	}
 
@@ -245,7 +246,7 @@ func RunConflictResolutionSession(ctx context.Context, env *environment.Environm
 	return nil
 }
 
-func RunCIRemediationSession(ctx context.Context, env *environment.Environment, store *state.Store, target state.WatchTarget, session state.Session, pr ghcli.PullRequest, failingChecks []ghcli.StatusCheckRoll) error {
+func RunCIRemediationSession(ctx context.Context, env *environment.Environment, store *state.Store, issueTracker backend.IssueTracker, target state.WatchTarget, session state.Session, pr ghcli.PullRequest, failingChecks []ghcli.StatusCheckRoll) error {
 	repoSlug := session.Repo
 	if repoSlug == "" {
 		repoSlug = target.Repo
@@ -291,7 +292,7 @@ func RunCIRemediationSession(ctx context.Context, env *environment.Environment, 
 			},
 			Tagline: "Stop the loop before it turns into noise.",
 		})
-		_ = ghcli.CommentOnIssue(ctx, env.Runner, target.Repo, session.IssueNumber, body)
+		_ = issueTracker.CommentOnWorkItem(ctx, target.Repo, session.IssueNumber, body)
 		return err
 	}
 

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	githubbackend "github.com/nicobistolfi/vigilante/internal/backend/github"
 	"github.com/nicobistolfi/vigilante/internal/environment"
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
 	"github.com/nicobistolfi/vigilante/internal/repo"
@@ -57,7 +58,7 @@ func TestRunIssueSessionSuccess(t *testing.T) {
 		},
 	}
 	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
-	got := RunIssueSession(context.Background(), env, store, state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 	if got.Status != state.SessionStatusSuccess {
 		t.Fatalf("unexpected status: %#v", got)
 	}
@@ -119,7 +120,7 @@ func TestRunIssueSessionStartCommentIncludesReusedRemoteBranchContext(t *testing
 		BranchDiffSummary:  "README.md | 2 ++",
 		Status:             state.SessionStatusRunning,
 	}
-	got := RunIssueSession(context.Background(), env, store, state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 	if got.Status != state.SessionStatusSuccess {
 		t.Fatalf("unexpected status: %#v", got)
 	}
@@ -172,7 +173,7 @@ func TestRunIssueSessionFailureCommentsOnIssue(t *testing.T) {
 		t.Fatal(err)
 	}
 	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
-	got := RunIssueSession(context.Background(), env, store, state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 	if got.Status != state.SessionStatusBlocked {
 		t.Fatalf("unexpected status: %#v", got)
 	}
@@ -221,6 +222,7 @@ func TestRunConflictResolutionSessionFailureCommentsOnIssue(t *testing.T) {
 		context.Background(),
 		env,
 		store,
+		githubbackend.NewBackend(&env.Runner),
 		state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"},
 		state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, IssueTitle: "Demo", IssueBody: "Preserve the requested behavior.", IssueURL: "https://github.com/owner/repo/issues/7", BaseBranch: "main", WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7"},
 		ghcli.PullRequest{Number: 17, Title: "Demo PR", Body: "PR body", URL: "https://github.com/owner/repo/pull/17", Mergeable: "CONFLICTING", MergeStateStatus: "DIRTY"},
@@ -263,6 +265,7 @@ func TestRunCIRemediationSessionFailureCommentsOnIssue(t *testing.T) {
 		context.Background(),
 		env,
 		store,
+		githubbackend.NewBackend(&env.Runner),
 		state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"},
 		state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, IssueTitle: "Demo", IssueURL: "https://github.com/owner/repo/issues/7", WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7"},
 		ghcli.PullRequest{Number: 17, URL: "https://github.com/owner/repo/pull/17"},
@@ -311,7 +314,7 @@ func TestRunIssueSessionSuccessWithClaudeProvider(t *testing.T) {
 		t.Fatal(err)
 	}
 	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "claude", Status: state.SessionStatusRunning}
-	got := RunIssueSession(context.Background(), env, store, state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 	if got.Status != state.SessionStatusSuccess {
 		t.Fatalf("unexpected status: %#v", got)
 	}
@@ -355,7 +358,7 @@ func TestRunIssueSessionSuccessWithGeminiProvider(t *testing.T) {
 		t.Fatal(err)
 	}
 	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "gemini", Status: state.SessionStatusRunning}
-	got := RunIssueSession(context.Background(), env, store, state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 	if got.Status != state.SessionStatusSuccess {
 		t.Fatalf("unexpected status: %#v", got)
 	}
@@ -407,7 +410,7 @@ func TestRunIssueSessionUsesMonorepoSkillWhenClassified(t *testing.T) {
 	}
 	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
 
-	got := RunIssueSession(context.Background(), env, store, target, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), target, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 
 	if got.Status != state.SessionStatusSuccess {
 		t.Fatalf("unexpected status: %#v", got)
@@ -460,7 +463,7 @@ func TestRunIssueSessionUsesNxSkillWhenClassified(t *testing.T) {
 	}
 	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
 
-	got := RunIssueSession(context.Background(), env, store, target, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), target, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 
 	if got.Status != state.SessionStatusSuccess {
 		t.Fatalf("unexpected status: %#v", got)
@@ -513,7 +516,7 @@ func TestRunIssueSessionUsesRushMonorepoSkillWhenClassified(t *testing.T) {
 	}
 	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
 
-	got := RunIssueSession(context.Background(), env, store, target, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), target, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 
 	if got.Status != state.SessionStatusSuccess {
 		t.Fatalf("unexpected status: %#v", got)
@@ -535,7 +538,7 @@ func TestRunIssueSessionFailsWhenProviderVersionIsIncompatible(t *testing.T) {
 	}
 	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
 
-	got := RunIssueSession(context.Background(), env, store, state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 
 	if got.Status != state.SessionStatusFailed {
 		t.Fatalf("unexpected status: %#v", got)

--- a/internal/state/backend_test.go
+++ b/internal/state/backend_test.go
@@ -1,0 +1,168 @@
+package state
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestWatchTargetEffectiveIssueBackendDefaultsToGitHub(t *testing.T) {
+	target := WatchTarget{Repo: "owner/repo"}
+	if got := target.EffectiveIssueBackend(); got != "github" {
+		t.Fatalf("expected github, got %q", got)
+	}
+}
+
+func TestWatchTargetEffectiveIssueBackendRespectsExplicit(t *testing.T) {
+	target := WatchTarget{Repo: "owner/repo", IssueBackend: "linear"}
+	if got := target.EffectiveIssueBackend(); got != "linear" {
+		t.Fatalf("expected linear, got %q", got)
+	}
+}
+
+func TestWatchTargetEffectiveGitBackendDefaultsToGitHub(t *testing.T) {
+	target := WatchTarget{Repo: "owner/repo"}
+	if got := target.EffectiveGitBackend(); got != "github" {
+		t.Fatalf("expected github, got %q", got)
+	}
+}
+
+func TestWatchTargetEffectivePRBackendDefaultsToGitHub(t *testing.T) {
+	target := WatchTarget{Repo: "owner/repo"}
+	if got := target.EffectivePRBackend(); got != "github" {
+		t.Fatalf("expected github, got %q", got)
+	}
+}
+
+func TestWatchTargetEffectiveProjectRefFallsBackToRepo(t *testing.T) {
+	target := WatchTarget{Repo: "owner/repo"}
+	if got := target.EffectiveProjectRef(); got != "owner/repo" {
+		t.Fatalf("expected owner/repo, got %q", got)
+	}
+}
+
+func TestWatchTargetEffectiveProjectRefRespectsExplicit(t *testing.T) {
+	target := WatchTarget{Repo: "owner/repo", ProjectRef: "LINEAR-123"}
+	if got := target.EffectiveProjectRef(); got != "LINEAR-123" {
+		t.Fatalf("expected LINEAR-123, got %q", got)
+	}
+}
+
+func TestMixedBackendModelingLinearIssuesPlusGitHubPRs(t *testing.T) {
+	target := WatchTarget{
+		Path:         "/repos/myapp",
+		Repo:         "owner/myapp",
+		IssueBackend: "linear",
+		GitBackend:   "github",
+		PRBackend:    "github",
+		ProjectRef:   "TEAM-project-id",
+	}
+	if target.EffectiveIssueBackend() != "linear" {
+		t.Fatal("issue backend should be linear")
+	}
+	if target.EffectiveGitBackend() != "github" {
+		t.Fatal("git backend should be github")
+	}
+	if target.EffectivePRBackend() != "github" {
+		t.Fatal("PR backend should be github")
+	}
+	if target.EffectiveProjectRef() != "TEAM-project-id" {
+		t.Fatal("project ref should be TEAM-project-id")
+	}
+}
+
+func TestMixedBackendModelingJiraIssuesPlusGitHubPRs(t *testing.T) {
+	target := WatchTarget{
+		Path:         "/repos/myapp",
+		Repo:         "owner/myapp",
+		IssueBackend: "jira",
+		GitBackend:   "github",
+		PRBackend:    "github",
+		ProjectRef:   "PROJ-board",
+	}
+	if target.EffectiveIssueBackend() != "jira" {
+		t.Fatal("issue backend should be jira")
+	}
+	if target.EffectiveGitBackend() != "github" {
+		t.Fatal("git backend should be github")
+	}
+}
+
+func TestSessionBackendFieldsSerializeCorrectly(t *testing.T) {
+	session := Session{
+		Repo:         "owner/repo",
+		IssueNumber:  42,
+		IssueBackend: "linear",
+		GitBackend:   "github",
+		PRBackend:    "github",
+		Status:       SessionStatusRunning,
+	}
+	data, err := json.Marshal(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded Session
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.IssueBackend != "linear" {
+		t.Fatalf("expected linear, got %q", decoded.IssueBackend)
+	}
+	if decoded.GitBackend != "github" {
+		t.Fatalf("expected github, got %q", decoded.GitBackend)
+	}
+	if decoded.PRBackend != "github" {
+		t.Fatalf("expected github, got %q", decoded.PRBackend)
+	}
+}
+
+func TestWatchTargetBackendFieldsSerializeCorrectly(t *testing.T) {
+	target := WatchTarget{
+		Path:         "/repos/test",
+		Repo:         "owner/test",
+		IssueBackend: "jira",
+		GitBackend:   "github",
+		PRBackend:    "github",
+		ProjectRef:   "PROJ-123",
+	}
+	data, err := json.Marshal(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded WatchTarget
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.IssueBackend != "jira" || decoded.ProjectRef != "PROJ-123" {
+		t.Fatalf("backend fields did not round-trip: %+v", decoded)
+	}
+}
+
+func TestWatchTargetBackendFieldsOmittedWhenEmpty(t *testing.T) {
+	target := WatchTarget{
+		Path: "/repos/test",
+		Repo: "owner/test",
+	}
+	data, err := json.Marshal(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := string(data)
+	for _, field := range []string{"issue_backend", "git_backend", "pr_backend", "project_ref"} {
+		if contains(raw, field) {
+			t.Fatalf("expected %q to be omitted from JSON, got: %s", field, raw)
+		}
+	}
+}
+
+func contains(s string, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s string, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -28,6 +28,10 @@ type WatchTarget struct {
 	MaxParallel    int                 `json:"max_parallel_sessions"`
 	LastScanAt     string              `json:"last_scan_at,omitempty"`
 	AddedAt        string              `json:"added_at,omitempty"`
+	IssueBackend   string              `json:"issue_backend,omitempty"`
+	GitBackend     string              `json:"git_backend,omitempty"`
+	PRBackend      string              `json:"pr_backend,omitempty"`
+	ProjectRef     string              `json:"project_ref,omitempty"`
 }
 
 type BranchMode string
@@ -36,6 +40,42 @@ const (
 	BranchModeAuto   BranchMode = "auto"
 	BranchModePinned BranchMode = "pinned"
 )
+
+// EffectiveIssueBackend returns the issue-tracking backend for this target.
+// Defaults to "github" when not explicitly configured.
+func (t WatchTarget) EffectiveIssueBackend() string {
+	if b := strings.TrimSpace(t.IssueBackend); b != "" {
+		return b
+	}
+	return "github"
+}
+
+// EffectiveGitBackend returns the git-hosting backend for this target.
+// Defaults to "github" when not explicitly configured.
+func (t WatchTarget) EffectiveGitBackend() string {
+	if b := strings.TrimSpace(t.GitBackend); b != "" {
+		return b
+	}
+	return "github"
+}
+
+// EffectivePRBackend returns the pull-request backend for this target.
+// Defaults to "github" when not explicitly configured.
+func (t WatchTarget) EffectivePRBackend() string {
+	if b := strings.TrimSpace(t.PRBackend); b != "" {
+		return b
+	}
+	return "github"
+}
+
+// EffectiveProjectRef returns the backend-specific project reference.
+// For GitHub targets this falls back to the Repo slug.
+func (t WatchTarget) EffectiveProjectRef() string {
+	if ref := strings.TrimSpace(t.ProjectRef); ref != "" {
+		return ref
+	}
+	return t.Repo
+}
 
 func (t WatchTarget) EffectiveBranchMode() BranchMode {
 	switch t.BranchMode {
@@ -75,6 +115,9 @@ type Session struct {
 	RepoPath                       string        `json:"repo_path"`
 	Repo                           string        `json:"repo"`
 	Provider                       string        `json:"provider,omitempty"`
+	IssueBackend                   string        `json:"issue_backend,omitempty"`
+	GitBackend                     string        `json:"git_backend,omitempty"`
+	PRBackend                      string        `json:"pr_backend,omitempty"`
 	IssueNumber                    int           `json:"issue_number"`
 	IssueTitle                     string        `json:"issue_title,omitempty"`
 	IssueBody                      string        `json:"issue_body,omitempty"`


### PR DESCRIPTION
## Summary
- Adds `internal/backend` package with four interfaces (`IssueTracker`, `PullRequestManager`, `LabelManager`, `RateLimiter`) and backend-neutral types
- Implements GitHub backend (`internal/backend/github`) wrapping existing `ghcli` functions for zero-behavior-change compatibility
- Updates `App` struct and `runner/session.go` to use backend interfaces instead of direct `ghcli` calls
- Adds `issue_backend`, `git_backend`, `pr_backend`, `project_ref` fields to `WatchTarget` and `Session` for mixed-backend support (e.g., Linear issues + GitHub PRs)

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] New tests for backend types, interface compliance, delegation, and mixed-backend modeling
- [x] `gofmt` and `go vet` clean
- [x] Existing GitHub behavior fully preserved through type aliases and backend delegation

Closes #334