### PR TITLE
[codex] fix linear issue listing

### DIFF
--- a/internal/backend/linear/linear.go
+++ b/internal/backend/linear/linear.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -43,14 +44,23 @@ func (b *Backend) ResolveAssignee(_ context.Context, assignee string) (string, e
 }
 
 func (b *Backend) ListOpenWorkItems(ctx context.Context, project string, assignee string) ([]backend.WorkItem, error) {
-	output, err := b.runner().Run(ctx, "", "linear", "issue", "list", "--json")
+	output, err := b.runner().Run(ctx, "", "linear", "issue", "list")
 	if err != nil {
 		return nil, err
 	}
 
-	items, err := parseLinearWorkItems(strings.TrimSpace(output))
-	if err != nil {
-		return nil, fmt.Errorf("parse linear issue list output: %w", err)
+	ids := parseLinearIssueListIDs(strings.TrimSpace(output))
+	items := make([]backend.WorkItem, 0, len(ids))
+	for _, id := range ids {
+		output, err := b.runner().Run(ctx, "", "linear", "issue", "view", id, "--json")
+		if err != nil {
+			return nil, err
+		}
+		item, err := parseLinearWorkItem(strings.TrimSpace(output))
+		if err != nil {
+			return nil, fmt.Errorf("parse linear issue view output for %q: %w", id, err)
+		}
+		items = append(items, item)
 	}
 	assignee = strings.TrimSpace(assignee)
 	if assignee == "" || assignee == "me" {
@@ -178,6 +188,29 @@ func parseLinearWorkItems(raw string) ([]backend.WorkItem, error) {
 	return items, nil
 }
 
+func parseLinearWorkItem(raw string) (backend.WorkItem, error) {
+	var item linearWorkItem
+	if err := json.Unmarshal([]byte(raw), &item); err != nil {
+		return backend.WorkItem{}, err
+	}
+	number := item.Number
+	if number == 0 {
+		number = parseLinearIssueNumber(item.Identifier)
+	}
+	createdAt, _ := time.Parse(time.RFC3339, strings.TrimSpace(item.CreatedAt))
+	workItem := backend.WorkItem{
+		Number:    number,
+		Title:     strings.TrimSpace(item.Title),
+		CreatedAt: createdAt,
+		URL:       strings.TrimSpace(item.URL),
+		Labels:    item.Labels,
+	}
+	if item.State != nil {
+		workItem.Stage = strings.TrimSpace(item.State.Name)
+	}
+	return workItem, nil
+}
+
 func parseLinearWorkItemDetails(raw string) (*backend.WorkItemDetails, error) {
 	var item linearWorkItem
 	if err := json.Unmarshal([]byte(raw), &item); err != nil {
@@ -243,4 +276,42 @@ func parseLinearIssueNumber(identifier string) int {
 	}
 	number, _ := strconv.Atoi(parts[len(parts)-1])
 	return number
+}
+
+func parseLinearIssueListIDs(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	lines := strings.Split(raw, "\n")
+	ids := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if isLinearIssueListSeparator(trimmed) {
+			continue
+		}
+		if linearIssueListHeaderRegex.MatchString(line) {
+			continue
+		}
+		match := linearIssueListIDRegex.FindString(line)
+		if match == "" {
+			continue
+		}
+		ids = append(ids, match)
+	}
+	return ids
+}
+
+var linearIssueListHeaderRegex = regexp.MustCompile(`(^|\s)ID(\s|$)`)
+var linearIssueListIDRegex = regexp.MustCompile(`\b[A-Z][A-Z0-9]*-\d+\b`)
+
+func isLinearIssueListSeparator(line string) bool {
+	for _, r := range line {
+		if r != '-' && r != '─' && r != ' ' {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/backend/linear/linear_test.go
+++ b/internal/backend/linear/linear_test.go
@@ -1,0 +1,65 @@
+package linear
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nicobistolfi/vigilante/internal/environment"
+	"github.com/nicobistolfi/vigilante/internal/testutil"
+)
+
+func TestListOpenWorkItemsHydratesIssueViewsFromListIDs(t *testing.T) {
+	runner := environment.Runner(testutil.FakeRunner{
+		Outputs: map[string]string{
+			"linear issue list": `ID       Title
+ENG-12   First issue
+ENG-3    Second issue
+`,
+			"linear issue view ENG-12 --json": `{"identifier":"ENG-12","title":"First issue","createdAt":"2026-04-01T10:00:00Z","url":"https://linear.app/issue/ENG-12","state":{"name":"Todo"},"labels":[{"name":"bug"}]}`,
+			"linear issue view ENG-3 --json":  `{"identifier":"ENG-3","title":"Second issue","createdAt":"2026-04-02T10:00:00Z","url":"https://linear.app/issue/ENG-3","state":{"name":"In Progress"},"labels":[]}`,
+		},
+	})
+	backend := NewBackend(&runner)
+
+	items, err := backend.ListOpenWorkItems(context.Background(), "", "me")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	if items[0].Number != 12 || items[0].Title != "First issue" || items[0].Stage != "Todo" {
+		t.Fatalf("unexpected first item: %#v", items[0])
+	}
+	if !items[0].CreatedAt.Equal(time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)) {
+		t.Fatalf("unexpected first item createdAt: %v", items[0].CreatedAt)
+	}
+	if items[1].Number != 3 || items[1].Title != "Second issue" || items[1].Stage != "In Progress" {
+		t.Fatalf("unexpected second item: %#v", items[1])
+	}
+}
+
+func TestParseLinearIssueListIDs(t *testing.T) {
+	raw := `
+ID        Title           State
+ENG-101   Example one     Todo
+ENG-55    Example two     In Progress
+`
+
+	ids := parseLinearIssueListIDs(raw)
+	if len(ids) != 2 || ids[0] != "ENG-101" || ids[1] != "ENG-55" {
+		t.Fatalf("unexpected ids: %#v", ids)
+	}
+}
+
+func TestParseLinearIssueListIDsWhenIDColumnIsNotFirst(t *testing.T) {
+	raw := `◌   ID       TITLE                                                              LABELS            E STATE UPDATED
+--- ENG-1070 Integrate PostHog Logs                                                               - Todo  17 minutes ago
+--- ENG-504  System Status - Add pop-up message for outage/LLM disruption mo... UI, notifications 1 Todo  39 days ago`
+
+	ids := parseLinearIssueListIDs(raw)
+	if len(ids) != 2 || ids[0] != "ENG-1070" || ids[1] != "ENG-504" {
+		t.Fatalf("unexpected ids: %#v", ids)
+	}
+}


### PR DESCRIPTION
## What changed
The Linear backend no longer calls `linear issue list --json`, which is not supported by the Linear CLI. It now runs `linear issue list`, parses the issue ID column from the table output, and hydrates each item with `linear issue view <ID> --json`.

## Why
The previous implementation depended on a CLI flag that the `linear issue list` command does not accept, so listing open work items failed before Vigilante could evaluate any Linear issues.

## Impact
Vigilante can now enumerate Linear issues using the supported CLI workflow and still build the same `WorkItem` data shape expected by the rest of the app.

## Root cause
The integration assumed parity between `linear issue list` and other Linear CLI commands that do support `--json`.

## Validation
I added focused tests for the list-table parsing and per-issue hydration flow.

I could not run `go test` or `gofmt` in this environment because the `go` toolchain is not installed.
