### PR TITLE
Skip CI/CD for Markdown-only pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,22 +13,61 @@ concurrency:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect Markdown-only pull request
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          mapfile -t changed_files < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+
+          if [ "${#changed_files[@]}" -eq 0 ]; then
+            echo "markdown_only=false" >> "$GITHUB_OUTPUT"
+            echo "No changed files detected; running full CI."
+            exit 0
+          fi
+
+          markdown_only=true
+          for path in "${changed_files[@]}"; do
+            case "$path" in
+              *.md) ;;
+              *)
+                markdown_only=false
+                break
+                ;;
+            esac
+          done
+
+          echo "Changed files:"
+          printf '%s\n' "${changed_files[@]}"
+          echo "markdown_only=$markdown_only" >> "$GITHUB_OUTPUT"
+
+          if [ "$markdown_only" = true ]; then
+            echo "Markdown-only pull request detected; full CI steps will be skipped."
+          fi
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        if: steps.changes.outputs.markdown_only != 'true'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Set up GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        if: steps.changes.outputs.markdown_only != 'true'
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:
           install-only: true
 
       - name: Check formatting
+        if: steps.changes.outputs.markdown_only != 'true'
         run: |
           unformatted="$(gofmt -l .)"
           if [ -n "$unformatted" ]; then
@@ -38,13 +77,21 @@ jobs:
           fi
 
       - name: Lint with go vet
+        if: steps.changes.outputs.markdown_only != 'true'
         run: go vet ./...
 
       - name: Run tests
+        if: steps.changes.outputs.markdown_only != 'true'
         run: go test ./...
 
       - name: Verify build
+        if: steps.changes.outputs.markdown_only != 'true'
         run: go build ./...
 
       - name: Validate GoReleaser config
+        if: steps.changes.outputs.markdown_only != 'true'
         run: goreleaser check
+
+      - name: Skip full CI for Markdown-only pull requests
+        if: steps.changes.outputs.markdown_only == 'true'
+        run: echo "Only Markdown files changed, so full CI was skipped intentionally."


### PR DESCRIPTION
## Summary
- detect Markdown-only pull requests in the `CI` workflow using the PR base/head diff
- skip the expensive Go validation steps for Markdown-only PRs while keeping the `CI` check green
- pin the actions touched in `ci.yml` and add a job timeout while updating the workflow

## Validation
- `git diff --check`
- shell check of the Markdown-only path matcher for root Markdown, nested Markdown, mixed, and non-Markdown file sets
- `actionlint` not installed locally
- YAML parser validation unavailable locally (`python3` lacked `PyYAML`)

Closes #404