### PR TITLE
Add vigilante commit for user-authored signed coding-agent commits

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -191,6 +191,17 @@ vigilante docker compose ps
 
 The proxy preserves the underlying tool's stdout, stderr, and exit status. Telemetry intentionally avoids raw positional arguments, flag values, repo slugs, tokens, paths, prompts, and free-form text.
 
+### Commit command
+
+`vigilante commit` is the required commit entrypoint for all coding-agent workflows. It wraps `git commit` while preserving the user's configured git author, committer, and signing behavior. Agent attribution lines in commit messages are stripped automatically.
+
+```sh
+vigilante commit -m "Fix validation logic"
+vigilante commit --amend --no-edit
+```
+
+Coding agents must use `vigilante commit` instead of `git commit` or GitHub CLI commit flows. This ensures that all agent-produced commits remain user-authored and signed.
+
 ## Installation
 
 Install `vigilante` with Homebrew:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -545,6 +545,8 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 	}
 
 	switch args[0] {
+	case "commit":
+		return a.runCommitCommand(ctx, args[1:])
 	case "setup":
 		fs := flag.NewFlagSet("setup", flag.ContinueOnError)
 		configureFlagSet(fs, func(w io.Writer) {
@@ -720,6 +722,29 @@ func runProxyBinary(ctx context.Context, stdin io.Reader, stdout io.Writer, stde
 		return 0, err
 	}
 	return 0, nil
+}
+
+func (a *App) runCommitCommand(ctx context.Context, args []string) error {
+	if len(args) == 1 && isHelpToken(args[0]) {
+		fmt.Fprintln(a.stdout, "usage: vigilante commit [git-commit-flags...]")
+		fmt.Fprintln(a.stdout)
+		fmt.Fprintln(a.stdout, "Create a commit preserving the user's git author, committer,")
+		fmt.Fprintln(a.stdout, "and signing configuration. Agent attribution is stripped from")
+		fmt.Fprintln(a.stdout, "the commit message automatically.")
+		return nil
+	}
+	sanitizedArgs, sanitizedStdin, err := ghcli.SanitizeProxyInvocation("git", append([]string{"commit"}, args...), a.stdin)
+	if err != nil {
+		return err
+	}
+	exitCode, err := a.proxyExec(ctx, sanitizedStdin, a.stdout, a.stderr, "git", sanitizedArgs...)
+	if err != nil {
+		return err
+	}
+	if exitCode != 0 {
+		return commandExitError{code: exitCode}
+	}
+	return nil
 }
 
 func (a *App) runResumeCommand(ctx context.Context, args []string) error {
@@ -5560,6 +5585,7 @@ func (a *App) printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  vigilante service restart")
 	fmt.Fprintln(w, "  vigilante daemon run [--once] [--interval duration]")
 	fmt.Fprintln(w, "  vigilante issue create --repo <owner/name> [--provider value] <prompt...>")
+	fmt.Fprintln(w, "  vigilante commit [git-commit-flags...]")
 	fmt.Fprintln(w, "  vigilante completion <bash|fish|zsh>")
 	fmt.Fprintln(w, "  vigilante <gh|git|docker> ...")
 	fmt.Fprintln(w)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -196,6 +196,7 @@ func TestRunSupportsTopLevelHelpFlags(t *testing.T) {
 				"vigilante watch",
 				"vigilante status",
 				"vigilante service restart",
+				"vigilante commit [git-commit-flags...]",
 				"vigilante completion <bash|fish|zsh>",
 				"vigilante <gh|git|docker> ...",
 				`Use "vigilante <command> --help" for command-specific usage.`,
@@ -288,6 +289,79 @@ func TestRunReturnsUnderlyingProxyExitCode(t *testing.T) {
 
 	if got := app.Run(context.Background(), []string{"git", "status"}); got != 17 {
 		t.Fatalf("Run() = %d, want %d", got, 17)
+	}
+}
+
+func TestRunCommitCommandProxiesToGitCommit(t *testing.T) {
+	app := New()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = &stderr
+	var gotName string
+	var gotArgs []string
+	app.proxyExec = func(_ context.Context, _ io.Reader, out io.Writer, _ io.Writer, name string, args ...string) (int, error) {
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		return 0, nil
+	}
+
+	exitCode := app.Run(context.Background(), []string{"commit", "-m", "Fix bug"})
+	if exitCode != 0 {
+		t.Fatalf("expected success exit code, got %d", exitCode)
+	}
+	if gotName != "git" {
+		t.Fatalf("commit tool = %q, want %q", gotName, "git")
+	}
+	if got, want := strings.Join(gotArgs, " "), "commit -m Fix bug"; got != want {
+		t.Fatalf("commit args = %q, want %q", got, want)
+	}
+}
+
+func TestRunCommitCommandSanitizesMessage(t *testing.T) {
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	var gotArgs []string
+	app.proxyExec = func(_ context.Context, _ io.Reader, _ io.Writer, _ io.Writer, _ string, args ...string) (int, error) {
+		gotArgs = append([]string(nil), args...)
+		return 0, nil
+	}
+
+	exitCode := app.Run(context.Background(), []string{"commit", "-m", "Fix bug\n\nGenerated with Codex"})
+	if exitCode != 0 {
+		t.Fatalf("expected success exit code, got %d", exitCode)
+	}
+	if got, want := strings.Join(gotArgs, " "), "commit -m Fix bug"; got != want {
+		t.Fatalf("commit args = %q, want %q", got, want)
+	}
+}
+
+func TestRunCommitCommandReturnsUnderlyingExitCode(t *testing.T) {
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.proxyExec = func(context.Context, io.Reader, io.Writer, io.Writer, string, ...string) (int, error) {
+		return 1, nil
+	}
+
+	if got := app.Run(context.Background(), []string{"commit", "-m", "test"}); got != 1 {
+		t.Fatalf("Run() = %d, want %d", got, 1)
+	}
+}
+
+func TestRunCommitCommandHelp(t *testing.T) {
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+
+	exitCode := app.Run(context.Background(), []string{"commit", "--help"})
+	if exitCode != 0 {
+		t.Fatalf("expected success exit code, got %d", exitCode)
+	}
+	if !strings.Contains(stdout.String(), "vigilante commit") {
+		t.Fatalf("expected help output to mention vigilante commit, got %q", stdout.String())
 	}
 }
 

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -186,7 +186,7 @@ func BuildIssuePromptForRuntime(runtime string, target state.WatchTarget, issue 
 		fmt.Sprintf("Issue URL: %s", issue.URL),
 		fmt.Sprintf("Worktree path: %s", session.WorktreePath),
 		fmt.Sprintf("Branch: %s", session.Branch),
-		"Use `vigilante gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, push the branch with `vigilante git push`, open a pull request with `vigilante gh pr create`, and report any execution failure back to the issue.",
+		"Use `vigilante gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, commit with `vigilante commit`, push the branch with `vigilante git push`, open a pull request with `vigilante gh pr create`, and report any execution failure back to the issue.",
 		fmt.Sprintf("When you open the pull request, the final PR body must include `Closes #%d` even if you write a custom summary or the summary is otherwise minimal.", issue.Number),
 		fmt.Sprintf("For the coding-agent start comment, use `## 🕹️ Coding Agent Launched: %s` instead of a generic session-start title.", displayProviderName(session.Provider)),
 		"For the coding-agent start comment, include a short GitHub issue-command hint block with at least `@vigilanteai resume` and `@vigilanteai cleanup`, and make clear that they are issue-comment commands rather than shell commands.",
@@ -483,7 +483,7 @@ func BuildConflictResolutionPromptForRuntime(runtime string, target state.WatchT
 	lines = append(lines,
 		"If the rebase fails, post-rebase validation fails, or the current session state is unclear, inspect `vigilante logs --repo <owner/name> --issue <n>` before retrying so the session transcript guides the next safe action.",
 		"Do not silently discard commits or issue-specific behavior just to get a clean merge. Prefer the smallest safe conflict fix.",
-		"Use `vigilante gh issue comment` for progress and failures, rerun `go test ./...` after conflict resolution succeeds, and push the updated branch with `vigilante git push` when finished.",
+		"Use `vigilante commit` for all commit-producing operations during conflict resolution. Use `vigilante gh issue comment` for progress and failures, rerun `go test ./...` after conflict resolution succeeds, and push the updated branch with `vigilante git push` when finished.",
 		"If you cannot preserve the issue intent safely, leave a concise GitHub blocker comment and exit with a non-zero status.",
 	)
 	if strings.TrimSpace(session.BranchDiffSummary) != "" {
@@ -542,7 +542,7 @@ func BuildCIRemediationPromptForRuntime(runtime string, target state.WatchTarget
 	)
 	lines = append(lines, commitIdentityPolicyLines()...)
 	lines = append(lines,
-		"Use `vigilante gh issue comment` for progress updates and blockers, push any successful fix to the existing PR branch with `vigilante git push`, and do not open a new pull request.",
+		"Use `vigilante commit` for all commit-producing operations. Use `vigilante gh issue comment` for progress updates and blockers, push any successful fix to the existing PR branch with `vigilante git push`, and do not open a new pull request.",
 		"If GitHub exposes a failing check summary or log URL during your investigation, use it. At minimum, work from the failing check identifiers listed above.",
 		"If you cannot fix the failure safely, leave a concise GitHub comment explaining the blocker and exit with a non-zero status so Vigilante can stop and hand off to a human.",
 		"Keep the changes minimal and focused on restoring CI for the existing pull request.",
@@ -561,6 +561,7 @@ func runtimeUsesInlineSkillHeader(runtime string) bool {
 
 func commitIdentityPolicyLines() []string {
 	return []string{
+		"Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.",
 		"Any commit, amend, rebase rewrite, or conflict-resolution commit must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.",
 		"Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.",
 	}

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -134,7 +134,7 @@ func TestBuildIssuePrompt(t *testing.T) {
 	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
 	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
 	prompt := BuildIssuePrompt(target, issue, session)
-	for _, text := range []string{"Use the `vigilante-issue-implementation` skill", "Detected repo shape: traditional", `Repo process context JSON: {"shape":"traditional"}`, "Selected issue implementation skill: vigilante-issue-implementation", "Issue: #12 - Fix bug", "Worktree path: /tmp/worktree", "vigilante gh issue comment", "vigilante git push", "vigilante gh pr create", "Closes #12", "Coding Agent Launched: Codex", "@vigilanteai resume", "@vigilanteai cleanup", "issue-comment commands rather than shell commands", "10-cell progress bar", "ETA: ~N minutes", "preserve the user's existing git author, committer, and signing configuration", "Do not add `Co-authored by:` trailers"} {
+	for _, text := range []string{"Use the `vigilante-issue-implementation` skill", "Detected repo shape: traditional", `Repo process context JSON: {"shape":"traditional"}`, "Selected issue implementation skill: vigilante-issue-implementation", "Issue: #12 - Fix bug", "Worktree path: /tmp/worktree", "vigilante gh issue comment", "vigilante commit", "vigilante git push", "vigilante gh pr create", "Closes #12", "Coding Agent Launched: Codex", "@vigilanteai resume", "@vigilanteai cleanup", "issue-comment commands rather than shell commands", "10-cell progress bar", "ETA: ~N minutes", "Use `vigilante commit` for all commit-producing operations", "Do not use `git commit` or GitHub CLI commit flows directly", "preserve the user's existing git author, committer, and signing configuration", "Do not add `Co-authored by:` trailers"} {
 		if !strings.Contains(prompt, text) {
 			t.Fatalf("prompt missing %q: %s", text, prompt)
 		}
@@ -537,7 +537,7 @@ func TestBuildConflictResolutionPrompt(t *testing.T) {
 	session := state.Session{IssueNumber: 12, IssueTitle: "Fix bug", IssueBody: "Preserve the original validation behavior.", IssueURL: "https://example.com/issues/12", BaseBranch: "main", WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", BranchDiffSummary: "Keep the error-state form inputs intact."}
 	pr := ghcli.PullRequest{Number: 88, URL: "https://example.com/pull/88", Title: "Fix bug", Body: "This PR keeps the original UX behavior.", Mergeable: "CONFLICTING", MergeStateStatus: "DIRTY"}
 	prompt := BuildConflictResolutionPrompt(target, session, pr)
-	for _, text := range []string{"Use the `vigilante-conflict-resolution` skill", "Issue specification: Preserve the original validation behavior.", "Pull Request title: Fix bug", "GitHub mergeability: mergeable=CONFLICTING mergeStateStatus=DIRTY", "Work through the rebase commit by commit.", "preserve the user's existing git author, committer, and signing configuration", "Do not add `Co-authored by:` trailers", "vigilante logs --repo <owner/name> --issue <n>", "go test ./...", "Existing branch summary: Keep the error-state form inputs intact."} {
+	for _, text := range []string{"Use the `vigilante-conflict-resolution` skill", "Issue specification: Preserve the original validation behavior.", "Pull Request title: Fix bug", "GitHub mergeability: mergeable=CONFLICTING mergeStateStatus=DIRTY", "Work through the rebase commit by commit.", "Use `vigilante commit` for all commit-producing operations", "Do not use `git commit` or GitHub CLI commit flows directly", "preserve the user's existing git author, committer, and signing configuration", "Do not add `Co-authored by:` trailers", "vigilante logs --repo <owner/name> --issue <n>", "go test ./...", "Existing branch summary: Keep the error-state form inputs intact."} {
 		if !strings.Contains(prompt, text) {
 			t.Fatalf("prompt missing %q: %s", text, prompt)
 		}
@@ -549,7 +549,7 @@ func TestBuildCIRemediationPrompt(t *testing.T) {
 	session := state.Session{IssueNumber: 12, IssueTitle: "Fix bug", IssueURL: "https://example.com/issues/12", WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12"}
 	pr := ghcli.PullRequest{Number: 88, URL: "https://example.com/pull/88"}
 	prompt := BuildCIRemediationPrompt(target, session, pr, []ghcli.StatusCheckRoll{{Context: "test", Conclusion: "FAILURE"}})
-	for _, text := range []string{"Use the `vigilante-issue-implementation` skill", "Pull Request: #88", "CI remediation context", "Failing check: test", "preserve the user's existing git author, committer, and signing configuration", "Do not add `Co-authored by:` trailers", "do not open a new pull request", "exit with a non-zero status"} {
+	for _, text := range []string{"Use the `vigilante-issue-implementation` skill", "Pull Request: #88", "CI remediation context", "Failing check: test", "Use `vigilante commit` for all commit-producing operations", "Do not use `git commit` or GitHub CLI commit flows directly", "preserve the user's existing git author, committer, and signing configuration", "Do not add `Co-authored by:` trailers", "do not open a new pull request", "exit with a non-zero status"} {
 		if !strings.Contains(prompt, text) {
 			t.Fatalf("prompt missing %q: %s", text, prompt)
 		}
@@ -599,6 +599,51 @@ func TestEnsureInstalledCommitProducingSkillsIncludeCommitIdentityPolicy(t *test
 			if !strings.Contains(body, text) {
 				t.Fatalf("%s missing commit identity guidance %q", name, text)
 			}
+		}
+	}
+}
+
+func TestEnsureInstalledCommitProducingSkillsRequireVigilanteCommit(t *testing.T) {
+	dir := t.TempDir()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	outside := t.TempDir()
+	if err := os.Chdir(outside); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.Chdir(wd)
+	}()
+
+	if err := EnsureInstalled(RuntimeCodex, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{
+		VigilanteIssueImplementation,
+		VigilanteIssueImplementationOnMonorepo,
+		VigilanteIssueImplementationOnTurborepo,
+		VigilanteIssueImplementationOnNx,
+		VigilanteIssueImplementationOnRush,
+		VigilanteIssueImplementationOnRushMonorepo,
+		VigilanteIssueImplementationOnBazel,
+		VigilanteIssueImplementationOnGradle,
+		VigilanteIssueImplementationOnGradleMultiProject,
+		VigilanteIssueImplementationOnBazelMonorepo,
+		VigilanteConflictResolution,
+	} {
+		data, err := os.ReadFile(filepath.Join(dir, "skills", name, "SKILL.md"))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		body := string(data)
+		if !strings.Contains(body, "vigilante commit") {
+			t.Fatalf("%s missing vigilante commit requirement", name)
+		}
+		if !strings.Contains(body, "Do not use `git commit` or GitHub CLI commit flows directly") {
+			t.Fatalf("%s missing git commit prohibition", name)
 		}
 	}
 }

--- a/skills/vigilante-conflict-resolution/SKILL.md
+++ b/skills/vigilante-conflict-resolution/SKILL.md
@@ -13,12 +13,13 @@ Use this skill after Vigilante has already opened a pull request and a follow-up
 2. Read repository instructions that affect the touched files before editing.
 3. Comment on the issue when conflict resolution begins and again for meaningful milestones or failures.
 4. Resolve only the conflicts needed to complete the rebase cleanly, commit by commit, while preserving the original issue specification and branch intent.
-5. Preserve the user's existing git author, committer, and signing configuration for every rebase rewrite, amend, or conflict-resolution commit, and do not overwrite `git config` with a coding-agent identity.
-6. Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.
-7. If the rebase fails, post-rebase validation fails, or the current session state is unclear, inspect `vigilante logs --repo <owner/name> --issue <n>` before retrying so the persisted session transcript becomes the factual source for the next safe action.
-8. After inspecting the log, either continue with the smallest safe fix, rerun the requested validation, or report a blocker on the issue when the transcript shows the branch should not be retried automatically.
-9. Push the updated branch back to GitHub after the rebase and requested validation succeed.
-10. Report the final result clearly on the issue, including any remaining blocker if the conflicts cannot be resolved safely.
+5. Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
+6. Preserve the user's existing git author, committer, and signing configuration for every rebase rewrite, amend, or conflict-resolution commit, and do not overwrite `git config` with a coding-agent identity.
+7. Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.
+8. If the rebase fails, post-rebase validation fails, or the current session state is unclear, inspect `vigilante logs --repo <owner/name> --issue <n>` before retrying so the persisted session transcript becomes the factual source for the next safe action.
+9. After inspecting the log, either continue with the smallest safe fix, rerun the requested validation, or report a blocker on the issue when the transcript shows the branch should not be retried automatically.
+10. Push the updated branch back to GitHub after the rebase and requested validation succeed.
+11. Report the final result clearly on the issue, including any remaining blocker if the conflicts cannot be resolved safely.
 
 ## Guardrails
 - Stay inside the provided worktree.

--- a/skills/vigilante-issue-implementation-on-bazel-monorepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-bazel-monorepo/SKILL.md
@@ -45,6 +45,7 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - If validation fails, first inspect the per-issue session log with `vigilante logs --repo <owner/name> --issue <n>` to determine whether the problem is in the code, target selection, test setup, or environment before retrying.
 
 6. Commit, push, and open a pull request
+- Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Commit only issue-relevant changes in the assigned branch.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.

--- a/skills/vigilante-issue-implementation-on-bazel/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-bazel/SKILL.md
@@ -12,6 +12,7 @@ description: Implement a GitHub issue end-to-end when Vigilante dispatches work 
 
 ## Workflow
 - Follow the base `vigilante-issue-implementation-on-monorepo` workflow for issue comments, validation, push, and PR creation.
+- Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.
 - Use Bazel-native target commands when they exist and match the touched code.

--- a/skills/vigilante-issue-implementation-on-gradle-multi-project/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-gradle-multi-project/SKILL.md
@@ -46,6 +46,7 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - If validation fails, first inspect the per-issue session log with `vigilante logs --repo <owner/name> --issue <n>` to determine whether the problem is in the code, Gradle task selection, test setup, or environment before retrying.
 
 6. Commit, push, and open a pull request
+- Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Commit only issue-relevant changes in the assigned branch.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.

--- a/skills/vigilante-issue-implementation-on-gradle/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-gradle/SKILL.md
@@ -12,6 +12,7 @@ description: Implement a GitHub issue end-to-end when Vigilante dispatches work 
 
 ## Workflow
 - Follow the base `vigilante-issue-implementation-on-monorepo` workflow for issue comments, validation, push, and PR creation.
+- Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.
 - Use Gradle-native project commands when they exist and match the touched modules.

--- a/skills/vigilante-issue-implementation-on-monorepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-monorepo/SKILL.md
@@ -45,6 +45,7 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - If validation fails, first inspect the per-issue session log with `vigilante logs --repo <owner/name> --issue <n>` to determine whether the problem is in the code, test setup, or environment before retrying.
 
 6. Commit, push, and open a pull request
+- Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Commit only issue-relevant changes in the assigned branch.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.

--- a/skills/vigilante-issue-implementation-on-nx/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-nx/SKILL.md
@@ -12,6 +12,7 @@ description: Implement a GitHub issue end-to-end when Vigilante dispatches work 
 
 ## Workflow
 - Follow the base `vigilante-issue-implementation-on-monorepo` workflow for issue comments, validation, push, and PR creation.
+- Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.
 - Use Nx-native workspace commands when they exist and match the touched projects.

--- a/skills/vigilante-issue-implementation-on-rush-monorepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-rush-monorepo/SKILL.md
@@ -45,6 +45,7 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - If validation fails, first inspect the per-issue session log with `vigilante logs --repo <owner/name> --issue <n>` to determine whether the problem is in the code, test setup, or environment before retrying.
 
 6. Commit, push, and open a pull request
+- Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Commit only issue-relevant changes in the assigned branch.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.

--- a/skills/vigilante-issue-implementation-on-rush/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-rush/SKILL.md
@@ -12,6 +12,7 @@ description: Implement a GitHub issue end-to-end when Vigilante dispatches work 
 
 ## Workflow
 - Follow the base `vigilante-issue-implementation-on-monorepo` workflow for issue comments, validation, push, and PR creation.
+- Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.
 - Use Rush-native workspace commands when they exist and match the touched projects.

--- a/skills/vigilante-issue-implementation-on-turborepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-turborepo/SKILL.md
@@ -53,6 +53,7 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - If validation fails, first inspect the per-issue session log with `vigilante logs --repo <owner/name> --issue <n>` to determine whether the problem is in the code, test setup, or environment before retrying.
 
 6. Commit, push, and open a pull request
+- Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Commit only issue-relevant changes in the assigned branch.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.

--- a/skills/vigilante-issue-implementation/SKILL.md
+++ b/skills/vigilante-issue-implementation/SKILL.md
@@ -53,6 +53,7 @@ Service dependencies:
 - If a command fails, first inspect the per-issue session log with `vigilante logs --repo <owner/name> --issue <n>` to determine whether the problem is in the code, test setup, or environment before retrying.
 
 6. Commit and push the branch
+- Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Commit only issue-relevant changes in the assigned branch.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.


### PR DESCRIPTION
## Summary

- Adds a `vigilante commit` CLI command that wraps `git commit` while preserving the user's configured git author, committer, and signing behavior, and stripping agent attribution from commit messages.
- Updates all 11 commit-producing skill SKILL.md files (issue-implementation, conflict-resolution, and their monorepo/stack variants) to require `vigilante commit` and explicitly forbid `git commit` and GitHub CLI commit flows.
- Updates runtime prompt generation (`BuildIssuePromptForRuntime`, `BuildConflictResolutionPromptForRuntime`, `BuildCIRemediationPromptForRuntime`, `commitIdentityPolicyLines`) to include `vigilante commit` as the required commit path.
- Adds CLI-level tests, prompt-text tests, and skill-content tests covering the new behavior.
- Documents `vigilante commit` in DOCS.md.

## Validation

- `go build ./...` — passes
- `go test ./...` — all tests pass
- `go vet ./...` — clean

Closes #349