### PR TITLE
Monitor issue and PR comments for active Vigilante sessions

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -3085,6 +3085,44 @@ func (a *App) listRunningSessions() error {
 	return nil
 }
 
+// collectSessionComments fetches issue comments and, when the session has an
+// associated open PR, also fetches PR timeline comments and PR review comments.
+// All surfaces are merged and deduplicated by comment ID so that the same
+// command is never processed twice regardless of where it was posted.
+func (a *App) collectSessionComments(ctx context.Context, session state.Session, purpose string) ([]ghcli.IssueComment, error) {
+	issueTracker := a.issueTrackerForSession(session)
+	project := a.issueProjectForSession(session)
+
+	issueComments, err := issueTracker.ListWorkItemCommentsForPolling(ctx, project, session.IssueNumber, purpose, a.logger)
+	if err != nil {
+		return nil, err
+	}
+
+	if session.PullRequestNumber == 0 || session.PullRequestState != "OPEN" {
+		return issueComments, nil
+	}
+
+	prMgr := a.prManagerForSession(session)
+
+	prComments, err := prMgr.ListPullRequestCommentsForPolling(ctx, session.Repo, session.PullRequestNumber, purpose+"_pr", a.logger)
+	if err != nil {
+		if a.logger != nil {
+			a.logger.Warn("pr comment poll failed, continuing with issue comments only", "repo", session.Repo, "pr", session.PullRequestNumber, "purpose", purpose, "err", err)
+		}
+		return issueComments, nil
+	}
+
+	reviewComments, err := prMgr.ListPullRequestReviewCommentsForPolling(ctx, session.Repo, session.PullRequestNumber, purpose+"_pr_review", a.logger)
+	if err != nil {
+		if a.logger != nil {
+			a.logger.Warn("pr review comment poll failed, continuing with issue+pr comments", "repo", session.Repo, "pr", session.PullRequestNumber, "purpose", purpose, "err", err)
+		}
+		return ghcli.MergeCommentSurfaces(issueComments, prComments), nil
+	}
+
+	return ghcli.MergeCommentSurfaces(issueComments, prComments, reviewComments), nil
+}
+
 func (a *App) processGitHubCleanupRequests(ctx context.Context, sessions []state.Session) ([]state.Session, error) {
 	for i := range sessions {
 		session := &sessions[i]
@@ -3092,7 +3130,7 @@ func (a *App) processGitHubCleanupRequests(ctx context.Context, sessions []state
 			continue
 		}
 
-		comments, err := a.issueTrackerForSession(*session).ListWorkItemCommentsForPolling(ctx, a.issueProjectForSession(*session), session.IssueNumber, "cleanup", a.logger)
+		comments, err := a.collectSessionComments(ctx, *session, "cleanup")
 		if err != nil {
 			a.logger.Error("cleanup comment lookup failed", "repo", session.Repo, "issue", session.IssueNumber, "err", err)
 			session.LastError = err.Error()
@@ -3154,7 +3192,7 @@ func (a *App) processGitHubRecreateRequests(ctx context.Context, sessions []stat
 			continue
 		}
 
-		comments, err := a.issueTrackerForSession(*session).ListWorkItemCommentsForPolling(ctx, a.issueProjectForSession(*session), session.IssueNumber, "recreate", a.logger)
+		comments, err := a.collectSessionComments(ctx, *session, "recreate")
 		if err != nil {
 			a.logger.Error("recreate comment lookup failed", "repo", session.Repo, "issue", session.IssueNumber, "err", err)
 			session.LastError = err.Error()
@@ -3325,7 +3363,7 @@ func (a *App) processGitHubResumeRequests(ctx context.Context, sessions []state.
 			continue
 		}
 
-		comments, err := a.issueTrackerForSession(*session).ListWorkItemCommentsForPolling(ctx, a.issueProjectForSession(*session), session.IssueNumber, "resume", a.logger)
+		comments, err := a.collectSessionComments(ctx, *session, "resume")
 		if err != nil {
 			a.recordSessionFailure(session, fallbackText(session.BlockedStage, "issue_execution"), "gh issue comments", err)
 			a.logger.Error("resume comment lookup failed", "repo", session.Repo, "issue", session.IssueNumber, "err", err)
@@ -4886,7 +4924,7 @@ func (a *App) processGitHubIterationRequestsForTarget(ctx context.Context, targe
 			continue
 		}
 
-		comments, err := a.issueTrackerForSession(*session).ListWorkItemCommentsForPolling(ctx, a.issueProjectForSession(*session), session.IssueNumber, "iteration", a.logger)
+		comments, err := a.collectSessionComments(ctx, *session, "iteration")
 		if err != nil {
 			a.logger.Error("iteration comment lookup failed", "repo", session.Repo, "issue", session.IssueNumber, "err", err)
 			session.LastError = err.Error()

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -9324,3 +9324,209 @@ func TestLogsCommandMissingLog(t *testing.T) {
 		t.Fatalf("expected error message about missing log, got %q", stderr.String())
 	}
 }
+
+func TestCollectSessionCommentsIssueOnly(t *testing.T) {
+	t.Setenv("VIGILANTE_HOME", t.TempDir())
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/7/comments": `[{"id":10,"body":"@vigilanteai resume","created_at":"2026-03-12T12:00:00Z","user":{"login":"alice"}}]`,
+		},
+	}
+	env := &environment.Environment{Runner: runner}
+	ghBackend := githubbackend.NewBackend(&env.Runner)
+	app := &App{
+		stdout:       testutil.IODiscard{},
+		stderr:       testutil.IODiscard{},
+		clock:        func() time.Time { return time.Date(2026, 3, 26, 20, 0, 0, 0, time.UTC) },
+		state:        store,
+		issueTracker: ghBackend,
+		prManager:    ghBackend,
+		env:          env,
+	}
+
+	session := state.Session{
+		Repo:        "owner/repo",
+		IssueNumber: 7,
+	}
+	comments, err := app.collectSessionComments(context.Background(), session, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(comments) != 1 || comments[0].ID != 10 {
+		t.Fatalf("expected 1 issue comment, got %#v", comments)
+	}
+}
+
+func TestCollectSessionCommentsMergesIssueAndPRComments(t *testing.T) {
+	t.Setenv("VIGILANTE_HOME", t.TempDir())
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/7/comments":            `[{"id":10,"body":"@vigilanteai resume","created_at":"2026-03-12T12:00:00Z","user":{"login":"alice"}}]`,
+			"gh api repos/owner/repo/issues/12/comments":           `[{"id":20,"body":"@vigilanteai cleanup","created_at":"2026-03-12T12:01:00Z","user":{"login":"bob"}}]`,
+			"gh api repos/owner/repo/pulls/12/comments --paginate": `[{"id":30,"body":"@vigilanteai please fix","created_at":"2026-03-12T12:02:00Z","user":{"login":"carol"}}]`,
+		},
+	}
+	env := &environment.Environment{Runner: runner}
+	ghBackend := githubbackend.NewBackend(&env.Runner)
+	app := &App{
+		stdout:       testutil.IODiscard{},
+		stderr:       testutil.IODiscard{},
+		clock:        func() time.Time { return time.Date(2026, 3, 26, 20, 0, 0, 0, time.UTC) },
+		state:        store,
+		issueTracker: ghBackend,
+		prManager:    ghBackend,
+		env:          env,
+	}
+
+	session := state.Session{
+		Repo:              "owner/repo",
+		IssueNumber:       7,
+		PullRequestNumber: 12,
+		PullRequestState:  "OPEN",
+	}
+	comments, err := app.collectSessionComments(context.Background(), session, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(comments) != 3 {
+		t.Fatalf("expected 3 merged comments, got %d: %#v", len(comments), comments)
+	}
+	wantIDs := []int64{10, 20, 30}
+	for i, want := range wantIDs {
+		if comments[i].ID != want {
+			t.Fatalf("expected comments[%d].ID = %d, got %d", i, want, comments[i].ID)
+		}
+	}
+}
+
+func TestCollectSessionCommentsSkipsPRWhenNotOpen(t *testing.T) {
+	t.Setenv("VIGILANTE_HOME", t.TempDir())
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/7/comments": `[{"id":10,"body":"hello","created_at":"2026-03-12T12:00:00Z","user":{"login":"alice"}}]`,
+		},
+	}
+	env := &environment.Environment{Runner: runner}
+	ghBackend := githubbackend.NewBackend(&env.Runner)
+	app := &App{
+		stdout:       testutil.IODiscard{},
+		stderr:       testutil.IODiscard{},
+		clock:        func() time.Time { return time.Date(2026, 3, 26, 20, 0, 0, 0, time.UTC) },
+		state:        store,
+		issueTracker: ghBackend,
+		prManager:    ghBackend,
+		env:          env,
+	}
+
+	// PR is MERGED - should not fetch PR comments
+	session := state.Session{
+		Repo:              "owner/repo",
+		IssueNumber:       7,
+		PullRequestNumber: 12,
+		PullRequestState:  "MERGED",
+	}
+	comments, err := app.collectSessionComments(context.Background(), session, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(comments) != 1 || comments[0].ID != 10 {
+		t.Fatalf("expected only issue comments for merged PR, got %#v", comments)
+	}
+}
+
+func TestCollectSessionCommentsGracefulPRFailure(t *testing.T) {
+	t.Setenv("VIGILANTE_HOME", t.TempDir())
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/7/comments": `[{"id":10,"body":"hello","created_at":"2026-03-12T12:00:00Z","user":{"login":"alice"}}]`,
+		},
+		Errors: map[string]error{
+			"gh api repos/owner/repo/issues/12/comments":           errors.New("rate limited"),
+			"gh api repos/owner/repo/pulls/12/comments --paginate": errors.New("rate limited"),
+		},
+	}
+	env := &environment.Environment{Runner: runner}
+	ghBackend := githubbackend.NewBackend(&env.Runner)
+	app := &App{
+		stdout:       testutil.IODiscard{},
+		stderr:       testutil.IODiscard{},
+		clock:        func() time.Time { return time.Date(2026, 3, 26, 20, 0, 0, 0, time.UTC) },
+		state:        store,
+		issueTracker: ghBackend,
+		prManager:    ghBackend,
+		env:          env,
+	}
+
+	session := state.Session{
+		Repo:              "owner/repo",
+		IssueNumber:       7,
+		PullRequestNumber: 12,
+		PullRequestState:  "OPEN",
+	}
+	// Should still return issue comments even when PR API fails
+	comments, err := app.collectSessionComments(context.Background(), session, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(comments) != 1 || comments[0].ID != 10 {
+		t.Fatalf("expected issue comments despite PR failure, got %#v", comments)
+	}
+}
+
+func TestCollectSessionCommentsDeduplicatesAcrossSurfaces(t *testing.T) {
+	t.Setenv("VIGILANTE_HOME", t.TempDir())
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	// On GitHub, issue comments and PR comments for the same PR share the
+	// same API. Simulate overlapping comment IDs to ensure deduplication.
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/7/comments":            `[{"id":10,"body":"issue comment","created_at":"2026-03-12T12:00:00Z","user":{"login":"alice"}}]`,
+			"gh api repos/owner/repo/issues/12/comments":           `[{"id":10,"body":"issue comment","created_at":"2026-03-12T12:00:00Z","user":{"login":"alice"}},{"id":20,"body":"pr comment","created_at":"2026-03-12T12:01:00Z","user":{"login":"bob"}}]`,
+			"gh api repos/owner/repo/pulls/12/comments --paginate": `[]`,
+		},
+	}
+	env := &environment.Environment{Runner: runner}
+	ghBackend := githubbackend.NewBackend(&env.Runner)
+	app := &App{
+		stdout:       testutil.IODiscard{},
+		stderr:       testutil.IODiscard{},
+		clock:        func() time.Time { return time.Date(2026, 3, 26, 20, 0, 0, 0, time.UTC) },
+		state:        store,
+		issueTracker: ghBackend,
+		prManager:    ghBackend,
+		env:          env,
+	}
+
+	session := state.Session{
+		Repo:              "owner/repo",
+		IssueNumber:       7,
+		PullRequestNumber: 12,
+		PullRequestState:  "OPEN",
+	}
+	comments, err := app.collectSessionComments(context.Background(), session, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(comments) != 2 {
+		t.Fatalf("expected 2 deduplicated comments, got %d: %#v", len(comments), comments)
+	}
+}

--- a/internal/backend/github/github.go
+++ b/internal/backend/github/github.go
@@ -138,6 +138,18 @@ func (b *Backend) ListPullRequestComments(ctx context.Context, repo string, numb
 	return ghcli.ListPullRequestComments(ctx, b.runner(), repo, number)
 }
 
+func (b *Backend) ListPullRequestCommentsForPolling(ctx context.Context, repo string, number int, purpose string, logger *slog.Logger) ([]backend.WorkItemComment, error) {
+	return ghcli.ListPullRequestCommentsForPolling(ctx, b.runner(), repo, number, purpose, logger)
+}
+
+func (b *Backend) ListPullRequestReviewComments(ctx context.Context, repo string, number int) ([]backend.WorkItemComment, error) {
+	return ghcli.ListPullRequestReviewComments(ctx, b.runner(), repo, number)
+}
+
+func (b *Backend) ListPullRequestReviewCommentsForPolling(ctx context.Context, repo string, number int, purpose string, logger *slog.Logger) ([]backend.WorkItemComment, error) {
+	return ghcli.ListPullRequestReviewCommentsForPolling(ctx, b.runner(), repo, number, purpose, logger)
+}
+
 func (b *Backend) CommentOnPullRequest(ctx context.Context, repo string, number int, body string) error {
 	return ghcli.CommentOnPullRequest(ctx, b.runner(), repo, number, body)
 }

--- a/internal/backend/interfaces.go
+++ b/internal/backend/interfaces.go
@@ -91,6 +91,19 @@ type PullRequestManager interface {
 	// ListPullRequestComments returns comments on a pull request.
 	ListPullRequestComments(ctx context.Context, repo string, number int) ([]WorkItemComment, error)
 
+	// ListPullRequestCommentsForPolling is a polling-safe variant of
+	// ListPullRequestComments that logs failures without propagating through
+	// access logging.
+	ListPullRequestCommentsForPolling(ctx context.Context, repo string, number int, purpose string, logger *slog.Logger) ([]WorkItemComment, error)
+
+	// ListPullRequestReviewComments returns inline review comments on a
+	// pull request (code-level comments from PR reviews).
+	ListPullRequestReviewComments(ctx context.Context, repo string, number int) ([]WorkItemComment, error)
+
+	// ListPullRequestReviewCommentsForPolling is a polling-safe variant of
+	// ListPullRequestReviewComments.
+	ListPullRequestReviewCommentsForPolling(ctx context.Context, repo string, number int, purpose string, logger *slog.Logger) ([]WorkItemComment, error)
+
 	// CommentOnPullRequest posts a comment on a pull request.
 	CommentOnPullRequest(ctx context.Context, repo string, number int, body string) error
 

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -787,3 +787,147 @@ func ListPullRequestComments(ctx context.Context, runner environment.Runner, rep
 func AddPullRequestCommentReaction(ctx context.Context, runner environment.Runner, repo string, commentID int64, content string) error {
 	return AddIssueCommentReaction(ctx, runner, repo, commentID, content)
 }
+
+// ListPullRequestCommentsForPolling is a polling-safe variant of
+// ListPullRequestComments that logs failures without propagating through
+// access logging.
+func ListPullRequestCommentsForPolling(ctx context.Context, runner environment.Runner, repo string, number int, purpose string, logger *slog.Logger) ([]IssueComment, error) {
+	output, err := runPullRequestCommentsCommand(ctx, runner, repo, number)
+	if err != nil {
+		if logger != nil {
+			logger.Error("pr comment poll failed", "repo", repo, "pr", number, "purpose", purpose, "err", err, "output", summarizeForLog(output))
+		}
+		return nil, err
+	}
+	comments, err := parseIssueComments(output)
+	if err != nil {
+		if logger != nil {
+			logger.Error("pr comment poll parse failed", "repo", repo, "pr", number, "purpose", purpose, "err", err, "output", summarizeForLog(output))
+		}
+		return nil, err
+	}
+	if logger != nil {
+		logger.Info("pr comment poll", "repo", repo, "pr", number, "purpose", purpose, "comments", len(comments))
+	}
+	return comments, nil
+}
+
+// runPullRequestCommentsCommand fetches PR issue comments bypassing the
+// access logger, mirroring runIssueCommentsCommand for the PR number.
+func runPullRequestCommentsCommand(ctx context.Context, runner environment.Runner, repo string, number int) (string, error) {
+	path := issueAPIPath(repo, number) + "/comments"
+	switch typed := runner.(type) {
+	case environment.LoggingRunner:
+		return typed.Base.Run(ctx, "", "gh", "api", path)
+	case *environment.LoggingRunner:
+		return typed.Base.Run(ctx, "", "gh", "api", path)
+	default:
+		return runner.Run(ctx, "", "gh", "api", path)
+	}
+}
+
+// ListPullRequestReviewComments returns inline review comments on a pull
+// request. These are code-level comments left during a PR review, fetched
+// from the pulls review comments API endpoint.
+func ListPullRequestReviewComments(ctx context.Context, runner environment.Runner, repo string, number int) ([]IssueComment, error) {
+	output, err := runner.Run(ctx, "", "gh", "api", pullReviewCommentsAPIPath(repo, number), "--paginate")
+	if err != nil {
+		return nil, err
+	}
+	return parsePullRequestReviewComments(output)
+}
+
+// ListPullRequestReviewCommentsForPolling is a polling-safe variant of
+// ListPullRequestReviewComments that logs failures without propagating
+// through access logging.
+func ListPullRequestReviewCommentsForPolling(ctx context.Context, runner environment.Runner, repo string, number int, purpose string, logger *slog.Logger) ([]IssueComment, error) {
+	output, err := runPullRequestReviewCommentsCommand(ctx, runner, repo, number)
+	if err != nil {
+		if logger != nil {
+			logger.Error("pr review comment poll failed", "repo", repo, "pr", number, "purpose", purpose, "err", err, "output", summarizeForLog(output))
+		}
+		return nil, err
+	}
+	comments, err := parsePullRequestReviewComments(output)
+	if err != nil {
+		if logger != nil {
+			logger.Error("pr review comment poll parse failed", "repo", repo, "pr", number, "purpose", purpose, "err", err, "output", summarizeForLog(output))
+		}
+		return nil, err
+	}
+	if logger != nil {
+		logger.Info("pr review comment poll", "repo", repo, "pr", number, "purpose", purpose, "comments", len(comments))
+	}
+	return comments, nil
+}
+
+func runPullRequestReviewCommentsCommand(ctx context.Context, runner environment.Runner, repo string, number int) (string, error) {
+	path := pullReviewCommentsAPIPath(repo, number)
+	switch typed := runner.(type) {
+	case environment.LoggingRunner:
+		return typed.Base.Run(ctx, "", "gh", "api", path, "--paginate")
+	case *environment.LoggingRunner:
+		return typed.Base.Run(ctx, "", "gh", "api", path, "--paginate")
+	default:
+		return runner.Run(ctx, "", "gh", "api", path, "--paginate")
+	}
+}
+
+func pullReviewCommentsAPIPath(repo string, number int) string {
+	return fmt.Sprintf("repos/%s/pulls/%d/comments", repo, number)
+}
+
+// pullRequestReviewComment is the subset of the GitHub pull request review
+// comment API response that we map into WorkItemComment.
+type pullRequestReviewComment struct {
+	ID        int64     `json:"id"`
+	Body      string    `json:"body"`
+	CreatedAt time.Time `json:"created_at"`
+	User      struct {
+		Login string `json:"login"`
+	} `json:"user"`
+}
+
+func parsePullRequestReviewComments(output string) ([]IssueComment, error) {
+	var raw []pullRequestReviewComment
+	if err := json.Unmarshal([]byte(strings.TrimSpace(output)), &raw); err != nil {
+		return nil, fmt.Errorf("parse pr review comments: %w", err)
+	}
+	comments := make([]IssueComment, len(raw))
+	for i, r := range raw {
+		comments[i] = IssueComment{
+			ID:        r.ID,
+			Body:      r.Body,
+			CreatedAt: r.CreatedAt,
+		}
+		comments[i].User.Login = r.User.Login
+	}
+	sort.Slice(comments, func(i, j int) bool {
+		return comments[i].CreatedAt.Before(comments[j].CreatedAt)
+	})
+	return comments, nil
+}
+
+// MergeCommentSurfaces merges multiple comment slices into a single
+// deduplicated, chronologically sorted slice. Comments with the same ID
+// are kept only once (first occurrence wins).
+func MergeCommentSurfaces(surfaces ...[]IssueComment) []IssueComment {
+	seen := make(map[int64]struct{})
+	var merged []IssueComment
+	for _, surface := range surfaces {
+		for _, c := range surface {
+			if _, ok := seen[c.ID]; ok {
+				continue
+			}
+			seen[c.ID] = struct{}{}
+			merged = append(merged, c)
+		}
+	}
+	sort.Slice(merged, func(i, j int) bool {
+		if merged[i].CreatedAt.Equal(merged[j].CreatedAt) {
+			return merged[i].ID < merged[j].ID
+		}
+		return merged[i].CreatedAt.Before(merged[j].CreatedAt)
+	})
+	return merged
+}

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -565,3 +565,184 @@ func TestLatestUserCommentTimeIgnoresAutomationComments(t *testing.T) {
 		t.Fatalf("expected latest user comment at %s, got %s", want, got)
 	}
 }
+
+func TestListPullRequestReviewComments(t *testing.T) {
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/pulls/12/comments --paginate": `[{"id":100,"body":"@vigilanteai resume","created_at":"2026-03-12T12:00:00Z","user":{"login":"alice"}},{"id":101,"body":"looks good","created_at":"2026-03-12T12:01:00Z","user":{"login":"bob"}}]`,
+		},
+	}
+
+	comments, err := ListPullRequestReviewComments(context.Background(), runner, "owner/repo", 12)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(comments) != 2 {
+		t.Fatalf("expected 2 review comments, got %d", len(comments))
+	}
+	if comments[0].ID != 100 || comments[0].User.Login != "alice" {
+		t.Fatalf("unexpected first review comment: %#v", comments[0])
+	}
+	if comments[1].ID != 101 || comments[1].Body != "looks good" {
+		t.Fatalf("unexpected second review comment: %#v", comments[1])
+	}
+}
+
+func TestListPullRequestCommentsForPolling(t *testing.T) {
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/12/comments": `[{"id":200,"body":"@vigilanteai cleanup","created_at":"2026-03-12T12:00:00Z","user":{"login":"alice"}}]`,
+		},
+	}
+
+	comments, err := ListPullRequestCommentsForPolling(context.Background(), runner, "owner/repo", 12, "test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(comments) != 1 || comments[0].ID != 200 {
+		t.Fatalf("unexpected PR comments: %#v", comments)
+	}
+}
+
+func TestMergeCommentSurfacesDeduplicatesByID(t *testing.T) {
+	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	issueComments := []IssueComment{
+		{ID: 10, Body: "hello", CreatedAt: now.Add(-3 * time.Minute)},
+		{ID: 11, Body: "@vigilanteai resume", CreatedAt: now.Add(-2 * time.Minute)},
+	}
+	prComments := []IssueComment{
+		{ID: 11, Body: "@vigilanteai resume", CreatedAt: now.Add(-2 * time.Minute)}, // duplicate
+		{ID: 20, Body: "@vigilanteai cleanup", CreatedAt: now.Add(-1 * time.Minute)},
+	}
+	reviewComments := []IssueComment{
+		{ID: 30, Body: "inline feedback", CreatedAt: now.Add(-30 * time.Second)},
+	}
+
+	merged := MergeCommentSurfaces(issueComments, prComments, reviewComments)
+	if len(merged) != 4 {
+		t.Fatalf("expected 4 merged comments after dedup, got %d: %#v", len(merged), merged)
+	}
+	// Verify chronological order
+	for i := 1; i < len(merged); i++ {
+		if merged[i].CreatedAt.Before(merged[i-1].CreatedAt) {
+			t.Fatalf("merged comments not in chronological order at index %d", i)
+		}
+	}
+	// Verify IDs
+	wantIDs := []int64{10, 11, 20, 30}
+	for i, want := range wantIDs {
+		if merged[i].ID != want {
+			t.Fatalf("expected merged[%d].ID = %d, got %d", i, want, merged[i].ID)
+		}
+	}
+}
+
+func TestMergeCommentSurfacesHandlesEmptySurfaces(t *testing.T) {
+	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	comments := []IssueComment{
+		{ID: 10, Body: "hello", CreatedAt: now},
+	}
+
+	merged := MergeCommentSurfaces(comments, nil, nil)
+	if len(merged) != 1 || merged[0].ID != 10 {
+		t.Fatalf("unexpected merged result: %#v", merged)
+	}
+
+	merged = MergeCommentSurfaces(nil, nil)
+	if len(merged) != 0 {
+		t.Fatalf("expected empty merge result, got %#v", merged)
+	}
+}
+
+func TestFindResumeCommentAcrossPRSurface(t *testing.T) {
+	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	issueComments := []IssueComment{
+		{ID: 10, Body: "working on it", CreatedAt: now.Add(-2 * time.Minute)},
+	}
+	prComments := []IssueComment{
+		{ID: 20, Body: "@vigilanteai resume", CreatedAt: now.Add(-1 * time.Minute)},
+	}
+
+	merged := MergeCommentSurfaces(issueComments, prComments)
+	comment := FindResumeComment(merged, 0)
+	if comment == nil || comment.ID != 20 {
+		t.Fatalf("expected resume command from PR comments to be found, got %#v", comment)
+	}
+}
+
+func TestFindCleanupCommentAcrossPRReviewSurface(t *testing.T) {
+	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	issueComments := []IssueComment{
+		{ID: 10, Body: "looks good", CreatedAt: now.Add(-2 * time.Minute)},
+	}
+	reviewComments := []IssueComment{
+		{ID: 30, Body: "@vigilanteai cleanup", CreatedAt: now.Add(-1 * time.Minute)},
+	}
+
+	merged := MergeCommentSurfaces(issueComments, nil, reviewComments)
+	comment := FindCleanupComment(merged, 0)
+	if comment == nil || comment.ID != 30 {
+		t.Fatalf("expected cleanup command from review comments to be found, got %#v", comment)
+	}
+}
+
+func TestFindIterationCommentAcrossMergedSurfaces(t *testing.T) {
+	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	issueComments := []IssueComment{
+		{ID: 10, Body: "@vigilanteai please fix the tests", CreatedAt: now.Add(-3 * time.Minute)},
+	}
+	prComments := []IssueComment{
+		{ID: 20, Body: "@vigilanteai also update the docs", CreatedAt: now.Add(-1 * time.Minute)},
+	}
+
+	merged := MergeCommentSurfaces(issueComments, prComments)
+	// With no claimed comment, should find the latest iteration comment (from PR)
+	comment := FindIterationComment(merged, 0, "")
+	if comment == nil || comment.ID != 20 {
+		t.Fatalf("expected iteration comment from PR, got %#v", comment)
+	}
+
+	// After claiming the PR comment, should find the issue comment
+	comment = FindIterationComment(merged, 20, now.Add(-1*time.Minute).Format(time.RFC3339))
+	if comment != nil {
+		t.Fatalf("expected no new iteration comment after claiming latest, got %#v", comment)
+	}
+}
+
+func TestMergeCommentSurfacesPreservesIDOrderAtSameTimestamp(t *testing.T) {
+	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+	comments1 := []IssueComment{
+		{ID: 20, Body: "second", CreatedAt: now},
+	}
+	comments2 := []IssueComment{
+		{ID: 10, Body: "first", CreatedAt: now},
+	}
+
+	merged := MergeCommentSurfaces(comments1, comments2)
+	if len(merged) != 2 || merged[0].ID != 10 || merged[1].ID != 20 {
+		t.Fatalf("expected ID-ordered tie-breaking, got %#v", merged)
+	}
+}
+
+func TestCommandsFromMultipleSessionsRouteCorrectly(t *testing.T) {
+	now := time.Date(2026, 3, 12, 12, 0, 0, 0, time.UTC)
+
+	session1Comments := []IssueComment{
+		{ID: 10, Body: "@vigilanteai resume", CreatedAt: now.Add(-2 * time.Minute)},
+	}
+	session2Comments := []IssueComment{
+		{ID: 20, Body: "@vigilanteai resume", CreatedAt: now.Add(-1 * time.Minute)},
+	}
+
+	// Session 1 already claimed comment 10
+	comment1 := FindResumeComment(session1Comments, 10)
+	if comment1 != nil {
+		t.Fatalf("session 1 should not find new resume after claiming 10, got %#v", comment1)
+	}
+
+	// Session 2 has not claimed any comment yet
+	comment2 := FindResumeComment(session2Comments, 0)
+	if comment2 == nil || comment2.ID != 20 {
+		t.Fatalf("session 2 should find resume comment 20, got %#v", comment2)
+	}
+}


### PR DESCRIPTION
## Summary

Extends Vigilante's in-progress session monitoring to watch PR discussion surfaces (timeline comments + review/inline comments) in addition to issue comments, for active sessions with open pull requests.

Closes #402

### Changes

- **`internal/github/github.go`** — Added `ListPullRequestCommentsForPolling`, `ListPullRequestReviewComments`, `ListPullRequestReviewCommentsForPolling`, `MergeCommentSurfaces` helper for deduplicating and merging comments across surfaces
- **`internal/backend/interfaces.go`** — Extended `PullRequestManager` with 3 new methods for polling-safe PR comment and review comment access
- **`internal/backend/github/github.go`** — Implemented the new interface methods
- **`internal/app/app.go`** — Added `collectSessionComments()` that gathers issue + PR + review comments with graceful degradation; updated all 4 polling functions (cleanup, recreate, resume, iteration) to use it

### Behavior

- When a session has an open PR (`PullRequestNumber > 0` and `PullRequestState == "OPEN"`), polling now fetches comments from all three surfaces and merges them
- If the PR API fails, monitoring gracefully degrades to issue-only comments without blocking the poll
- Comments are deduplicated by ID across surfaces, preventing duplicate command processing
- Monitoring naturally stops for PR surfaces when the PR is no longer open
- Authorization/safety checks remain consistent across all comment surfaces

## Test plan

- [x] Tests for PR review comment parsing (`TestListPullRequestReviewComments`)
- [x] Tests for polling-safe PR comment listing (`TestListPullRequestCommentsForPolling`)
- [x] Tests for comment surface merge/dedup (`TestMergeCommentSurfacesDeduplicatesByID`, `TestMergeCommentSurfacesHandlesEmptySurfaces`, `TestMergeCommentSurfacesPreservesIDOrderAtSameTimestamp`)
- [x] Tests for cross-surface command detection (`TestFindResumeCommentAcrossPRSurface`, `TestFindCleanupCommentAcrossPRReviewSurface`, `TestFindIterationCommentAcrossMergedSurfaces`)
- [x] Tests for session routing with multiple sessions (`TestCommandsFromMultipleSessionsRouteCorrectly`)
- [x] Tests for `collectSessionComments` — issue-only, merged, closed-PR skip, graceful failure, dedup
- [x] All existing tests continue to pass
- [x] `go vet`, `gofmt`, `go test ./... -count=1` clean