### PR TITLE
Fix frozen clock so dirty-worktree auto-recovery triggers (#367)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -174,7 +174,7 @@ func New() *App {
 		stderr:       os.Stderr,
 		state:        store,
 		logger:       logger,
-		clock:        time.Now().UTC,
+		clock:        func() time.Time { return time.Now().UTC() },
 		issueTracker: ghBackend,
 		labelManager: ghBackend,
 		prManager:    ghBackend,

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -4092,6 +4092,71 @@ func TestShouldAutoRecoverBlockedSession(t *testing.T) {
 	}
 }
 
+func TestNewAppClockReturnsLiveTime(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	t1 := app.clock()
+	time.Sleep(5 * time.Millisecond)
+	t2 := app.clock()
+	if !t2.After(t1) {
+		t.Fatalf("expected clock to advance: t1=%v t2=%v", t1, t2)
+	}
+	if t1.Location() != time.UTC {
+		t.Fatalf("expected UTC, got %v", t1.Location())
+	}
+}
+
+func TestBlockedDirtyWorktreeSessionSkipsAutoRecoveryBeforeTimeout(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 3, 12, 18, 0, 0, 0, time.UTC)
+	// Session was blocked only 3 minutes ago, well within the 10-minute auto-recovery timeout.
+	recent := now.Add(-3 * time.Minute)
+	if err := os.Chtimes(worktreePath, recent, recent); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.clock = func() time.Time { return now }
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1/comments": "[]",
+		},
+	}
+
+	inactive, err := app.blockedSessionExceededInactivityTimeout(context.Background(), state.Session{
+		Repo:         "owner/repo",
+		IssueNumber:  1,
+		Branch:       "vigilante/issue-1",
+		WorktreePath: worktreePath,
+		Status:       state.SessionStatusBlocked,
+		BlockedAt:    recent.Format(time.RFC3339),
+		BlockedStage: "pr_maintenance",
+		BlockedReason: state.BlockedReason{
+			Kind:    "dirty_worktree",
+			Summary: "worktree is not clean before PR maintenance",
+		},
+		UpdatedAt: recent.Format(time.RFC3339),
+	}, 10*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inactive {
+		t.Fatal("expected recently blocked dirty-worktree session to NOT exceed inactivity timeout before auto-recovery window")
+	}
+}
+
 func TestScanOnceCleansUpBlockedSessionAfterDefaultInactivityTimeout(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))


### PR DESCRIPTION
## Summary

- Fix `App.New()` assigning `clock: time.Now().UTC` (a bound method value capturing a frozen startup timestamp) instead of a live closure — every call to `a.clock()` returned the same time, preventing `blockedSessionExceededInactivityTimeout` from aging blocked sessions past the auto-recovery window
- Replace with `func() time.Time { return time.Now().UTC() }` so timeout comparisons use wall clock time
- Add regression tests: `TestNewAppClockReturnsLiveTime` (successive calls advance) and `TestBlockedDirtyWorktreeSessionSkipsAutoRecoveryBeforeTimeout` (recently blocked session stays below timeout)

## Test plan

- [x] `TestNewAppClockReturnsLiveTime` — verifies `New()` clock returns advancing UTC time
- [x] `TestBlockedDirtyWorktreeSessionSkipsAutoRecoveryBeforeTimeout` — negative case: recently blocked session not prematurely recovered
- [x] `TestScanOnceAutoRecoversStaleBlockedMaintenanceSession` — existing e2e recovery path still passes
- [x] `TestShouldAutoRecoverBlockedSession` — existing blocked-session eligibility logic unchanged
- [x] `TestBlockedSessionExceededInactivityTimeout*` — all 3 existing inactivity activity-signal tests pass
- [x] Full test suite passes (`go test ./...`)

Closes #367