### PR TITLE
Add JS/TS/Node security-hardening guidance to issue execution

### DIFF
--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -32,6 +32,12 @@ const (
 	MonorepoStackGradle    MonorepoStack = "gradle"
 )
 
+type TechStack string
+
+const (
+	TechStackNodeJS TechStack = "nodejs"
+)
+
 type ProcessHints struct {
 	WorkspaceConfigFiles   []string `json:"workspace_config_files,omitempty"`
 	WorkspaceManifestFiles []string `json:"workspace_manifest_files,omitempty"`
@@ -40,11 +46,15 @@ type ProcessHints struct {
 	GradleRootBuildFiles   []string `json:"gradle_root_build_files,omitempty"`
 	BazelRepoMarkers       []string `json:"bazel_repo_markers,omitempty"`
 	BazelPackageRoots      []string `json:"bazel_package_roots,omitempty"`
+	NodePackageManagers    []string `json:"node_package_managers,omitempty"`
+	NodeLockFiles          []string `json:"node_lock_files,omitempty"`
+	TypeScriptConfigs      []string `json:"typescript_configs,omitempty"`
 }
 
 type Classification struct {
 	Shape         Shape         `json:"shape"`
 	MonorepoStack MonorepoStack `json:"monorepo_stack,omitempty"`
+	TechStacks    []TechStack   `json:"tech_stacks,omitempty"`
 	ProcessHints  ProcessHints  `json:"process_hints,omitempty"`
 }
 
@@ -211,6 +221,8 @@ func Classify(path string) Classification {
 	if isGradleMultiProject(absPath, classification.ProcessHints.GradleSettingsFiles) {
 		classification.Shape = ShapeGradleMultiProject
 	}
+	detectNodeJSTechStack(absPath, &classification)
+
 	slices.Sort(classification.ProcessHints.GradleSettingsFiles)
 	slices.Sort(classification.ProcessHints.GradleRootBuildFiles)
 	slices.Sort(classification.ProcessHints.WorkspaceConfigFiles)
@@ -218,6 +230,9 @@ func Classify(path string) Classification {
 	slices.Sort(classification.ProcessHints.MultiPackageRoots)
 	slices.Sort(classification.ProcessHints.BazelRepoMarkers)
 	slices.Sort(classification.ProcessHints.BazelPackageRoots)
+	slices.Sort(classification.ProcessHints.NodePackageManagers)
+	slices.Sort(classification.ProcessHints.NodeLockFiles)
+	slices.Sort(classification.ProcessHints.TypeScriptConfigs)
 	return classification
 }
 
@@ -352,6 +367,40 @@ func cargoTomlHasWorkspace(path string) bool {
 		return false
 	}
 	return strings.Contains(string(data), "[workspace]")
+}
+
+func detectNodeJSTechStack(absPath string, classification *Classification) {
+	if !fileExists(filepath.Join(absPath, "package.json")) {
+		return
+	}
+
+	for _, lockFile := range []string{"package-lock.json", "npm-shrinkwrap.json"} {
+		if fileExists(filepath.Join(absPath, lockFile)) {
+			classification.ProcessHints.NodeLockFiles = append(classification.ProcessHints.NodeLockFiles, lockFile)
+			if !slices.Contains(classification.ProcessHints.NodePackageManagers, "npm") {
+				classification.ProcessHints.NodePackageManagers = append(classification.ProcessHints.NodePackageManagers, "npm")
+			}
+		}
+	}
+	if fileExists(filepath.Join(absPath, "yarn.lock")) {
+		classification.ProcessHints.NodeLockFiles = append(classification.ProcessHints.NodeLockFiles, "yarn.lock")
+		classification.ProcessHints.NodePackageManagers = append(classification.ProcessHints.NodePackageManagers, "yarn")
+	}
+	if fileExists(filepath.Join(absPath, "pnpm-lock.yaml")) {
+		classification.ProcessHints.NodeLockFiles = append(classification.ProcessHints.NodeLockFiles, "pnpm-lock.yaml")
+		classification.ProcessHints.NodePackageManagers = append(classification.ProcessHints.NodePackageManagers, "pnpm")
+	}
+	if len(classification.ProcessHints.NodePackageManagers) == 0 {
+		classification.ProcessHints.NodePackageManagers = append(classification.ProcessHints.NodePackageManagers, "npm")
+	}
+
+	for _, tsConfig := range []string{"tsconfig.json", "tsconfig.build.json"} {
+		if fileExists(filepath.Join(absPath, tsConfig)) {
+			classification.ProcessHints.TypeScriptConfigs = append(classification.ProcessHints.TypeScriptConfigs, tsConfig)
+		}
+	}
+
+	classification.TechStacks = append(classification.TechStacks, TechStackNodeJS)
 }
 
 func isGradleMultiProject(path string, settingsFiles []string) bool {

--- a/internal/repo/repo_test.go
+++ b/internal/repo/repo_test.go
@@ -260,6 +260,157 @@ func TestClassifyMonorepoUsesUnknownStackFallback(t *testing.T) {
 	}
 }
 
+func TestClassifyNodeJSRepoFromPackageJSON(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{\"name\":\"demo\"}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Classify(dir)
+
+	if len(got.TechStacks) != 1 || got.TechStacks[0] != TechStackNodeJS {
+		t.Fatalf("expected nodejs tech stack, got %#v", got.TechStacks)
+	}
+	if len(got.ProcessHints.NodePackageManagers) != 1 || got.ProcessHints.NodePackageManagers[0] != "npm" {
+		t.Fatalf("expected npm package manager, got %#v", got.ProcessHints.NodePackageManagers)
+	}
+	if len(got.ProcessHints.NodeLockFiles) != 1 || got.ProcessHints.NodeLockFiles[0] != "package-lock.json" {
+		t.Fatalf("expected package-lock.json lock file, got %#v", got.ProcessHints.NodeLockFiles)
+	}
+}
+
+func TestClassifyNodeJSRepoWithPnpm(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{\"name\":\"demo\"}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pnpm-lock.yaml"), []byte("lockfileVersion: 5\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Classify(dir)
+
+	if len(got.TechStacks) != 1 || got.TechStacks[0] != TechStackNodeJS {
+		t.Fatalf("expected nodejs tech stack, got %#v", got.TechStacks)
+	}
+	if len(got.ProcessHints.NodePackageManagers) != 1 || got.ProcessHints.NodePackageManagers[0] != "pnpm" {
+		t.Fatalf("expected pnpm package manager, got %#v", got.ProcessHints.NodePackageManagers)
+	}
+	if len(got.ProcessHints.NodeLockFiles) != 1 || got.ProcessHints.NodeLockFiles[0] != "pnpm-lock.yaml" {
+		t.Fatalf("expected pnpm-lock.yaml lock file, got %#v", got.ProcessHints.NodeLockFiles)
+	}
+}
+
+func TestClassifyNodeJSRepoWithYarn(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{\"name\":\"demo\"}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "yarn.lock"), []byte("# yarn lockfile\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Classify(dir)
+
+	if len(got.TechStacks) != 1 || got.TechStacks[0] != TechStackNodeJS {
+		t.Fatalf("expected nodejs tech stack, got %#v", got.TechStacks)
+	}
+	if len(got.ProcessHints.NodePackageManagers) != 1 || got.ProcessHints.NodePackageManagers[0] != "yarn" {
+		t.Fatalf("expected yarn package manager, got %#v", got.ProcessHints.NodePackageManagers)
+	}
+}
+
+func TestClassifyNodeJSRepoWithTypeScript(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{\"name\":\"demo\"}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte("{\"compilerOptions\":{}}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Classify(dir)
+
+	if len(got.TechStacks) != 1 || got.TechStacks[0] != TechStackNodeJS {
+		t.Fatalf("expected nodejs tech stack, got %#v", got.TechStacks)
+	}
+	if len(got.ProcessHints.TypeScriptConfigs) != 1 || got.ProcessHints.TypeScriptConfigs[0] != "tsconfig.json" {
+		t.Fatalf("expected tsconfig.json, got %#v", got.ProcessHints.TypeScriptConfigs)
+	}
+}
+
+func TestClassifyNodeJSRepoDefaultsToNpmWhenNoLockFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{\"name\":\"demo\"}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Classify(dir)
+
+	if len(got.TechStacks) != 1 || got.TechStacks[0] != TechStackNodeJS {
+		t.Fatalf("expected nodejs tech stack, got %#v", got.TechStacks)
+	}
+	if len(got.ProcessHints.NodePackageManagers) != 1 || got.ProcessHints.NodePackageManagers[0] != "npm" {
+		t.Fatalf("expected npm default package manager, got %#v", got.ProcessHints.NodePackageManagers)
+	}
+	if len(got.ProcessHints.NodeLockFiles) != 0 {
+		t.Fatalf("expected no lock files, got %#v", got.ProcessHints.NodeLockFiles)
+	}
+}
+
+func TestClassifyNonNodeJSRepoHasNoTechStack(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/demo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Classify(dir)
+
+	if len(got.TechStacks) != 0 {
+		t.Fatalf("expected no tech stacks for Go repo, got %#v", got.TechStacks)
+	}
+	if len(got.ProcessHints.NodePackageManagers) != 0 {
+		t.Fatalf("expected no node package managers, got %#v", got.ProcessHints.NodePackageManagers)
+	}
+}
+
+func TestClassifyTurborepoMonorepoAlsoDetectsNodeJS(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte("{\"workspaces\":[\"apps/*\"]}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pnpm-workspace.yaml"), []byte("packages:\n  - apps/*\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "turbo.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pnpm-lock.yaml"), []byte("lockfileVersion: 5\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "tsconfig.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := Classify(dir)
+
+	if got.Shape != ShapeMonorepo {
+		t.Fatalf("expected monorepo, got %#v", got.Shape)
+	}
+	if len(got.TechStacks) != 1 || got.TechStacks[0] != TechStackNodeJS {
+		t.Fatalf("expected nodejs tech stack on turborepo, got %#v", got.TechStacks)
+	}
+	if len(got.ProcessHints.NodePackageManagers) != 1 || got.ProcessHints.NodePackageManagers[0] != "pnpm" {
+		t.Fatalf("expected pnpm, got %#v", got.ProcessHints.NodePackageManagers)
+	}
+	if len(got.ProcessHints.TypeScriptConfigs) != 1 {
+		t.Fatalf("expected tsconfig, got %#v", got.ProcessHints.TypeScriptConfigs)
+	}
+}
+
 func TestExpandPath(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/skill/security.go
+++ b/internal/skill/security.go
@@ -1,0 +1,87 @@
+package skill
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/nicobistolfi/vigilante/internal/repo"
+)
+
+func securityGuidanceForClassification(classification repo.Classification) string {
+	if !slices.Contains(classification.TechStacks, repo.TechStackNodeJS) {
+		return ""
+	}
+	return nodeJSSecurityGuidance(classification)
+}
+
+func nodeJSSecurityGuidance(classification repo.Classification) string {
+	sections := []string{
+		"JS/TS/Node security guidance for this repository (apply where relevant to touched code and workflow — do not broaden issue scope):",
+	}
+
+	sections = append(sections, dependencySupplyChainGuidance(classification)...)
+	sections = append(sections, packageManagerGuidance(classification)...)
+	sections = append(sections, runtimeSecureCodingGuidance()...)
+	if len(classification.ProcessHints.TypeScriptConfigs) > 0 {
+		sections = append(sections, typeScriptSafetyGuidance()...)
+	}
+	sections = append(sections, cicdSecretsGuidance()...)
+	sections = append(sections, staticAnalysisGuidance()...)
+	if classification.Shape == repo.ShapeMonorepo {
+		sections = append(sections, monorepoSecurityGuidance()...)
+	}
+
+	return strings.Join(sections, "\n")
+}
+
+func dependencySupplyChainGuidance(classification repo.Classification) []string {
+	lines := []string{
+		"- Dependency & supply-chain: use frozen-lockfile installs (`npm ci`, `pnpm install --frozen-lockfile`, `yarn install --immutable`) in CI and agent runs. Review lockfile changes for unexpected registry or integrity shifts. Prefer packages with npm provenance or sigstore signatures when choosing new dependencies. Scope packages correctly (`@org/pkg`) to avoid dependency-confusion attacks. Minimize new dependencies — prefer built-in Node APIs when practical.",
+	}
+	return lines
+}
+
+func packageManagerGuidance(classification repo.Classification) []string {
+	managers := classification.ProcessHints.NodePackageManagers
+	lines := []string{}
+	if slices.Contains(managers, "npm") {
+		lines = append(lines, "- npm hardening: prefer `npm ci` over `npm install` for reproducible builds. Use `--ignore-scripts` when installing untrusted packages. Review `.npmrc` for `ignore-scripts=false` or registry overrides that may weaken supply-chain safety.")
+	}
+	if slices.Contains(managers, "pnpm") {
+		lines = append(lines, "- pnpm hardening: rely on pnpm strict mode and its content-addressable store for integrity. Prefer `pnpm install --frozen-lockfile` in CI. Use `.npmrc` with `strict-peer-dependencies=true` when practical.")
+	}
+	if slices.Contains(managers, "yarn") {
+		lines = append(lines, "- Yarn hardening: prefer `yarn install --immutable` in CI. Use `yarn dlx` cautiously for one-off scripts. Review `.yarnrc.yml` for `enableScripts` and `nodeLinker` settings.")
+	}
+	return lines
+}
+
+func runtimeSecureCodingGuidance() []string {
+	return []string{
+		"- Runtime security: avoid prototype-pollution patterns (do not merge untrusted objects with spread/Object.assign into prototypes; prefer `Object.create(null)` or Map for lookup tables). Use `child_process.execFile` or `child_process.spawn` with explicit argv arrays instead of `child_process.exec` with string interpolation to prevent command injection. Use `crypto.randomUUID()` or `crypto.getRandomValues` instead of `Math.random()` for security-sensitive values. Validate untrusted input at system boundaries (user input, API payloads, URL parameters) with schema validation. Be aware of SSRF, path-traversal (`path.resolve` + prefix check), and ReDoS risks when handling external data.",
+	}
+}
+
+func typeScriptSafetyGuidance() []string {
+	return []string{
+		"- TypeScript safety: prefer `strict: true` compiler settings. Avoid `any` as an escape hatch for untrusted data — use `unknown` with runtime validation instead. Use branded types or validation libraries (zod, io-ts) at trust boundaries. Do not suppress type errors with `@ts-ignore` unless the suppression is documented and scoped.",
+	}
+}
+
+func cicdSecretsGuidance() []string {
+	return []string{
+		"- CI/CD & secrets: pin GitHub Actions to full commit SHAs rather than mutable tags. Use `permissions:` blocks with least privilege in workflow files. Never echo, log, or interpolate secrets in shell commands — use environment variables or secret-masking. Avoid storing tokens, keys, or credentials in source files, `.env` committed to git, or workflow logs.",
+	}
+}
+
+func staticAnalysisGuidance() []string {
+	return []string{
+		"- Static analysis: when the repository already uses ESLint, preserve or enable security-focused rules (eslint-plugin-security, eslint-plugin-no-unsanitized). When CodeQL, Semgrep, or similar SAST tools are configured, do not weaken or disable their rulesets. When proposing new tooling, prefer tools already present in the ecosystem over adding new dependencies.",
+	}
+}
+
+func monorepoSecurityGuidance() []string {
+	return []string{
+		"- Monorepo security: respect workspace dependency boundaries — do not introduce phantom dependencies (imports that rely on hoisting rather than explicit package.json declarations). Validate that shared packages do not leak internal secrets or credentials through exports. Be cautious with remote build caches that may expose environment variables or sensitive build artifacts. Ensure workspace publish workflows verify package integrity before publishing to registries.",
+	}
+}

--- a/internal/skill/security_test.go
+++ b/internal/skill/security_test.go
@@ -1,0 +1,175 @@
+package skill
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nicobistolfi/vigilante/internal/repo"
+)
+
+func TestSecurityGuidanceForNodeJSRepo(t *testing.T) {
+	classification := repo.Classification{
+		Shape:      repo.ShapeTraditional,
+		TechStacks: []repo.TechStack{repo.TechStackNodeJS},
+		ProcessHints: repo.ProcessHints{
+			NodePackageManagers: []string{"npm"},
+			NodeLockFiles:       []string{"package-lock.json"},
+			TypeScriptConfigs:   []string{"tsconfig.json"},
+		},
+	}
+
+	guidance := securityGuidanceForClassification(classification)
+
+	for _, text := range []string{
+		"JS/TS/Node security guidance",
+		"Dependency & supply-chain",
+		"frozen-lockfile",
+		"npm hardening",
+		"Runtime security",
+		"prototype-pollution",
+		"child_process.execFile",
+		"TypeScript safety",
+		"strict: true",
+		"CI/CD & secrets",
+		"pin GitHub Actions",
+		"Static analysis",
+		"ESLint",
+	} {
+		if !strings.Contains(guidance, text) {
+			t.Fatalf("guidance missing %q", text)
+		}
+	}
+}
+
+func TestSecurityGuidanceForNodeJSRepoWithPnpm(t *testing.T) {
+	classification := repo.Classification{
+		Shape:      repo.ShapeTraditional,
+		TechStacks: []repo.TechStack{repo.TechStackNodeJS},
+		ProcessHints: repo.ProcessHints{
+			NodePackageManagers: []string{"pnpm"},
+			NodeLockFiles:       []string{"pnpm-lock.yaml"},
+		},
+	}
+
+	guidance := securityGuidanceForClassification(classification)
+
+	if !strings.Contains(guidance, "pnpm hardening") {
+		t.Fatalf("guidance missing pnpm-specific content")
+	}
+	if strings.Contains(guidance, "- npm hardening:") {
+		t.Fatalf("guidance should not include npm-specific hardening section for pnpm-only repo")
+	}
+}
+
+func TestSecurityGuidanceForNodeJSRepoWithYarn(t *testing.T) {
+	classification := repo.Classification{
+		Shape:      repo.ShapeTraditional,
+		TechStacks: []repo.TechStack{repo.TechStackNodeJS},
+		ProcessHints: repo.ProcessHints{
+			NodePackageManagers: []string{"yarn"},
+			NodeLockFiles:       []string{"yarn.lock"},
+		},
+	}
+
+	guidance := securityGuidanceForClassification(classification)
+
+	if !strings.Contains(guidance, "Yarn hardening") {
+		t.Fatalf("guidance missing yarn-specific content")
+	}
+}
+
+func TestSecurityGuidanceOmitsTypeScriptWhenNotDetected(t *testing.T) {
+	classification := repo.Classification{
+		Shape:      repo.ShapeTraditional,
+		TechStacks: []repo.TechStack{repo.TechStackNodeJS},
+		ProcessHints: repo.ProcessHints{
+			NodePackageManagers: []string{"npm"},
+		},
+	}
+
+	guidance := securityGuidanceForClassification(classification)
+
+	if strings.Contains(guidance, "TypeScript safety") {
+		t.Fatalf("guidance should not include TypeScript section when no tsconfig detected")
+	}
+}
+
+func TestSecurityGuidanceIncludesMonorepoForMonorepoShape(t *testing.T) {
+	classification := repo.Classification{
+		Shape:         repo.ShapeMonorepo,
+		MonorepoStack: repo.MonorepoStackTurborepo,
+		TechStacks:    []repo.TechStack{repo.TechStackNodeJS},
+		ProcessHints: repo.ProcessHints{
+			NodePackageManagers: []string{"pnpm"},
+			NodeLockFiles:       []string{"pnpm-lock.yaml"},
+		},
+	}
+
+	guidance := securityGuidanceForClassification(classification)
+
+	if !strings.Contains(guidance, "Monorepo security") {
+		t.Fatalf("guidance missing monorepo security section")
+	}
+	if !strings.Contains(guidance, "phantom dependencies") {
+		t.Fatalf("guidance missing phantom dependency warning")
+	}
+}
+
+func TestSecurityGuidanceOmitsMonorepoForTraditionalShape(t *testing.T) {
+	classification := repo.Classification{
+		Shape:      repo.ShapeTraditional,
+		TechStacks: []repo.TechStack{repo.TechStackNodeJS},
+		ProcessHints: repo.ProcessHints{
+			NodePackageManagers: []string{"npm"},
+		},
+	}
+
+	guidance := securityGuidanceForClassification(classification)
+
+	if strings.Contains(guidance, "Monorepo security") {
+		t.Fatalf("guidance should not include monorepo section for traditional repo")
+	}
+}
+
+func TestSecurityGuidanceEmptyForNonNodeJSRepo(t *testing.T) {
+	classification := repo.Classification{
+		Shape: repo.ShapeTraditional,
+	}
+
+	guidance := securityGuidanceForClassification(classification)
+
+	if guidance != "" {
+		t.Fatalf("expected empty guidance for non-Node repo, got %q", guidance)
+	}
+}
+
+func TestSecurityGuidanceEmptyForGoRepo(t *testing.T) {
+	classification := repo.Classification{
+		Shape: repo.ShapeTraditional,
+		ProcessHints: repo.ProcessHints{
+			GradleSettingsFiles: []string{"settings.gradle"},
+		},
+	}
+
+	guidance := securityGuidanceForClassification(classification)
+
+	if guidance != "" {
+		t.Fatalf("expected empty guidance for non-Node repo, got %q", guidance)
+	}
+}
+
+func TestSecurityGuidanceDoesNotBroadenScope(t *testing.T) {
+	classification := repo.Classification{
+		Shape:      repo.ShapeTraditional,
+		TechStacks: []repo.TechStack{repo.TechStackNodeJS},
+		ProcessHints: repo.ProcessHints{
+			NodePackageManagers: []string{"npm"},
+		},
+	}
+
+	guidance := securityGuidanceForClassification(classification)
+
+	if !strings.Contains(guidance, "do not broaden issue scope") {
+		t.Fatalf("guidance missing scope-limiting instruction")
+	}
+}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -235,6 +235,9 @@ func BuildIssuePromptForRuntime(runtime string, target state.WatchTarget, issue 
 			fmt.Sprintf("When local services are required, use the `%s` skill instead of inventing ad hoc `vigilante docker compose` logic.", DockerComposeLaunch),
 		)
 	}
+	if guidance := securityGuidanceForClassification(target.Classification); guidance != "" {
+		lines = append(lines, guidance)
+	}
 	return strings.Join(lines, "\n")
 }
 
@@ -330,6 +333,7 @@ func repoClassificationJSON(target state.WatchTarget) string {
 	payload := struct {
 		Shape         repo.Shape         `json:"shape"`
 		MonorepoStack repo.MonorepoStack `json:"monorepo_stack,omitempty"`
+		TechStacks    []repo.TechStack   `json:"tech_stacks,omitempty"`
 		ProcessHints  *repo.ProcessHints `json:"process_hints,omitempty"`
 	}{
 		Shape: classification.Shape,
@@ -340,13 +344,19 @@ func repoClassificationJSON(target state.WatchTarget) string {
 		}
 		payload.MonorepoStack = classification.MonorepoStack
 	}
+	if len(classification.TechStacks) > 0 {
+		payload.TechStacks = classification.TechStacks
+	}
 	if len(classification.ProcessHints.WorkspaceConfigFiles) > 0 ||
 		len(classification.ProcessHints.WorkspaceManifestFiles) > 0 ||
 		len(classification.ProcessHints.MultiPackageRoots) > 0 ||
 		len(classification.ProcessHints.GradleSettingsFiles) > 0 ||
 		len(classification.ProcessHints.GradleRootBuildFiles) > 0 ||
 		len(classification.ProcessHints.BazelRepoMarkers) > 0 ||
-		len(classification.ProcessHints.BazelPackageRoots) > 0 {
+		len(classification.ProcessHints.BazelPackageRoots) > 0 ||
+		len(classification.ProcessHints.NodePackageManagers) > 0 ||
+		len(classification.ProcessHints.NodeLockFiles) > 0 ||
+		len(classification.ProcessHints.TypeScriptConfigs) > 0 {
 		payload.ProcessHints = &classification.ProcessHints
 	}
 	data, err := json.Marshal(payload)

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -1042,6 +1042,89 @@ func TestBazelMonorepoSkillCoversTargetSelectionAndDatabaseFlows(t *testing.T) {
 	}
 }
 
+func TestBuildIssuePromptIncludesSecurityGuidanceForNodeJSRepo(t *testing.T) {
+	target := state.WatchTarget{
+		Path: "/tmp/repo",
+		Repo: "owner/repo",
+		Classification: repo.Classification{
+			Shape:      repo.ShapeTraditional,
+			TechStacks: []repo.TechStack{repo.TechStackNodeJS},
+			ProcessHints: repo.ProcessHints{
+				NodePackageManagers: []string{"npm"},
+				NodeLockFiles:       []string{"package-lock.json"},
+				TypeScriptConfigs:   []string{"tsconfig.json"},
+			},
+		},
+	}
+	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
+	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
+
+	prompt := BuildIssuePrompt(target, issue, session)
+
+	for _, text := range []string{
+		"JS/TS/Node security guidance",
+		"Dependency & supply-chain",
+		"npm hardening",
+		"Runtime security",
+		"TypeScript safety",
+		"CI/CD & secrets",
+		"Static analysis",
+		`"tech_stacks":["nodejs"]`,
+		`"node_package_managers":["npm"]`,
+		`"node_lock_files":["package-lock.json"]`,
+		`"typescript_configs":["tsconfig.json"]`,
+	} {
+		if !strings.Contains(prompt, text) {
+			t.Fatalf("prompt missing %q", text)
+		}
+	}
+}
+
+func TestBuildIssuePromptExcludesSecurityGuidanceForNonNodeRepo(t *testing.T) {
+	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
+	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
+	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
+
+	prompt := BuildIssuePrompt(target, issue, session)
+
+	if strings.Contains(prompt, "JS/TS/Node security guidance") {
+		t.Fatalf("prompt should not include JS security guidance for non-Node repo")
+	}
+}
+
+func TestBuildIssuePromptIncludesSecurityGuidanceForMonorepoNodeJS(t *testing.T) {
+	target := state.WatchTarget{
+		Path: "/tmp/repo",
+		Repo: "owner/repo",
+		Classification: repo.Classification{
+			Shape:         repo.ShapeMonorepo,
+			MonorepoStack: repo.MonorepoStackTurborepo,
+			TechStacks:    []repo.TechStack{repo.TechStackNodeJS},
+			ProcessHints: repo.ProcessHints{
+				WorkspaceConfigFiles: []string{"pnpm-workspace.yaml", "turbo.json"},
+				MultiPackageRoots:    []string{"apps", "packages"},
+				NodePackageManagers:  []string{"pnpm"},
+				NodeLockFiles:        []string{"pnpm-lock.yaml"},
+			},
+		},
+	}
+	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
+	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
+
+	prompt := BuildIssuePrompt(target, issue, session)
+
+	for _, text := range []string{
+		"JS/TS/Node security guidance",
+		"pnpm hardening",
+		"Monorepo security",
+		"phantom dependencies",
+	} {
+		if !strings.Contains(prompt, text) {
+			t.Fatalf("prompt missing %q", text)
+		}
+	}
+}
+
 func TestBuildIssueCreatePromptContainsExpectedFields(t *testing.T) {
 	target := state.WatchTarget{
 		Repo:         "owner/repo",


### PR DESCRIPTION
## Summary

- Adds stack-aware security guidance to Vigilante prompt assembly for JavaScript, TypeScript, and Node.js repositories
- Extends repository classification with `TechStack` detection and Node.js-specific `ProcessHints` (package managers, lockfiles, TypeScript configs)
- Creates `internal/skill/security.go` with curated, concise guidance covering dependency/supply-chain, package-manager hardening (npm/pnpm/yarn), runtime secure-coding, TypeScript safety, CI/CD secrets, static analysis, and monorepo concerns
- Non-JS repositories receive no JS-specific security guidance
- Guidance adapts to detected ecosystem signals (e.g., pnpm-only repos get pnpm hardening, monorepos get workspace boundary guidance)
- Existing prompt and skill policies (`vigilante commit`, issue comments, validation) remain intact

## Validation

- `go test ./...` — all packages pass
- `gofmt -l .` — no formatting issues
- `go vet ./...` — no vet warnings
- `go build ./...` — builds cleanly
- New tests cover: Node.js detection for npm/pnpm/yarn, TypeScript detection, default fallback to npm, non-Node repos excluded, monorepo repos get monorepo guidance, traditional repos don't, prompt assembly integration for Node.js and non-Node repos

## Test plan

- [x] Verify JS/TS/Node repos receive security guidance in generated prompts
- [x] Verify non-JS repos (Go, Gradle, etc.) do not receive JS-specific guidance
- [x] Verify guidance adapts to detected package manager (npm, pnpm, yarn)
- [x] Verify TypeScript guidance is conditional on tsconfig detection
- [x] Verify monorepo security guidance is conditional on monorepo shape
- [x] Verify repo classification JSON includes tech_stacks and node hints
- [x] Verify existing prompt tests continue to pass unchanged

Closes #352