### PR TITLE
Prevent scan starvation during PR maintenance

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2010,77 +2010,18 @@ func sessionAffectedByGitHubRateLimitPause(session state.Session) bool {
 func (a *App) maintainPullRequests(ctx context.Context, sessions []state.Session, issueCache scanIssueDetailsCache) ([]state.Session, error) {
 	for i := range sessions {
 		session := &sessions[i]
-		sessionCtx := withSessionAccessLogContext(ctx, "maintenance", *session)
 		if session.Status != state.SessionStatusSuccess || session.CleanupCompletedAt != "" || session.MonitoringStoppedAt != "" {
+			continue
+		}
+		if session.PullRequestMaintenanceInFlight {
 			continue
 		}
 		if shouldDelaySuccessfulSessionPoll(*session, a.clock()) {
 			continue
 		}
-
-		pr, err := a.prManager.FindPullRequestForBranch(sessionCtx, session.Repo, pullRequestHeadSelector(*session))
-		if err != nil {
-			session.LastMaintenanceError = err.Error()
-			session.UpdatedAt = a.clock().Format(time.RFC3339)
-			a.logger.Error("pr lookup failed", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "err", err)
-			continue
-		}
-		if pr == nil {
-			continue
-		}
-
-		updatePullRequestTrackingFromLookup(session, *pr)
-		if pr.MergedAt == nil {
-			if pr.State != "OPEN" {
-				if err := a.cleanupSessionArtifacts(sessionCtx, session, "pull_request_closed"); err != nil {
-					a.logger.Error("cleanup failed", "repo", session.Repo, "issue", session.IssueNumber, "pr", pr.Number, "branch", session.Branch, "worktree", session.WorktreePath, "state", pr.State, "err", err)
-					continue
-				}
-				a.logger.Info("cleanup complete", "repo", session.Repo, "issue", session.IssueNumber, "pr", pr.Number, "branch", session.Branch, "worktree", session.WorktreePath, "state", pr.State)
-				a.syncSessionIssueLabelsBestEffort(ctx, session, pr, nil, issueCache)
-				continue
-			}
-			detailedPR, issueDetails, err := a.maintainOpenPullRequest(sessionCtx, session, *pr, issueCache)
-			if err != nil {
-				session.UpdatedAt = a.clock().Format(time.RFC3339)
-				a.logger.Error("pr maintenance failed", "repo", session.Repo, "issue", session.IssueNumber, "pr", pr.Number, "branch", session.Branch, "err", err)
-				if shouldCommentMaintenanceFailure(*session, err) {
-					blocked := classifyBlockedReason("pr_maintenance", "git fetch origin main", err)
-					previousStatus := session.Status
-					markSessionBlocked(session, "pr_maintenance", blocked, a.clock())
-					a.emitSessionTransition(previousStatus, *session, "pr_maintenance")
-					body := ghcli.FormatProgressComment(ghcli.ProgressComment{
-						Stage:      "Blocked",
-						Emoji:      "🧱",
-						Percent:    85,
-						ETAMinutes: 15,
-						Items: []string{
-							maintenanceBlockedMessage(blocked, pr.Number, session.Branch),
-							blocking.CauseLine(blocked),
-							fmt.Sprintf("Next step: fix the blocker, then run `%s` or request resume from GitHub.", session.ResumeHint),
-						},
-						Tagline: "Difficulties strengthen the mind, as labor does the body.",
-					})
-					if commentErr := a.commentOnIssue(sessionCtx, session.Repo, session.IssueNumber, body, "blocked", "pr_maintenance"); commentErr != nil {
-						a.logger.Error("pr maintenance failure comment failed", "repo", session.Repo, "issue", session.IssueNumber, "pr", pr.Number, "err", commentErr)
-					}
-					session.LastMaintenanceError = err.Error()
-				}
-				a.syncSessionIssueLabelsBestEffort(ctx, session, pr, nil, issueCache)
-				continue
-			}
-			a.syncSessionIssueLabelsBestEffort(ctx, session, detailedPR, issueDetails, issueCache)
-			continue
-		}
-
-		session.PullRequestMergedAt = pr.MergedAt.UTC().Format(time.RFC3339)
-		if err := a.cleanupSessionArtifacts(sessionCtx, session, "pull_request_merged"); err != nil {
-			a.logger.Error("cleanup failed", "repo", session.Repo, "issue", session.IssueNumber, "pr", session.PullRequestNumber, "branch", session.Branch, "worktree", session.WorktreePath, "merged_at", session.PullRequestMergedAt, "err", err)
-			continue
-		}
-
-		a.logger.Info("cleanup complete", "repo", session.Repo, "issue", session.IssueNumber, "pr", session.PullRequestNumber, "branch", session.Branch, "worktree", session.WorktreePath, "source", "pull_request_merged", "merged_at", session.PullRequestMergedAt)
-		a.syncSessionIssueLabelsBestEffort(ctx, session, pr, nil, issueCache)
+		session.PullRequestMaintenanceInFlight = true
+		session.UpdatedAt = a.clock().Format(time.RFC3339)
+		a.launchPullRequestMaintenance(ctx, *session, issueCache[sessionKey(session.Repo, session.IssueNumber)])
 	}
 
 	return sessions, nil
@@ -2091,6 +2032,9 @@ func (a *App) cleanupClosedIssueSessions(ctx context.Context, sessions []state.S
 		session := &sessions[i]
 		sessionCtx := withSessionAccessLogContext(ctx, "maintenance", *session)
 		if session.Status != state.SessionStatusSuccess || session.CleanupCompletedAt != "" || session.MonitoringStoppedAt != "" {
+			continue
+		}
+		if session.PullRequestMaintenanceInFlight {
 			continue
 		}
 		if shouldDelaySuccessfulSessionPoll(*session, a.clock()) {
@@ -2189,6 +2133,131 @@ func (a *App) launchIssueSession(ctx context.Context, target state.WatchTarget, 
 		a.syncSessionIssueLabelsBestEffort(ctx, &result, nil, nil, nil)
 		a.logger.Info("scan repo session finished", "repo", target.Repo, "issue", issue.Number, "status", result.Status)
 	}()
+}
+
+func (a *App) launchPullRequestMaintenance(ctx context.Context, session state.Session, seededIssueDetails *ghcli.IssueDetails) {
+	a.sessionWG.Add(1)
+	go func() {
+		defer a.sessionWG.Done()
+
+		issueCache := make(scanIssueDetailsCache)
+		if seededIssueDetails != nil {
+			issueCache[sessionKey(session.Repo, session.IssueNumber)] = seededIssueDetails
+		}
+		result := session
+		pr, issueDetails, _ := a.runPullRequestMaintenance(ctx, &result, issueCache)
+
+		a.sessionMu.Lock()
+		sessions, loadErr := a.state.LoadSessions()
+		if loadErr != nil {
+			a.sessionMu.Unlock()
+			a.logger.Error("pr maintenance result load failed", "repo", session.Repo, "issue", session.IssueNumber, "err", loadErr)
+			return
+		}
+
+		latest, ok := findSession(sessions, session.Repo, session.IssueNumber)
+		if !ok {
+			a.sessionMu.Unlock()
+			return
+		}
+		if !latest.PullRequestMaintenanceInFlight {
+			a.sessionMu.Unlock()
+			return
+		}
+		if latest.Status != state.SessionStatusSuccess || latest.CleanupCompletedAt != "" || latest.MonitoringStoppedAt != "" {
+			latest.PullRequestMaintenanceInFlight = false
+			latest.UpdatedAt = a.clock().Format(time.RFC3339)
+			sessions = upsertSession(sessions, latest)
+			if saveErr := a.state.SaveSessions(sessions); saveErr != nil {
+				a.sessionMu.Unlock()
+				a.logger.Error("pr maintenance result save failed", "repo", session.Repo, "issue", session.IssueNumber, "err", saveErr)
+				return
+			}
+			a.sessionMu.Unlock()
+			return
+		}
+
+		result.PullRequestMaintenanceInFlight = false
+		sessions = upsertSession(sessions, result)
+		if saveErr := a.state.SaveSessions(sessions); saveErr != nil {
+			a.sessionMu.Unlock()
+			a.logger.Error("pr maintenance result save failed", "repo", session.Repo, "issue", session.IssueNumber, "err", saveErr)
+			return
+		}
+		a.sessionMu.Unlock()
+
+		if issueDetails == nil {
+			issueDetails = issueCache[sessionKey(result.Repo, result.IssueNumber)]
+		}
+		a.syncSessionIssueLabelsBestEffort(ctx, &result, pr, issueDetails, issueCache)
+	}()
+}
+
+func (a *App) runPullRequestMaintenance(ctx context.Context, session *state.Session, issueCache scanIssueDetailsCache) (*ghcli.PullRequest, *ghcli.IssueDetails, error) {
+	sessionCtx := withSessionAccessLogContext(ctx, "maintenance", *session)
+	prManager := a.prManagerForSession(*session)
+
+	pr, err := prManager.FindPullRequestForBranch(sessionCtx, session.Repo, pullRequestHeadSelector(*session))
+	if err != nil {
+		session.LastMaintenanceError = err.Error()
+		session.UpdatedAt = a.clock().Format(time.RFC3339)
+		a.logger.Error("pr lookup failed", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "err", err)
+		return nil, nil, err
+	}
+	if pr == nil {
+		return nil, nil, nil
+	}
+
+	updatePullRequestTrackingFromLookup(session, *pr)
+	if pr.MergedAt == nil {
+		if pr.State != "OPEN" {
+			if err := a.cleanupSessionArtifacts(sessionCtx, session, "pull_request_closed"); err != nil {
+				a.logger.Error("cleanup failed", "repo", session.Repo, "issue", session.IssueNumber, "pr", pr.Number, "branch", session.Branch, "worktree", session.WorktreePath, "state", pr.State, "err", err)
+				return pr, nil, err
+			}
+			a.logger.Info("cleanup complete", "repo", session.Repo, "issue", session.IssueNumber, "pr", pr.Number, "branch", session.Branch, "worktree", session.WorktreePath, "state", pr.State)
+			return pr, nil, nil
+		}
+
+		detailedPR, issueDetails, err := a.maintainOpenPullRequest(sessionCtx, session, *pr, issueCache)
+		if err != nil {
+			session.UpdatedAt = a.clock().Format(time.RFC3339)
+			a.logger.Error("pr maintenance failed", "repo", session.Repo, "issue", session.IssueNumber, "pr", pr.Number, "branch", session.Branch, "err", err)
+			if shouldCommentMaintenanceFailure(*session, err) {
+				blocked := classifyBlockedReason("pr_maintenance", "git fetch origin main", err)
+				previousStatus := session.Status
+				markSessionBlocked(session, "pr_maintenance", blocked, a.clock())
+				a.emitSessionTransition(previousStatus, *session, "pr_maintenance")
+				body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+					Stage:      "Blocked",
+					Emoji:      "🧱",
+					Percent:    85,
+					ETAMinutes: 15,
+					Items: []string{
+						maintenanceBlockedMessage(blocked, pr.Number, session.Branch),
+						blocking.CauseLine(blocked),
+						fmt.Sprintf("Next step: fix the blocker, then run `%s` or request resume from GitHub.", session.ResumeHint),
+					},
+					Tagline: "Difficulties strengthen the mind, as labor does the body.",
+				})
+				if commentErr := a.commentOnIssue(sessionCtx, session.Repo, session.IssueNumber, body, "blocked", "pr_maintenance"); commentErr != nil {
+					a.logger.Error("pr maintenance failure comment failed", "repo", session.Repo, "issue", session.IssueNumber, "pr", pr.Number, "err", commentErr)
+				}
+				session.LastMaintenanceError = err.Error()
+			}
+			return pr, nil, err
+		}
+		return detailedPR, issueDetails, nil
+	}
+
+	session.PullRequestMergedAt = pr.MergedAt.UTC().Format(time.RFC3339)
+	if err := a.cleanupSessionArtifacts(sessionCtx, session, "pull_request_merged"); err != nil {
+		a.logger.Error("cleanup failed", "repo", session.Repo, "issue", session.IssueNumber, "pr", session.PullRequestNumber, "branch", session.Branch, "worktree", session.WorktreePath, "merged_at", session.PullRequestMergedAt, "err", err)
+		return pr, nil, err
+	}
+
+	a.logger.Info("cleanup complete", "repo", session.Repo, "issue", session.IssueNumber, "pr", session.PullRequestNumber, "branch", session.Branch, "worktree", session.WorktreePath, "source", "pull_request_merged", "merged_at", session.PullRequestMergedAt)
+	return pr, nil, nil
 }
 
 func (a *App) waitForSessions() {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -39,6 +40,14 @@ type countingRunner struct {
 	counts map[string]int
 }
 
+type blockingMaintenanceRunner struct {
+	base     testutil.FakeRunner
+	blockDir string
+	started  chan struct{}
+	release  chan struct{}
+	once     sync.Once
+}
+
 func (r *countingRunner) Run(ctx context.Context, dir string, name string, args ...string) (string, error) {
 	if r.counts == nil {
 		r.counts = make(map[string]int)
@@ -48,6 +57,24 @@ func (r *countingRunner) Run(ctx context.Context, dir string, name string, args 
 }
 
 func (r *countingRunner) LookPath(file string) (string, error) {
+	return r.base.LookPath(file)
+}
+
+func (r *blockingMaintenanceRunner) Run(ctx context.Context, dir string, name string, args ...string) (string, error) {
+	if dir == r.blockDir && testutil.Key(name, args...) == "git fetch origin main" {
+		r.once.Do(func() {
+			close(r.started)
+		})
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-r.release:
+		}
+	}
+	return r.base.Run(ctx, dir, name, args...)
+}
+
+func (r *blockingMaintenanceRunner) LookPath(file string) (string, error) {
 	return r.base.LookPath(file)
 }
 
@@ -5172,6 +5199,144 @@ func TestScanOnceMaintainedIssueDoesNotConsumeOnlyDispatchSlot(t *testing.T) {
 	}
 	if sessions[1].IssueNumber != 2 || sessions[1].Status != state.SessionStatusSuccess {
 		t.Fatalf("expected issue #2 to complete a new session: %#v", sessions[1])
+	}
+}
+
+func TestScanOnceLongRunningPRMaintenanceDoesNotBlockFreshScans(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	worktreePath1 := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	worktreePath2 := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-2")
+	branch2 := "vigilante/issue-2-second"
+	if err := os.MkdirAll(worktreePath1, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+
+	var stdout bytes.Buffer
+	app := New()
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	runner := &blockingMaintenanceRunner{
+		blockDir: worktreePath1,
+		started:  make(chan struct{}),
+		release:  make(chan struct{}),
+		base: testutil.FakeRunner{
+			LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+			Outputs: mergeStringMaps(freshBaseBranchOutputs(repoPath, "main"), map[string]string{
+				"gh api user --jq .login": "nicobistolfi\n",
+				"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
+				"git fetch origin main":  "ok",
+				"git status --porcelain": "",
+				"git rebase origin/main": "Current branch vigilante/issue-1 is up to date.\n",
+				"gh pr view --repo owner/repo 31 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,baseRefName": `{"number":31,"title":"Test PR","body":"Test PR body","url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null,"labels":[],"isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","reviewDecision":"APPROVED","statusCheckRollup":[{"context":"test","state":"IN_PROGRESS","conclusion":""}],"baseRefName":"main"}`,
+				"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels":                                                      `[{"number":1,"title":"first","createdAt":"2026-03-09T12:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[{"name":"to-do"}]},{"number":2,"title":"second","createdAt":"2026-03-10T12:00:00Z","url":"https://github.com/owner/repo/issues/2","labels":[{"name":"to-do"}]}]`,
+				"git worktree prune": "ok",
+				"git worktree add -b " + branch2 + " " + worktreePath2 + " origin/main":                                                       "ok",
+				sessionStartCommentCommand("owner/repo", 2, worktreePath2, state.Session{Branch: branch2}):                                    "ok",
+				preflightPromptCommand(worktreePath2, "owner/repo", repoPath, 2, "second", "https://github.com/owner/repo/issues/2", branch2): "baseline ok",
+				issuePromptCommand(worktreePath2, "owner/repo", repoPath, 2, "second", "https://github.com/owner/repo/issues/2", branch2):     "done",
+				"gh api repos/owner/repo/issues/1":          `{"title":"first","body":"Issue body","html_url":"https://github.com/owner/repo/issues/1","state":"open","labels":[]}`,
+				"gh api repos/owner/repo/issues/1/comments": "[]",
+			}),
+			Errors: map[string]error{
+				"git show-ref --verify --quiet refs/heads/" + branch2:        errors.New("exit status 1"),
+				"git show-ref --verify --quiet refs/heads/vigilante/issue-2": errors.New("exit status 1"),
+			},
+		},
+	}
+	app.env.Runner = runner
+
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: repoPath, Repo: "owner/repo", Branch: "main", Assignee: "me", Labels: []string{"to-do"}, MaxParallel: 1}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:     repoPath,
+		Repo:         "owner/repo",
+		IssueNumber:  1,
+		IssueTitle:   "first",
+		IssueURL:     "https://github.com/owner/repo/issues/1",
+		Branch:       "vigilante/issue-1",
+		WorktreePath: worktreePath1,
+		Status:       state.SessionStatusSuccess,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- app.ScanOnce(context.Background())
+	}()
+
+	select {
+	case <-runner.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for maintenance to start")
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ScanOnce blocked on long-running PR maintenance")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		sessions, err := app.state.LoadSessions()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(sessions) == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected fresh issue dispatch while maintenance was in flight, sessions=%#v", sessions)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	targets, err := app.state.LoadWatchTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 || targets[0].LastScanAt == "" {
+		t.Fatalf("expected watch target last_scan_at to advance during maintenance, got %#v", targets)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions[0].IssueNumber != 1 || !sessions[0].PullRequestMaintenanceInFlight {
+		t.Fatalf("expected issue #1 maintenance to remain in flight, got %#v", sessions[0])
+	}
+	if sessions[1].IssueNumber != 2 {
+		t.Fatalf("expected second issue to be dispatched, got %#v", sessions)
+	}
+	if got := stdout.String(); !strings.Contains(got, "repo: owner/repo started issue #2 in "+worktreePath2) || !strings.Contains(got, "scanned 1 watch target(s), started 1 issue session(s)") {
+		t.Fatalf("unexpected output: %s", got)
+	}
+
+	close(runner.release)
+	app.waitForSessions()
+
+	sessions, err = app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions[0].PullRequestMaintenanceInFlight {
+		t.Fatalf("expected maintenance flag to clear after completion: %#v", sessions[0])
+	}
+	if sessions[0].LastMaintenanceError != "pr maintenance waiting for required checks on PR #31" {
+		t.Fatalf("expected maintenance wait state after completion, got %#v", sessions[0])
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -171,6 +171,7 @@ type Session struct {
 	PullRequestReviewDecision      string        `json:"pull_request_review_decision,omitempty"`
 	PullRequestChecksState         string        `json:"pull_request_checks_state,omitempty"`
 	PullRequestStatusFingerprint   string        `json:"pull_request_status_fingerprint,omitempty"`
+	PullRequestMaintenanceInFlight bool          `json:"pull_request_maintenance_in_flight,omitempty"`
 	LastMaintainedAt               string        `json:"last_maintained_at,omitempty"`
 	LastMaintenanceError           string        `json:"last_maintenance_error,omitempty"`
 	LastCIRemediationFingerprint   string        `json:"last_ci_remediation_fingerprint,omitempty"`


### PR DESCRIPTION
## Summary
- schedule PR maintenance on a background worker instead of blocking the scan loop
- guard each success session with an in-flight flag so maintenance is not duplicated across scan ticks
- add a regression test proving fresh scans and dispatch continue while maintenance is still running

## Validation
- `go test ./... -count=1`
- `go vet ./internal/app/... ./internal/state/...`

Closes #382