### PR TITLE
Document package hardening from PR #390 in README and DOCS.md

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -625,6 +625,63 @@ For pull requests tied to an active Vigilante session:
 - keep the legacy plain `automerge` PR label working as a compatibility alias during migration to the namespaced label
 - never force through branch protection, required reviews, or failing checks
 
+## Package Hardening
+
+Vigilante runs a deterministic, code-driven package hardening scan for watched repositories classified with the `nodejs` tech stack. The scan is not LLM-driven — all checks use static analysis of manifest files, lockfiles, and CI configuration.
+
+### When the Scan Runs
+
+The hardening scan triggers after a coding-agent session pushes a branch upstream. Vigilante uses `git diff` against the PR base branch to detect whether any `package.json` files were added or modified. If no `package.json` changes are found, the scan is skipped. The scan does not list all open PRs — it only runs in the context of a session that just pushed.
+
+### Checks Performed
+
+The scan performs the following deterministic checks:
+
+- **Lockfile presence** (`lockfile-present`): Checks whether a `package-lock.json`, `pnpm-lock.yaml`, or `yarn.lock` exists at the repository root. A missing lockfile means dependency resolution is non-deterministic and is flagged as high severity.
+- **npm audit** (`npm-audit-vulnerabilities`): When the detected package manager is npm and a lockfile is present, Vigilante runs `npm audit --json` in the worktree and reports known vulnerabilities. If the lockfile is missing, the audit is skipped with a medium-severity finding explaining why.
+- **Non-exact dependency ranges** (`non-exact-ranges`): Flags dependencies in `package.json` that use range specifiers (`^`, `~`, `>`, `<`, `*`, `||`) instead of exact pinned versions. This is reported as low severity since lockfiles typically pin transitive versions.
+- **CI deterministic install** (`ci-deterministic-install`): Scans GitHub Actions workflow files for deterministic install commands (`npm ci`, `pnpm install --frozen-lockfile`, `yarn install --immutable`). A missing deterministic install step is flagged as medium severity.
+- **CI audit step** (`ci-audit-step`): Checks whether CI workflows include a dependency audit step. A missing audit step is flagged as low severity.
+
+### PR Comment and Label Behavior
+
+When findings are present, Vigilante:
+
+1. Posts a structured PR comment with a findings table showing severity, check name, and details. The comment includes a collapsible remediation section with specific fix instructions for each finding.
+2. Applies the `vigilante:flagged-security-review` label to the pull request.
+3. Stores the comment ID and PR state in local hardening state to avoid duplicate comments on subsequent scans.
+
+The comment is identified by the `<!-- vigilante:package-hardening -->` HTML marker so Vigilante can locate it when scanning for checkbox changes.
+
+### Checkbox-Driven Remediation
+
+The hardening comment includes an **implement fixes** checkbox:
+
+```
+- [ ] **implement fixes** — Vigilante will launch an automated remediation session for the findings above.
+```
+
+When a human checks this box, Vigilante detects the change during its next poll loop, reacts with an `eyes` emoji, and dispatches an agentic remediation session scoped to the PR branch. After the remediation session completes, Vigilante posts a follow-up result comment indicating whether remediation succeeded or was incomplete.
+
+Vigilante monitors checkbox state only for PRs that already have a recorded hardening comment. It does not re-scan PRs that have already had a remediation attempt dispatched.
+
+### Configuration
+
+The feature is controlled by the `package_hardening_enabled` field in `~/.vigilante/config.json`:
+
+```json
+{
+  "package_hardening_enabled": true
+}
+```
+
+- When the field is absent or `null`, hardening defaults to **enabled**.
+- Set to `false` to disable the feature entirely.
+
+### Scope Limitation
+
+Package hardening currently applies only to repositories classified with the `nodejs` tech stack. Repositories without this classification are silently skipped. Support for additional package ecosystems is expected to expand in future releases.
+
 ## Issue Labeling System
 
 Vigilante should use a small issue-label taxonomy that complements issue comments instead of replacing them. The repository-owned proposal lives in [`.github/labels.json`](.github/labels.json).

--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ At a high level, Vigilante runs this loop for each watched repository:
 
 GitHub is the only fully implemented backend today. The architecture already separates issue tracking, pull requests, labels, and rate limits so backends such as Linear and Jira can be added without rewriting the orchestration loop.
 
+## Package Hardening
+
+Vigilante includes a deterministic, code-driven package hardening scan for pull requests that modify `package.json` files. When a PR branch is pushed, Vigilante checks for lockfile presence, runs `npm audit`, flags non-exact dependency ranges, and verifies that CI workflows use deterministic install commands. If issues are found, Vigilante posts a structured comment on the PR with findings and applies the `vigilante:flagged-security-review` label. The comment includes an **implement fixes** checkbox that triggers an automated remediation session when checked.
+
+> **Note:** Package hardening currently applies only to repositories with a supported JavaScript/TypeScript/Node.js tech stack. Support for additional ecosystems is expected to expand over time.
+
+The feature is enabled by default and can be toggled with the `package_hardening_enabled` field in `config.json`. For operational details including trigger conditions, checks performed, and remediation flow, see [DOCS.md](DOCS.md).
+
 ## Key Commands
 
 - `vigilante setup`: verify dependencies, install bundled skills, and install the managed service
@@ -147,6 +155,7 @@ The full reference moved to [DOCS.md](DOCS.md), including:
 - full command reference and expected behaviors
 - local state layout and logs
 - issue selection, labeling, and pull-request maintenance
+- package hardening trigger conditions, checks, remediation flow, and config toggle
 - headless agent execution contract
 - GitHub integration, worktree strategy, and service behavior
 - CI, releases, and implementation status notes


### PR DESCRIPTION
## Summary

- Adds a concise package hardening section to `README.md` with user-visible behavior and a scope caveat that the feature currently applies only to supported JS/TS/Node.js repositories.
- Adds detailed operational documentation to `DOCS.md` covering trigger conditions, checks performed, PR comment/label behavior (`vigilante:flagged-security-review`), checkbox-driven remediation flow (`implement fixes`), and the `package_hardening_enabled` config toggle.
- Updates the "More Docs" index in the README to reference the new package hardening docs section.

## Test plan

- [x] Verified documentation accuracy against the implementation in PR #390 (`internal/hardening/`, `internal/app/app.go`, `internal/state/state.go`)
- [x] Confirmed the README caveat is prominently placed before the Key Commands section
- [x] Confirmed DOCS.md covers all acceptance criteria: trigger conditions, checks, PR comment/label behavior, remediation flow, config toggle, and scope limitation
- [x] Verified docs do not claim support for unsupported ecosystems
- [x] Verified consistent use of `package_hardening_enabled`, `vigilante:flagged-security-review`, and `implement fixes` terminology

Closes #392