### PR TITLE
Extend vigilante clone with --fork automation and upstream PR creation

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -812,19 +812,29 @@ func (a *App) runCommitCommand(ctx context.Context, args []string) error {
 
 func (a *App) runCloneCommand(ctx context.Context, args []string) error {
 	if len(args) == 1 && isHelpToken(args[0]) {
-		fmt.Fprintln(a.stdout, "usage: vigilante clone [git-clone-flags...] [--] <repo> [<path>]")
+		fmt.Fprintln(a.stdout, "usage: vigilante clone [--fork] [git-clone-flags...] [--] <repo> [<path>]")
 		fmt.Fprintln(a.stdout)
 		fmt.Fprintln(a.stdout, "Clone a repository using git, then automatically register the")
 		fmt.Fprintln(a.stdout, "resulting local path as a Vigilante watch target.")
+		fmt.Fprintln(a.stdout)
+		fmt.Fprintln(a.stdout, "  --fork    Create a GitHub fork under the authenticated user's account,")
+		fmt.Fprintln(a.stdout, "            clone the fork locally, and register with fork metadata so")
+		fmt.Fprintln(a.stdout, "            Vigilante can open upstream PRs automatically.")
 		return nil
 	}
 	if err := a.state.EnsureLayout(); err != nil {
 		return err
 	}
 
+	forkMode, gitArgs := extractCloneForkFlag(args)
+
+	if forkMode {
+		return a.runCloneFork(ctx, gitArgs)
+	}
+
 	var cloneStderr bytes.Buffer
 	stderr := io.MultiWriter(a.stderr, &cloneStderr)
-	exitCode, err := a.proxyExec(ctx, a.stdin, a.stdout, stderr, "git", append([]string{"clone"}, args...)...)
+	exitCode, err := a.proxyExec(ctx, a.stdin, a.stdout, stderr, "git", append([]string{"clone"}, gitArgs...)...)
 	if err != nil {
 		return err
 	}
@@ -832,7 +842,7 @@ func (a *App) runCloneCommand(ctx context.Context, args []string) error {
 		return commandExitError{code: exitCode}
 	}
 
-	clonePath, err := resolveCloneTargetPath(args, cloneStderr.String())
+	clonePath, err := resolveCloneTargetPath(gitArgs, cloneStderr.String())
 	if err != nil {
 		return fmt.Errorf("clone succeeded but automatic watch-target registration failed: %w", err)
 	}
@@ -851,6 +861,149 @@ func (a *App) runCloneCommand(ctx context.Context, args []string) error {
 		fmt.Fprintf(a.stdout, "added cloned repository to watch targets: %s\n", clonePath)
 	}
 	return nil
+}
+
+func (a *App) runCloneFork(ctx context.Context, args []string) error {
+	parsed, err := parseCloneArgs(args)
+	if err != nil {
+		return fmt.Errorf("--fork requires a repository argument: %w", err)
+	}
+	upstreamRepo := parsed.repo
+
+	// Resolve the upstream repo slug from the URL/SSH form.
+	upstreamSlug := inferRepoSlugFromURL(upstreamRepo)
+	if upstreamSlug == "" {
+		return fmt.Errorf("could not determine GitHub repository slug from %q", upstreamRepo)
+	}
+
+	// Get the authenticated user.
+	authOwner, err := forkmode.AuthenticatedOwner(ctx, a.env.Runner)
+	if err != nil {
+		return fmt.Errorf("--fork requires GitHub authentication: %w", err)
+	}
+
+	// Create the fork deterministically.
+	upstreamName := upstreamSlug[strings.LastIndex(upstreamSlug, "/")+1:]
+	forkRepo := authOwner + "/" + upstreamName
+	fmt.Fprintf(a.stdout, "forking %s into %s...\n", upstreamSlug, forkRepo)
+	if err := forkmode.EnsureFork(ctx, a.env.Runner, upstreamSlug, forkRepo, authOwner, authOwner); err != nil {
+		return fmt.Errorf("fork creation failed: %w", err)
+	}
+	fmt.Fprintf(a.stdout, "fork ready: %s\n", forkRepo)
+
+	// Build the clone URL using the fork repo.
+	forkCloneURL := "https://github.com/" + forkRepo + ".git"
+
+	// Replace the upstream repo argument with the fork URL in git clone args.
+	forkGitArgs := replaceCloneRepoArg(args, upstreamRepo, forkCloneURL)
+
+	// Clone the fork.
+	var cloneStderr bytes.Buffer
+	stderr := io.MultiWriter(a.stderr, &cloneStderr)
+	exitCode, err := a.proxyExec(ctx, a.stdin, a.stdout, stderr, "git", append([]string{"clone"}, forkGitArgs...)...)
+	if err != nil {
+		return err
+	}
+	if exitCode != 0 {
+		return commandExitError{code: exitCode}
+	}
+
+	clonePath, err := resolveCloneTargetPath(forkGitArgs, cloneStderr.String())
+	if err != nil {
+		return fmt.Errorf("clone succeeded but automatic watch-target registration failed: %w", err)
+	}
+
+	// Add the upstream remote so users can fetch from the parent.
+	upstreamURL := "https://github.com/" + upstreamSlug + ".git"
+	if _, err := a.env.Runner.Run(ctx, clonePath, "git", "remote", "add", "upstream", upstreamURL); err != nil {
+		fmt.Fprintf(a.stderr, "warning: could not add upstream remote: %v\n", err)
+	}
+
+	// Register the watch target with fork metadata.
+	branchOptions := watchBranchOptions{
+		forkMode:    true,
+		forkFlagSet: true,
+		forkOwner:   authOwner,
+	}
+	targets, err := a.state.LoadWatchTargets()
+	if err != nil {
+		return fmt.Errorf("clone succeeded but automatic watch-target registration failed for %s: load watch targets: %w", clonePath, err)
+	}
+	alreadyWatched := findWatchTargetByPath(targets, clonePath).Path != ""
+	if err := a.watchWithOptions(ctx, clonePath, nil, "", unsetMaxParallel, "", watchIssueOptions{}, branchOptions); err != nil {
+		return fmt.Errorf("clone succeeded but automatic watch-target registration failed for %s: %w", clonePath, err)
+	}
+
+	// Set the upstream repo metadata on the watch target.
+	targets, err = a.state.LoadWatchTargets()
+	if err == nil {
+		for i, t := range targets {
+			if t.Path == clonePath || (clonePath != "" && t.Path != "" && t.Path == clonePath) {
+				targets[i].UpstreamRepo = upstreamSlug
+				break
+			}
+		}
+		_ = a.state.SaveWatchTargets(targets)
+	}
+
+	if alreadyWatched {
+		fmt.Fprintf(a.stdout, "watch target already existed for cloned fork: %s\n", clonePath)
+	} else {
+		fmt.Fprintf(a.stdout, "added cloned fork to watch targets: %s (fork of %s)\n", clonePath, upstreamSlug)
+	}
+	return nil
+}
+
+// extractCloneForkFlag removes --fork from the argument list and returns
+// whether it was present along with the remaining arguments.
+func extractCloneForkFlag(args []string) (bool, []string) {
+	forkMode := false
+	var remaining []string
+	for _, arg := range args {
+		if arg == "--fork" {
+			forkMode = true
+			continue
+		}
+		remaining = append(remaining, arg)
+	}
+	return forkMode, remaining
+}
+
+// inferRepoSlugFromURL extracts an "owner/repo" slug from a GitHub URL or
+// SSH address.  Returns "" if the input does not look like a GitHub repo.
+func inferRepoSlugFromURL(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	trimmed = strings.TrimRight(trimmed, "/")
+	trimmed = strings.TrimSuffix(trimmed, ".git")
+
+	// SSH: git@github.com:owner/repo
+	if idx := strings.Index(trimmed, "github.com:"); idx >= 0 {
+		return trimmed[idx+len("github.com:"):]
+	}
+	// HTTPS: https://github.com/owner/repo
+	if idx := strings.Index(trimmed, "github.com/"); idx >= 0 {
+		return trimmed[idx+len("github.com/"):]
+	}
+	// Already a slug: owner/repo
+	parts := strings.Split(trimmed, "/")
+	if len(parts) == 2 && parts[0] != "" && parts[1] != "" && !strings.Contains(trimmed, ":") && !strings.Contains(trimmed, ".") {
+		return trimmed
+	}
+	return ""
+}
+
+// replaceCloneRepoArg replaces the repository positional argument in a
+// clone args list.
+func replaceCloneRepoArg(args []string, oldRepo string, newRepo string) []string {
+	result := make([]string, len(args))
+	copy(result, args)
+	for i, arg := range result {
+		if arg == oldRepo {
+			result[i] = newRepo
+			return result
+		}
+	}
+	return result
 }
 
 func (a *App) runResumeCommand(ctx context.Context, args []string) error {
@@ -1791,6 +1944,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 					WorktreePath:       wt.Path,
 					ForkMode:           target.ForkMode,
 					ForkOwner:          target.ForkOwner,
+					UpstreamRepo:       target.UpstreamRepo,
 					PushRemote:         target.EffectivePushRemote(),
 					PushRepo:           target.PushRepo,
 					ReusedRemoteBranch: wt.ReusedRemoteBranch,
@@ -2576,7 +2730,103 @@ func (a *App) maintainPullRequestChecks(ctx context.Context, session *state.Sess
 	if requiredChecksState(pr.StatusCheckRollup) == "failing" {
 		return nil
 	}
+	if requiredChecksState(pr.StatusCheckRollup) == "passing" {
+		if err := a.tryCreateUpstreamPR(ctx, session, pr); err != nil {
+			a.logger.Error("upstream PR creation failed", "repo", session.Repo, "issue", session.IssueNumber, "pr", pr.Number, "err", err)
+			session.UpstreamPRError = err.Error()
+		}
+	}
 	return a.tryAutoSquashMerge(ctx, session, pr, issueDetails, issueCache)
+}
+
+// tryCreateUpstreamPR creates a pull request against the parent repository
+// when a fork-mode session has all required checks passing.  It is a no-op
+// for non-fork sessions or when the upstream PR already exists.
+func (a *App) tryCreateUpstreamPR(ctx context.Context, session *state.Session, pr ghcli.PullRequest) error {
+	if !session.ForkMode {
+		return nil
+	}
+	upstreamRepo := strings.TrimSpace(session.UpstreamRepo)
+	if upstreamRepo == "" {
+		return nil
+	}
+	if session.UpstreamPRNumber > 0 {
+		return nil
+	}
+
+	headSelector := pullRequestHeadSelector(*session)
+	if headSelector == "" {
+		return fmt.Errorf("cannot determine head selector for upstream PR")
+	}
+
+	// Prevent duplicate: check if an upstream PR already exists for this head.
+	existingPR, err := a.prManager.FindPullRequestForBranch(ctx, upstreamRepo, headSelector)
+	if err != nil {
+		return fmt.Errorf("check existing upstream PR: %w", err)
+	}
+	if existingPR != nil {
+		session.UpstreamPRNumber = existingPR.Number
+		session.UpstreamPRURL = strings.TrimSpace(existingPR.URL)
+		session.UpstreamPRError = ""
+		a.logger.Info("upstream PR already exists", "repo", upstreamRepo, "pr", existingPR.Number, "url", existingPR.URL)
+		return nil
+	}
+
+	// Create the upstream PR using the fork branch as the head.
+	baseBranch := pullRequestBaseBranch(*session)
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
+	title := strings.TrimSpace(pr.Title)
+	if title == "" {
+		title = fmt.Sprintf("PR #%d from fork", pr.Number)
+	}
+	body := strings.TrimSpace(pr.Body)
+	if body == "" {
+		body = fmt.Sprintf("Automated upstream PR from fork PR %s#%d.", session.Repo, pr.Number)
+	}
+
+	output, err := a.env.Runner.Run(ctx, "", "gh", "pr", "create",
+		"--repo", upstreamRepo,
+		"--head", headSelector,
+		"--base", baseBranch,
+		"--title", title,
+		"--body", body,
+	)
+	if err != nil {
+		return fmt.Errorf("create upstream PR: %w", err)
+	}
+
+	// Parse the PR URL from the output to extract the number.
+	prURL := strings.TrimSpace(output)
+	session.UpstreamPRURL = prURL
+	session.UpstreamPRError = ""
+
+	// Try to find the created PR to get the number.
+	upstreamPR, findErr := a.prManager.FindPullRequestForBranch(ctx, upstreamRepo, headSelector)
+	if findErr == nil && upstreamPR != nil {
+		session.UpstreamPRNumber = upstreamPR.Number
+		session.UpstreamPRURL = strings.TrimSpace(upstreamPR.URL)
+	}
+
+	a.logger.Info("upstream PR created", "repo", upstreamRepo, "issue", session.IssueNumber, "url", prURL)
+
+	commentBody := ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Upstream PR Created",
+		Emoji:      "🚀",
+		Percent:    95,
+		ETAMinutes: 3,
+		Items: []string{
+			fmt.Sprintf("Fork PR #%d passed all required checks.", pr.Number),
+			fmt.Sprintf("Opened upstream PR against `%s`: %s", upstreamRepo, prURL),
+			"Waiting for upstream review and merge.",
+		},
+		Tagline: "From fork to upstream — the contribution circle is complete.",
+	})
+	if commentErr := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, commentBody, "progress", "upstream_pr"); commentErr != nil {
+		a.logger.Error("upstream PR comment failed", "repo", session.Repo, "issue", session.IssueNumber, "err", commentErr)
+	}
+	return nil
 }
 
 func (a *App) tryAutoSquashMerge(ctx context.Context, session *state.Session, pr ghcli.PullRequest, issueDetails *ghcli.IssueDetails, issueCache scanIssueDetailsCache) error {
@@ -3327,6 +3577,7 @@ func (a *App) RedispatchSession(ctx context.Context, repoSlug string, issue int,
 		WorktreePath:       wt.Path,
 		ForkMode:           target.ForkMode,
 		ForkOwner:          target.ForkOwner,
+		UpstreamRepo:       target.UpstreamRepo,
 		PushRemote:         target.EffectivePushRemote(),
 		PushRepo:           target.PushRepo,
 		ReusedRemoteBranch: wt.ReusedRemoteBranch,
@@ -4548,6 +4799,7 @@ func blockedIssueSessionForDispatchFailure(target state.WatchTarget, issue ghcli
 		WorktreePath: worktree.IssueWorktreePath(target.Path, issue.Number),
 		ForkMode:     target.ForkMode,
 		ForkOwner:    target.ForkOwner,
+		UpstreamRepo: target.UpstreamRepo,
 		PushRemote:   target.EffectivePushRemote(),
 		PushRepo:     target.PushRepo,
 		Status:       state.SessionStatusFailed,
@@ -4833,6 +5085,7 @@ func (a *App) dispatchIssueSession(ctx context.Context, target state.WatchTarget
 	session.WorktreePath = wt.Path
 	session.ForkMode = target.ForkMode
 	session.ForkOwner = target.ForkOwner
+	session.UpstreamRepo = target.UpstreamRepo
 	session.PushRemote = target.EffectivePushRemote()
 	session.PushRepo = target.PushRepo
 	session.ReusedRemoteBranch = wt.ReusedRemoteBranch

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -623,6 +623,358 @@ func TestRunCloneCommandHelp(t *testing.T) {
 	}
 }
 
+func TestRunCloneForkCreatesForkedWatchTarget(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Chdir(home)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = &stderr
+	app.proxyExec = func(_ context.Context, _ io.Reader, _ io.Writer, errOut io.Writer, name string, args ...string) (int, error) {
+		// Verify git clone is called with the fork URL, not the upstream.
+		if name == "git" && len(args) > 1 && args[0] == "clone" {
+			for _, arg := range args[1:] {
+				if strings.Contains(arg, "forker/repo") {
+					fmt.Fprint(errOut, "Cloning into 'repo'...\n")
+					return 0, nil
+				}
+			}
+			t.Fatalf("expected fork URL in git clone args: %v", args)
+		}
+		return 0, nil
+	}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			testutil.Key("gh", "api", "user"):                                                              `{"login":"forker"}`,
+			testutil.Key("gh", "api", "repos/forker/repo"):                                                 `{"full_name":"forker/repo","parent":{"full_name":"upstream-owner/repo"}}`,
+			testutil.Key("git", "remote", "add", "upstream", "https://github.com/upstream-owner/repo.git"): "",
+			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                                      "true\n",
+			testutil.Key("git", "remote", "get-url", "origin"):                                             "https://github.com/forker/repo.git\n",
+			testutil.Key("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"):                     "origin/main\n",
+		},
+	}
+
+	exitCode := app.Run(context.Background(), []string{"clone", "--fork", "https://github.com/upstream-owner/repo.git"})
+	if exitCode != 0 {
+		t.Fatalf("expected success exit code, got %d; stderr=%q stdout=%q", exitCode, stderr.String(), stdout.String())
+	}
+
+	if !strings.Contains(stdout.String(), "fork ready: forker/repo") {
+		t.Fatalf("expected fork creation output, got %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "fork of upstream-owner/repo") {
+		t.Fatalf("expected upstream reference in output, got %q", stdout.String())
+	}
+
+	targets, err := app.state.LoadWatchTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 watch target, got %d: %#v", len(targets), targets)
+	}
+	target := targets[0]
+	if !target.ForkMode {
+		t.Fatal("expected ForkMode=true")
+	}
+	if target.ForkOwner != "forker" {
+		t.Fatalf("expected ForkOwner=forker, got %q", target.ForkOwner)
+	}
+	if target.UpstreamRepo != "upstream-owner/repo" {
+		t.Fatalf("expected UpstreamRepo=upstream-owner/repo, got %q", target.UpstreamRepo)
+	}
+}
+
+func TestRunCloneForkWithExplicitDestinationPath(t *testing.T) {
+	home := t.TempDir()
+	destPath := filepath.Join(home, "my-fork-dir")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Chdir(home)
+	if err := os.MkdirAll(destPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.proxyExec = func(_ context.Context, _ io.Reader, _ io.Writer, errOut io.Writer, _ string, _ ...string) (int, error) {
+		fmt.Fprint(errOut, "Cloning into 'my-fork-dir'...\n")
+		return 0, nil
+	}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			testutil.Key("gh", "api", "user"):                                                     `{"login":"forker"}`,
+			testutil.Key("gh", "api", "repos/forker/repo"):                                        `{"full_name":"forker/repo","parent":{"full_name":"owner/repo"}}`,
+			testutil.Key("git", "remote", "add", "upstream", "https://github.com/owner/repo.git"): "",
+			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                             "true\n",
+			testutil.Key("git", "remote", "get-url", "origin"):                                    "https://github.com/forker/repo.git\n",
+			testutil.Key("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"):            "origin/main\n",
+		},
+	}
+
+	exitCode := app.Run(context.Background(), []string{"clone", "--fork", "git@github.com:owner/repo.git", destPath})
+	if exitCode != 0 {
+		t.Fatalf("expected success, got %d", exitCode)
+	}
+
+	targets, err := app.state.LoadWatchTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 || targets[0].Path != destPath {
+		t.Fatalf("expected explicit destination to be watched with fork metadata, got %#v", targets)
+	}
+}
+
+func TestRunCloneForkFailsWhenForkCreationFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			testutil.Key("gh", "api", "user"): `{"login":"forker"}`,
+		},
+		Errors: map[string]error{
+			testutil.Key("gh", "api", "repos/forker/repo"):                          errors.New("HTTP 404: Not Found"),
+			testutil.Key("gh", "api", "--method", "POST", "repos/owner/repo/forks"): errors.New("HTTP 403: Forbidden"),
+		},
+		ErrorOutputs: map[string]string{
+			testutil.Key("gh", "api", "repos/forker/repo"):                          "Not Found",
+			testutil.Key("gh", "api", "--method", "POST", "repos/owner/repo/forks"): "Forbidden",
+		},
+	}
+
+	exitCode := app.Run(context.Background(), []string{"clone", "--fork", "git@github.com:owner/repo.git"})
+	if exitCode == 0 {
+		t.Fatal("expected failure when fork creation fails")
+	}
+}
+
+func TestRunCloneForkDoesNotCloneWhenAuthFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Errors: map[string]error{
+			testutil.Key("gh", "api", "user"): errors.New("not authenticated"),
+		},
+		ErrorOutputs: map[string]string{
+			testutil.Key("gh", "api", "user"): "auth required",
+		},
+	}
+
+	exitCode := app.Run(context.Background(), []string{"clone", "--fork", "git@github.com:owner/repo.git"})
+	if exitCode == 0 {
+		t.Fatal("expected failure when auth fails")
+	}
+}
+
+func TestExtractCloneForkFlag(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantFork bool
+		wantArgs []string
+	}{
+		{
+			name:     "no fork flag",
+			args:     []string{"git@github.com:owner/repo.git"},
+			wantFork: false,
+			wantArgs: []string{"git@github.com:owner/repo.git"},
+		},
+		{
+			name:     "fork flag at start",
+			args:     []string{"--fork", "git@github.com:owner/repo.git"},
+			wantFork: true,
+			wantArgs: []string{"git@github.com:owner/repo.git"},
+		},
+		{
+			name:     "fork flag at end",
+			args:     []string{"git@github.com:owner/repo.git", "--fork"},
+			wantFork: true,
+			wantArgs: []string{"git@github.com:owner/repo.git"},
+		},
+		{
+			name:     "fork flag with destination",
+			args:     []string{"--fork", "git@github.com:owner/repo.git", "/tmp/dest"},
+			wantFork: true,
+			wantArgs: []string{"git@github.com:owner/repo.git", "/tmp/dest"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotFork, gotArgs := extractCloneForkFlag(tc.args)
+			if gotFork != tc.wantFork {
+				t.Errorf("fork = %v, want %v", gotFork, tc.wantFork)
+			}
+			if len(gotArgs) != len(tc.wantArgs) {
+				t.Fatalf("args = %v, want %v", gotArgs, tc.wantArgs)
+			}
+			for i := range gotArgs {
+				if gotArgs[i] != tc.wantArgs[i] {
+					t.Errorf("args[%d] = %q, want %q", i, gotArgs[i], tc.wantArgs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestInferRepoSlugFromURL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://github.com/owner/repo.git", "owner/repo"},
+		{"https://github.com/owner/repo", "owner/repo"},
+		{"git@github.com:owner/repo.git", "owner/repo"},
+		{"git@github.com:owner/repo", "owner/repo"},
+		{"owner/repo", "owner/repo"},
+		{"not-a-repo-url", ""},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got := inferRepoSlugFromURL(tc.input)
+			if got != tc.want {
+				t.Errorf("inferRepoSlugFromURL(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReplaceCloneRepoArg(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		oldRepo string
+		newRepo string
+		want    []string
+	}{
+		{
+			name:    "simple replacement",
+			args:    []string{"git@github.com:owner/repo.git"},
+			oldRepo: "git@github.com:owner/repo.git",
+			newRepo: "https://github.com/forker/repo.git",
+			want:    []string{"https://github.com/forker/repo.git"},
+		},
+		{
+			name:    "with flags and destination",
+			args:    []string{"--depth", "1", "git@github.com:owner/repo.git", "/tmp/dest"},
+			oldRepo: "git@github.com:owner/repo.git",
+			newRepo: "https://github.com/forker/repo.git",
+			want:    []string{"--depth", "1", "https://github.com/forker/repo.git", "/tmp/dest"},
+		},
+		{
+			name:    "no match returns unchanged",
+			args:    []string{"other-repo"},
+			oldRepo: "not-present",
+			newRepo: "new-url",
+			want:    []string{"other-repo"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := replaceCloneRepoArg(tc.args, tc.oldRepo, tc.newRepo)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len = %d, want %d: %v", len(got), len(tc.want), got)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("args[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestRunCloneForkHelpOutput(t *testing.T) {
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+
+	exitCode := app.Run(context.Background(), []string{"clone", "--help"})
+	if exitCode != 0 {
+		t.Fatalf("expected success, got %d", exitCode)
+	}
+	if !strings.Contains(stdout.String(), "--fork") {
+		t.Fatalf("expected help to mention --fork, got %q", stdout.String())
+	}
+}
+
+func TestNonForkCloneUnchangedByForkFeature(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "hello-world")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Chdir(home)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	var gotName string
+	var gotArgs []string
+	app.proxyExec = func(_ context.Context, _ io.Reader, _ io.Writer, errOut io.Writer, name string, args ...string) (int, error) {
+		gotName = name
+		gotArgs = append([]string(nil), args...)
+		fmt.Fprint(errOut, "Cloning into 'hello-world'...\n")
+		return 0, nil
+	}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                  "true\n",
+			testutil.Key("git", "remote", "get-url", "origin"):                         "git@github.com:owner/hello-world.git\n",
+			testutil.Key("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"): "origin/main\n",
+		},
+	}
+
+	exitCode := app.Run(context.Background(), []string{"clone", "git@github.com:owner/hello-world.git"})
+	if exitCode != 0 {
+		t.Fatalf("expected success, got %d", exitCode)
+	}
+	if gotName != "git" {
+		t.Fatalf("clone tool = %q, want %q", gotName, "git")
+	}
+	if got := strings.Join(gotArgs, " "); got != "clone git@github.com:owner/hello-world.git" {
+		t.Fatalf("clone args = %q, want standard non-fork clone", got)
+	}
+
+	targets, err := app.state.LoadWatchTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 || targets[0].Path != repoPath {
+		t.Fatalf("expected watch target at cloned path, got %#v", targets)
+	}
+	if targets[0].ForkMode {
+		t.Fatal("non-fork clone should not set ForkMode")
+	}
+	if targets[0].UpstreamRepo != "" {
+		t.Fatal("non-fork clone should not set UpstreamRepo")
+	}
+}
+
 func TestDesiredSessionLabels(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/internal/fork/contributing.go
+++ b/internal/fork/contributing.go
@@ -1,0 +1,47 @@
+package fork
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/nicobistolfi/vigilante/internal/environment"
+)
+
+// contributingGuidePaths lists the standard locations for contribution
+// guidelines in a GitHub repository, checked in priority order.
+var contributingGuidePaths = []string{
+	"CONTRIBUTING.md",
+	"CONTRIBUTING",
+	".github/CONTRIBUTING.md",
+	".github/CONTRIBUTING",
+	"docs/CONTRIBUTING.md",
+}
+
+// DiscoverContributingGuide reads the first contributor guide found at a
+// standard location in the repository rooted at repoPath.  Returns the
+// file contents and the relative path where it was found, or empty strings
+// when no guide is present.
+func DiscoverContributingGuide(ctx context.Context, runner environment.Runner, repoPath string) (content string, path string, err error) {
+	for _, candidate := range contributingGuidePaths {
+		out, readErr := runner.Run(ctx, repoPath, "cat", candidate)
+		if readErr != nil {
+			continue
+		}
+		trimmed := strings.TrimSpace(out)
+		if trimmed == "" {
+			continue
+		}
+		return trimmed, candidate, nil
+	}
+	return "", "", nil
+}
+
+// FormatContributingPromptSection returns a prompt block that includes the
+// contributor guide contents, or an explicit note that no guide was found.
+func FormatContributingPromptSection(content string, path string) string {
+	if content == "" {
+		return "No contributor guide (CONTRIBUTING.md or similar) was found in this repository. Follow general open-source contribution best practices."
+	}
+	return fmt.Sprintf("Contributor guide discovered at `%s`. Follow these contribution guidelines on a best-effort basis while keeping Vigilante's operational safety rules authoritative:\n\n%s", path, content)
+}

--- a/internal/fork/contributing_test.go
+++ b/internal/fork/contributing_test.go
@@ -1,0 +1,96 @@
+package fork
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/nicobistolfi/vigilante/internal/testutil"
+)
+
+func TestDiscoverContributingGuideFindsFirstMatch(t *testing.T) {
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			testutil.Key("cat", "CONTRIBUTING.md"): "# Contributing\nPlease open a PR.",
+		},
+		Errors: map[string]error{
+			testutil.Key("cat", "CONTRIBUTING"):            errors.New("no such file"),
+			testutil.Key("cat", ".github/CONTRIBUTING.md"): errors.New("no such file"),
+			testutil.Key("cat", ".github/CONTRIBUTING"):    errors.New("no such file"),
+			testutil.Key("cat", "docs/CONTRIBUTING.md"):    errors.New("no such file"),
+		},
+	}
+	content, path, err := DiscoverContributingGuide(context.Background(), runner, "/tmp/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != "CONTRIBUTING.md" {
+		t.Fatalf("expected path=CONTRIBUTING.md, got %q", path)
+	}
+	if content != "# Contributing\nPlease open a PR." {
+		t.Fatalf("unexpected content: %q", content)
+	}
+}
+
+func TestDiscoverContributingGuideFindsGitHubSubdir(t *testing.T) {
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			testutil.Key("cat", ".github/CONTRIBUTING.md"): "Follow the style guide.",
+		},
+		Errors: map[string]error{
+			testutil.Key("cat", "CONTRIBUTING.md"):      errors.New("no such file"),
+			testutil.Key("cat", "CONTRIBUTING"):         errors.New("no such file"),
+			testutil.Key("cat", ".github/CONTRIBUTING"): errors.New("no such file"),
+			testutil.Key("cat", "docs/CONTRIBUTING.md"): errors.New("no such file"),
+		},
+	}
+	content, path, err := DiscoverContributingGuide(context.Background(), runner, "/tmp/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != ".github/CONTRIBUTING.md" {
+		t.Fatalf("expected .github/CONTRIBUTING.md, got %q", path)
+	}
+	if content != "Follow the style guide." {
+		t.Fatalf("unexpected content: %q", content)
+	}
+}
+
+func TestDiscoverContributingGuideReturnsEmptyWhenNoneFound(t *testing.T) {
+	runner := testutil.FakeRunner{
+		Errors: map[string]error{
+			testutil.Key("cat", "CONTRIBUTING.md"):         errors.New("no such file"),
+			testutil.Key("cat", "CONTRIBUTING"):            errors.New("no such file"),
+			testutil.Key("cat", ".github/CONTRIBUTING.md"): errors.New("no such file"),
+			testutil.Key("cat", ".github/CONTRIBUTING"):    errors.New("no such file"),
+			testutil.Key("cat", "docs/CONTRIBUTING.md"):    errors.New("no such file"),
+		},
+	}
+	content, path, err := DiscoverContributingGuide(context.Background(), runner, "/tmp/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content != "" || path != "" {
+		t.Fatalf("expected empty result when no guide found, got content=%q path=%q", content, path)
+	}
+}
+
+func TestFormatContributingPromptSectionWithContent(t *testing.T) {
+	result := FormatContributingPromptSection("Run `make test` before submitting.", "CONTRIBUTING.md")
+	if result == "" {
+		t.Fatal("expected non-empty result")
+	}
+	if want := "Contributor guide discovered at `CONTRIBUTING.md`"; result[:len(want)] != want {
+		t.Fatalf("unexpected prefix: %q", result[:80])
+	}
+}
+
+func TestFormatContributingPromptSectionEmpty(t *testing.T) {
+	result := FormatContributingPromptSection("", "")
+	if result == "" {
+		t.Fatal("expected non-empty result")
+	}
+	if want := "No contributor guide"; result[:len(want)] != want {
+		t.Fatalf("unexpected: %q", result[:60])
+	}
+}

--- a/internal/fork/fork.go
+++ b/internal/fork/fork.go
@@ -76,6 +76,18 @@ func ConfigureWorktree(ctx context.Context, runner environment.Runner, session s
 	return nil
 }
 
+// AuthenticatedOwner returns the login of the currently authenticated GitHub
+// user via the gh CLI.
+func AuthenticatedOwner(ctx context.Context, runner environment.Runner) (string, error) {
+	return authenticatedOwner(ctx, runner)
+}
+
+// EnsureFork creates a GitHub fork of upstreamRepo under forkOwner's account
+// if it does not already exist, and waits for the fork to become available.
+func EnsureFork(ctx context.Context, runner environment.Runner, upstreamRepo string, forkRepo string, authOwner string, forkOwner string) error {
+	return ensureForkRepository(ctx, runner, upstreamRepo, forkRepo, authOwner, forkOwner)
+}
+
 func authenticatedOwner(ctx context.Context, runner environment.Runner) (string, error) {
 	output, err := runner.Run(ctx, "", "gh", "api", "user")
 	if err != nil {

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -63,6 +63,11 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 		appendSessionLog(logPath, "fork worktree configuration failed", session, err.Error())
 		return session
 	}
+	if session.ForkMode && strings.TrimSpace(session.ContributingGuide) == "" {
+		guide, guidePath, _ := forkmode.DiscoverContributingGuide(ctx, env.Runner, session.WorktreePath)
+		session.ContributingGuide = guide
+		session.ContributingGuidePath = guidePath
+	}
 	startItems := []string{
 		fmt.Sprintf("Vigilante launched this implementation session in `%s`.", session.WorktreePath),
 		fmt.Sprintf("Branch: `%s`.", session.Branch),

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -243,12 +243,19 @@ func BuildIssuePromptForRuntime(runtime string, target state.WatchTarget, issue 
 		if owner := strings.TrimSpace(session.ForkOwner); owner != "" {
 			headSelector = owner + ":" + session.Branch
 		}
+		upstreamTarget := target.Repo
+		if upstream := strings.TrimSpace(target.UpstreamRepo); upstream != "" {
+			upstreamTarget = upstream
+		}
 		lines = append(lines,
-			fmt.Sprintf("Fork mode is enabled for this run. Upstream repository context remains `%s`.", target.Repo),
+			fmt.Sprintf("Fork mode is enabled for this run. Upstream repository context remains `%s`.", upstreamTarget),
 			fmt.Sprintf("Push the branch to remote `%s` (repo `%s`) rather than `origin`.", session.PushRemote, fallbackPromptText(session.PushRepo, "fork repo not recorded")),
-			fmt.Sprintf("Open the pull request against `%s` with head `%s` so the PR is cross-repo from the fork.", target.Repo, headSelector),
+			fmt.Sprintf("Open the pull request against `%s` with head `%s` so the PR is cross-repo from the fork.", upstreamTarget, headSelector),
 			"Include a concise implementation summary and a short `Benefits` section in the PR body in addition to the required closing line.",
 		)
+	}
+	if session.ForkMode {
+		lines = append(lines, contributingGuidePromptSection(session))
 	}
 	if normalizedRepoShape(target) == string(repo.ShapeMonorepo) {
 		lines = append(lines,
@@ -892,6 +899,15 @@ func copyFile(src string, dst string, mode os.FileMode) error {
 		return err
 	}
 	return out.Close()
+}
+
+func contributingGuidePromptSection(session state.Session) string {
+	guide := strings.TrimSpace(session.ContributingGuide)
+	guidePath := strings.TrimSpace(session.ContributingGuidePath)
+	if guide == "" {
+		return "No contributor guide (CONTRIBUTING.md or similar) was found in this repository. Follow general open-source contribution best practices."
+	}
+	return fmt.Sprintf("Contributor guide discovered at `%s`. Follow these contribution guidelines on a best-effort basis while keeping Vigilante's operational safety rules authoritative:\n\n%s", guidePath, guide)
 }
 
 func pathJoin(parts ...string) string {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -26,6 +26,7 @@ type WatchTarget struct {
 	ForkOwner             string              `json:"fork_owner,omitempty"`
 	PushRemote            string              `json:"push_remote,omitempty"`
 	PushRepo              string              `json:"push_repo,omitempty"`
+	UpstreamRepo          string              `json:"upstream_repo,omitempty"`
 	Classification        repo.Classification `json:"classification,omitempty"`
 	Provider              string              `json:"provider,omitempty"`
 	Labels                []string            `json:"labels,omitempty"`
@@ -174,6 +175,12 @@ type Session struct {
 	ForkOwner                      string              `json:"fork_owner,omitempty"`
 	PushRemote                     string              `json:"push_remote,omitempty"`
 	PushRepo                       string              `json:"push_repo,omitempty"`
+	UpstreamRepo                   string              `json:"upstream_repo,omitempty"`
+	UpstreamPRNumber               int                 `json:"upstream_pr_number,omitempty"`
+	UpstreamPRURL                  string              `json:"upstream_pr_url,omitempty"`
+	UpstreamPRError                string              `json:"upstream_pr_error,omitempty"`
+	ContributingGuide              string              `json:"contributing_guide,omitempty"`
+	ContributingGuidePath          string              `json:"contributing_guide_path,omitempty"`
 	ReusedRemoteBranch             string              `json:"reused_remote_branch,omitempty"`
 	BranchDiffSummary              string              `json:"branch_diff_summary,omitempty"`
 	Status                         SessionStatus       `json:"status"`


### PR DESCRIPTION
## Summary

- Add `--fork` flag to `vigilante clone` that deterministically creates a GitHub fork, clones the fork locally with standard `git clone` destination semantics, and registers it as a watch target with fork/parent metadata
- Automatically open upstream PRs against the parent repository when fork PR required checks pass, with duplicate prevention and clear failure reporting
- Discover and inject contributor-guide instructions (`CONTRIBUTING.md` and standard variants) into coding-agent prompts for fork-mode sessions
- Add `UpstreamRepo` field to `WatchTarget` and upstream PR tracking fields to `Session` for end-to-end fork lifecycle management

## Test plan

- [x] `vigilante clone --fork <repo>` creates fork, clones it, and registers watch target with `ForkMode=true` and `UpstreamRepo` metadata
- [x] Explicit destination path works with `--fork` 
- [x] Fork creation failure prevents clone attempt
- [x] Auth failure prevents fork creation
- [x] `--fork` flag extraction handles all positions (start, end, with destination)
- [x] Repo slug inference from HTTPS URLs, SSH addresses, and bare slugs
- [x] Non-fork `vigilante clone` behavior is unchanged (regression test)
- [x] Help output mentions `--fork`
- [x] Contributor guide discovery across standard locations (`CONTRIBUTING.md`, `.github/CONTRIBUTING.md`, etc.)
- [x] Contributor guide prompt section handles both present and absent guides
- [x] All existing clone tests continue to pass
- [x] Full `go test ./...` passes with `gofmt` and `go vet` clean

Closes #398