### PR TITLE
Add clone command with automatic watch registration

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -144,6 +144,7 @@ For each watched repository:
 `vigilante --help` and `vigilante -h` print top-level usage. Each command also supports command-specific help, for example:
 
 ```sh
+vigilante clone --help
 vigilante watch --help
 vigilante daemon run --help
 ```
@@ -201,6 +202,29 @@ vigilante commit --amend --no-edit
 ```
 
 Coding agents must use `vigilante commit` instead of `git commit` or GitHub CLI commit flows. This ensures that all agent-produced commits remain user-authored and signed.
+
+### `vigilante clone [git-clone-flags...] [--] <repo> [<path>]`
+
+Clone a repository using `git clone`, then automatically register the resulting local path as a Vigilante watch target.
+
+Expected behavior:
+
+- forwards clone flags and arguments through to `git clone`
+- supports both explicit destination paths and git-derived default destination names
+- adds the cloned repository to `~/.vigilante/watchlist.json` only after clone success
+- reuses existing watch-target deduplication when the cloned repository is already watched
+- returns a non-zero exit code if clone fails
+- returns a non-zero exit code if clone succeeds but automatic watch-target registration fails
+
+Examples:
+
+```sh
+vigilante clone git@github.com:owner/hello-world-app.git
+```
+
+```sh
+vigilante clone --depth 1 https://github.com/owner/hello-world-app.git ~/src/hello-world-app
+```
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It is the orchestration layer around agents such as `codex`, `claude`, and `gemi
 
 [Docs](DOCS.md) · [Closed Issues](https://github.com/aliengiraffe/vigilante/issues?q=is%3Aissue%20state%3Aclosed) · [Releases](https://github.com/aliengiraffe/vigilante/releases) · [Contributing](CONTRIBUTE.md)
 
-Start here: install `vigilante`, run `vigilante setup`, then register a repo with `vigilante watch /path/to/repo`.
+Start here: install `vigilante`, run `vigilante setup`, then clone and auto-register a repo with `vigilante clone <repo>` or register an existing checkout with `vigilante watch /path/to/repo`.
 
 ## Install
 
@@ -43,7 +43,7 @@ vigilante setup --provider codex
 Register a repository and let Vigilante manage it:
 
 ```sh
-vigilante watch ~/path/to/repo
+vigilante clone git@github.com:owner/repo.git
 ```
 
 Useful follow-up commands:
@@ -60,7 +60,7 @@ Typical first-run flow:
 ```sh
 brew install vigilante
 vigilante setup --provider codex
-vigilante watch ~/hello-world-app
+vigilante clone git@github.com:owner/hello-world-app.git
 vigilante daemon run --once
 ```
 
@@ -99,6 +99,7 @@ The feature is enabled by default and can be toggled with the `package_hardening
 ## Key Commands
 
 - `vigilante setup`: verify dependencies, install bundled skills, and install the managed service
+- `vigilante clone <repo> [<path>]`: clone a repository with `git clone` semantics and auto-add it to watch targets
 - `vigilante watch <path>`: register a local repository for issue monitoring
 - `vigilante list`: show watched repositories
 - `vigilante status`: show service health, watched repos, active sessions, and rate-limit state

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,15 +1,19 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"slices"
 	"sort"
@@ -86,6 +90,7 @@ var automergeLabels = []string{"vigilante:automerge", "automerge"}
 
 var supportedCompletionShells = []string{"bash", "fish", "zsh"}
 var errHelpHandled = errors.New("help handled")
+var cloneIntoPattern = regexp.MustCompile(`Cloning into (?:bare repository )?'([^']+)'`)
 
 type App struct {
 	stdin  io.Reader
@@ -601,6 +606,8 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 	switch args[0] {
 	case "commit":
 		return a.runCommitCommand(ctx, args[1:])
+	case "clone":
+		return a.runCloneCommand(ctx, args[1:])
 	case "setup":
 		fs := flag.NewFlagSet("setup", flag.ContinueOnError)
 		configureFlagSet(fs, func(w io.Writer) {
@@ -799,6 +806,49 @@ func (a *App) runCommitCommand(ctx context.Context, args []string) error {
 	}
 	if exitCode != 0 {
 		return commandExitError{code: exitCode}
+	}
+	return nil
+}
+
+func (a *App) runCloneCommand(ctx context.Context, args []string) error {
+	if len(args) == 1 && isHelpToken(args[0]) {
+		fmt.Fprintln(a.stdout, "usage: vigilante clone [git-clone-flags...] [--] <repo> [<path>]")
+		fmt.Fprintln(a.stdout)
+		fmt.Fprintln(a.stdout, "Clone a repository using git, then automatically register the")
+		fmt.Fprintln(a.stdout, "resulting local path as a Vigilante watch target.")
+		return nil
+	}
+	if err := a.state.EnsureLayout(); err != nil {
+		return err
+	}
+
+	var cloneStderr bytes.Buffer
+	stderr := io.MultiWriter(a.stderr, &cloneStderr)
+	exitCode, err := a.proxyExec(ctx, a.stdin, a.stdout, stderr, "git", append([]string{"clone"}, args...)...)
+	if err != nil {
+		return err
+	}
+	if exitCode != 0 {
+		return commandExitError{code: exitCode}
+	}
+
+	clonePath, err := resolveCloneTargetPath(args, cloneStderr.String())
+	if err != nil {
+		return fmt.Errorf("clone succeeded but automatic watch-target registration failed: %w", err)
+	}
+
+	targets, err := a.state.LoadWatchTargets()
+	if err != nil {
+		return fmt.Errorf("clone succeeded but automatic watch-target registration failed for %s: load watch targets: %w", clonePath, err)
+	}
+	alreadyWatched := findWatchTargetByPath(targets, clonePath).Path != ""
+	if err := a.watchWithOptions(ctx, clonePath, nil, "", unsetMaxParallel, "", watchIssueOptions{}, watchBranchOptions{}); err != nil {
+		return fmt.Errorf("clone succeeded but automatic watch-target registration failed for %s: %w", clonePath, err)
+	}
+	if alreadyWatched {
+		fmt.Fprintf(a.stdout, "watch target already existed for cloned repository: %s\n", clonePath)
+	} else {
+		fmt.Fprintf(a.stdout, "added cloned repository to watch targets: %s\n", clonePath)
 	}
 	return nil
 }
@@ -5738,6 +5788,7 @@ func (a *App) issueCreate(ctx context.Context, repoSlug string, providerOverride
 func (a *App) printUsage(w io.Writer) {
 	fmt.Fprintln(w, "usage:")
 	fmt.Fprintln(w, "  vigilante setup [--provider value]")
+	fmt.Fprintln(w, "  vigilante clone [git-clone-flags...] [--] <repo> [<path>]")
 	fmt.Fprintln(w, "  vigilante watch [--label value] [--assignee value] [--max-parallel value] [--provider value] [--issue-tracker value] [--issue-tracker-stage value] [--branch value | --track-default-branch] [--fork [--fork-owner value]] <path>")
 	fmt.Fprintln(w, "  vigilante unwatch <path>")
 	fmt.Fprintln(w, "  vigilante list [--blocked | --running]")
@@ -6006,6 +6057,118 @@ func ExpandPath(raw string) (string, error) {
 		}
 	}
 	return filepath.Abs(raw)
+}
+
+func resolveCloneTargetPath(args []string, stderr string) (string, error) {
+	cloneArgs, err := parseCloneArgs(args)
+	if err != nil {
+		return "", err
+	}
+	if cloneArgs.destination != "" {
+		return ExpandPath(cloneArgs.destination)
+	}
+	if match := cloneIntoPattern.FindStringSubmatch(stderr); len(match) == 2 {
+		return ExpandPath(match[1])
+	}
+
+	inferred := inferCloneDestination(cloneArgs.repo)
+	if inferred == "" {
+		return "", errors.New("could not determine cloned repository path")
+	}
+	return ExpandPath(inferred)
+}
+
+type cloneArgs struct {
+	repo        string
+	destination string
+}
+
+func parseCloneArgs(args []string) (cloneArgs, error) {
+	var positionals []string
+	endOfOptions := false
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if !endOfOptions && arg == "--" {
+			endOfOptions = true
+			continue
+		}
+		if !endOfOptions && strings.HasPrefix(arg, "-") && arg != "-" {
+			if cloneOptionConsumesNext(arg) {
+				i++
+				if i >= len(args) {
+					return cloneArgs{}, fmt.Errorf("clone succeeded but automatic watch-target registration could not resolve the destination path from %q", arg)
+				}
+				continue
+			}
+			continue
+		}
+		positionals = append(positionals, arg)
+	}
+
+	if len(positionals) == 0 {
+		return cloneArgs{}, errors.New("clone succeeded but automatic watch-target registration could not resolve the repository argument")
+	}
+	result := cloneArgs{repo: positionals[0]}
+	if len(positionals) > 1 {
+		result.destination = positionals[1]
+	}
+	return result, nil
+}
+
+func cloneOptionConsumesNext(arg string) bool {
+	if strings.Contains(arg, "=") {
+		return false
+	}
+	switch arg {
+	case "-j", "--jobs",
+		"--template",
+		"--reference",
+		"--reference-if-able",
+		"-o", "--origin",
+		"-b", "--branch",
+		"-u", "--upload-pack",
+		"--depth",
+		"--shallow-since",
+		"--shallow-exclude",
+		"--separate-git-dir",
+		"-c", "--config",
+		"--server-option",
+		"--filter",
+		"--bundle-uri":
+		return true
+	}
+	for _, prefix := range []string{"-j", "-o", "-b", "-u", "-c"} {
+		if strings.HasPrefix(arg, prefix) && len(arg) > len(prefix) {
+			return false
+		}
+	}
+	return false
+}
+
+func inferCloneDestination(rawRepo string) string {
+	trimmed := strings.TrimSpace(rawRepo)
+	trimmed = strings.TrimRight(trimmed, "/")
+	if trimmed == "" {
+		return ""
+	}
+
+	if parsed, err := url.Parse(trimmed); err == nil && parsed.Scheme != "" {
+		trimmed = parsed.Path
+	}
+	trimmed = strings.TrimRight(trimmed, "/")
+	if trimmed == "" {
+		return ""
+	}
+	if idx := strings.LastIndex(trimmed, ":"); idx > strings.LastIndex(trimmed, "/") {
+		trimmed = trimmed[idx+1:]
+	}
+
+	base := path.Base(trimmed)
+	base = strings.TrimSuffix(base, ".git")
+	if base == "." || base == "/" || base == "" {
+		return ""
+	}
+	return base
 }
 
 func findWatchTargetByRepo(targets []state.WatchTarget, repo string) (state.WatchTarget, bool) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -252,6 +252,7 @@ func TestRunSupportsTopLevelHelpFlags(t *testing.T) {
 			}
 			for _, want := range []string{
 				"usage:",
+				"vigilante clone",
 				"vigilante watch",
 				"vigilante status",
 				"vigilante service restart",
@@ -421,6 +422,204 @@ func TestRunCommitCommandHelp(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "vigilante commit") {
 		t.Fatalf("expected help output to mention vigilante commit, got %q", stdout.String())
+	}
+}
+
+func TestRunCloneCommandProxiesToGitCloneAndRegistersWatchTarget(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "hello-world")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Chdir(home)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = &stderr
+	var gotName string
+	var gotArgs []string
+	app.proxyExec = func(_ context.Context, _ io.Reader, _ io.Writer, errOut io.Writer, name string, args ...string) (int, error) {
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		fmt.Fprint(errOut, "Cloning into 'hello-world'...\n")
+		return 0, nil
+	}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                  "true\n",
+			testutil.Key("git", "remote", "get-url", "origin"):                         "git@github.com:owner/hello-world.git\n",
+			testutil.Key("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"): "origin/main\n",
+		},
+	}
+
+	exitCode := app.Run(context.Background(), []string{"clone", "git@github.com:owner/hello-world.git"})
+	if exitCode != 0 {
+		t.Fatalf("expected success exit code, got %d", exitCode)
+	}
+	if gotName != "git" {
+		t.Fatalf("clone tool = %q, want %q", gotName, "git")
+	}
+	if got, want := strings.Join(gotArgs, " "), "clone git@github.com:owner/hello-world.git"; got != want {
+		t.Fatalf("clone args = %q, want %q", got, want)
+	}
+	if got := stderr.String(); !strings.Contains(got, "Cloning into 'hello-world'...") {
+		t.Fatalf("expected git stderr to be preserved, got %q", got)
+	}
+	if got := stdout.String(); !strings.Contains(got, "added cloned repository to watch targets: "+repoPath) {
+		t.Fatalf("expected automatic watch registration output, got %q", got)
+	}
+
+	targets, err := app.state.LoadWatchTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 || targets[0].Path != repoPath {
+		t.Fatalf("expected cloned repository to be watched, got %#v", targets)
+	}
+}
+
+func TestRunCloneCommandUsesExplicitDestinationPath(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "custom-destination")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Chdir(home)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.proxyExec = func(_ context.Context, _ io.Reader, _ io.Writer, errOut io.Writer, _ string, _ ...string) (int, error) {
+		fmt.Fprint(errOut, "Cloning into 'custom-destination'...\n")
+		return 0, nil
+	}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                  "true\n",
+			testutil.Key("git", "remote", "get-url", "origin"):                         "git@github.com:owner/repo.git\n",
+			testutil.Key("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"): "origin/main\n",
+		},
+	}
+
+	if exitCode := app.Run(context.Background(), []string{"clone", "git@github.com:owner/repo.git", repoPath}); exitCode != 0 {
+		t.Fatalf("expected success exit code, got %d", exitCode)
+	}
+
+	targets, err := app.state.LoadWatchTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 || targets[0].Path != repoPath {
+		t.Fatalf("expected explicit destination to be watched, got %#v", targets)
+	}
+}
+
+func TestRunCloneCommandInfersDestinationWhenGitCloneIsQuiet(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "hello-world")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Chdir(home)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.proxyExec = func(_ context.Context, _ io.Reader, _ io.Writer, _ io.Writer, _ string, _ ...string) (int, error) {
+		return 0, nil
+	}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                  "true\n",
+			testutil.Key("git", "remote", "get-url", "origin"):                         "git@github.com:owner/hello-world.git\n",
+			testutil.Key("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"): "origin/main\n",
+		},
+	}
+
+	if exitCode := app.Run(context.Background(), []string{"clone", "--quiet", "git@github.com:owner/hello-world.git"}); exitCode != 0 {
+		t.Fatalf("expected success exit code, got %d", exitCode)
+	}
+
+	targets, err := app.state.LoadWatchTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 || targets[0].Path != repoPath {
+		t.Fatalf("expected inferred destination to be watched, got %#v", targets)
+	}
+}
+
+func TestRunCloneCommandDoesNotRegisterWatchTargetWhenCloneFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.proxyExec = func(context.Context, io.Reader, io.Writer, io.Writer, string, ...string) (int, error) {
+		return 1, nil
+	}
+
+	if got := app.Run(context.Background(), []string{"clone", "git@github.com:owner/repo.git"}); got != 1 {
+		t.Fatalf("Run() = %d, want %d", got, 1)
+	}
+
+	targets, err := app.state.LoadWatchTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 0 {
+		t.Fatalf("expected no persisted targets after clone failure: %#v", targets)
+	}
+}
+
+func TestRunCloneCommandReturnsErrorWhenWatchRegistrationFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	var stderr bytes.Buffer
+	app.stderr = &stderr
+	app.proxyExec = func(_ context.Context, _ io.Reader, _ io.Writer, errOut io.Writer, _ string, _ ...string) (int, error) {
+		fmt.Fprint(errOut, "Cloning into 'hello-world'...\n")
+		return 0, nil
+	}
+
+	exitCode := app.Run(context.Background(), []string{"clone", "git@github.com:owner/hello-world.git"})
+	if exitCode == 0 {
+		t.Fatal("expected clone registration failure")
+	}
+	if got := stderr.String(); !strings.Contains(got, "Cloning into 'hello-world'...") {
+		t.Fatalf("expected git stderr to be preserved, got %q", got)
+	}
+	if got := stderr.String(); !strings.Contains(got, "automatic watch-target registration failed") {
+		t.Fatalf("expected registration failure to be reported, got %q", got)
+	}
+}
+
+func TestRunCloneCommandHelp(t *testing.T) {
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+
+	exitCode := app.Run(context.Background(), []string{"clone", "--help"})
+	if exitCode != 0 {
+		t.Fatalf("expected success exit code, got %d", exitCode)
+	}
+	if !strings.Contains(stdout.String(), "vigilante clone") {
+		t.Fatalf("expected help output to mention vigilante clone, got %q", stdout.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a top-level `vigilante clone` command that proxies `git clone`
- auto-register the cloned repository as a watch target after clone success
- document the new flow and cover the new command paths in `internal/app` tests

## Validation
- `go test ./internal/app/...`
- `go vet ./internal/app/...`
- `gofmt -w internal/app/app.go internal/app/app_test.go`
- `govulncheck` not installed in this environment

Closes #397