### PR TITLE
Add vigilante start for one-off issue execution

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -606,6 +606,8 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 	switch args[0] {
 	case "commit":
 		return a.runCommitCommand(ctx, args[1:])
+	case "start":
+		return a.runStartCommand(ctx, args[1:])
 	case "clone":
 		return a.runCloneCommand(ctx, args[1:])
 	case "setup":
@@ -1099,6 +1101,199 @@ func (a *App) runCleanupCommand(ctx context.Context, args []string) error {
 	default:
 		return a.CleanupSession(ctx, *repo, *issue, "cli")
 	}
+}
+
+func (a *App) runStartCommand(ctx context.Context, args []string) error {
+	fs := flag.NewFlagSet("start", flag.ContinueOnError)
+	configureFlagSet(fs, func(w io.Writer) {
+		fmt.Fprintln(w, "usage: vigilante start <repo-folder> --issue <n> [--provider value]")
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Run a one-off issue implementation session against a local repository.")
+		fmt.Fprintln(w, "The repository does not need to be watched.")
+		fmt.Fprintln(w)
+		fs.SetOutput(w)
+		fs.PrintDefaults()
+	})
+	issue := fs.Int("issue", 0, "issue number to implement")
+	selectedProvider := fs.String("provider", "", "coding agent provider")
+	if err := parseFlagSet(fs, args, a.stdout); err != nil {
+		if errors.Is(err, errHelpHandled) {
+			return nil
+		}
+		return err
+	}
+	if fs.NArg() != 1 {
+		return errors.New("usage: vigilante start <repo-folder> --issue <n> [--provider value]")
+	}
+	if *issue <= 0 {
+		return errors.New("usage: vigilante start <repo-folder> --issue <n> [--provider value]")
+	}
+	return a.StartOneOffSession(ctx, fs.Arg(0), *issue, strings.TrimSpace(*selectedProvider))
+}
+
+// StartOneOffSession runs a one-off issue implementation session for a local
+// repository that is not necessarily in the watchlist. The repository is not
+// added to the watchlist as a side effect.
+func (a *App) StartOneOffSession(ctx context.Context, rawPath string, issueNumber int, providerID string) error {
+	if err := a.state.EnsureLayout(); err != nil {
+		return err
+	}
+
+	repoPath, err := ExpandPath(rawPath)
+	if err != nil {
+		return err
+	}
+
+	info, err := repo.Discover(ctx, a.env.Runner, repoPath)
+	if err != nil {
+		return err
+	}
+
+	if providerID != "" {
+		resolvedProvider, err := provider.Resolve(providerID)
+		if err != nil {
+			return err
+		}
+		providerID = resolvedProvider.ID()
+	} else {
+		providerID = provider.DefaultID
+	}
+
+	// Build a transient watch target from the discovered repository info.
+	// This target is never persisted to the watchlist.
+	target := state.WatchTarget{
+		Path:           info.Path,
+		Repo:           info.Repo,
+		BranchMode:     state.BranchModeAuto,
+		Branch:         info.Branch,
+		Classification: info.Classification,
+		Provider:       providerID,
+		MaxParallel:    1,
+	}
+
+	if err := a.ensureIssueTrackerReady(ctx, target.EffectiveIssueBackend()); err != nil {
+		return err
+	}
+
+	issueTracker := a.issueTrackerForTarget(target)
+	details, err := issueTracker.GetWorkItemDetails(ctx, target.EffectiveProjectRef(), issueNumber)
+	if err != nil {
+		return fmt.Errorf("issue #%d could not be resolved for %s: %w", issueNumber, info.Repo, err)
+	}
+	if details.State != "open" && details.State != "OPEN" {
+		return fmt.Errorf("issue #%d is not open (state: %s)", issueNumber, details.State)
+	}
+
+	issueLabels := make([]string, 0, len(details.Labels))
+	for _, l := range details.Labels {
+		issueLabels = append(issueLabels, l.Name)
+	}
+	ghIssue := ghcli.Issue{
+		Number: issueNumber,
+		Title:  details.Title,
+		URL:    details.URL,
+		Labels: labelsToBackendLabels(issueLabels),
+	}
+
+	selectedProvider, err := resolveIssueProvider(target, ghIssue)
+	if err != nil {
+		return err
+	}
+
+	target, err = a.prepareExecutionTarget(ctx, target)
+	if err != nil {
+		return err
+	}
+
+	a.sessionMu.Lock()
+	defer a.sessionMu.Unlock()
+
+	sessions, err := a.state.LoadSessions()
+	if err != nil {
+		return err
+	}
+	if existing, ok := findSession(sessions, info.Repo, issueNumber); ok {
+		if existing.Status == state.SessionStatusRunning {
+			return fmt.Errorf("a session is already running for %s#%d", info.Repo, issueNumber)
+		}
+	}
+
+	wt, err := worktree.CreateIssueWorktree(ctx, a.env.Runner, target, ghIssue.Number, ghIssue.Title)
+	if err != nil {
+		return err
+	}
+
+	now := a.clock().Format(time.RFC3339)
+	session := state.Session{
+		RepoPath:           target.Path,
+		Repo:               target.Repo,
+		Provider:           selectedProvider,
+		IssueBackend:       target.EffectiveIssueBackend(),
+		GitBackend:         target.EffectiveGitBackend(),
+		PRBackend:          target.EffectivePRBackend(),
+		IssueNumber:        ghIssue.Number,
+		IssueTitle:         ghIssue.Title,
+		IssueURL:           ghIssue.URL,
+		BaseBranch:         target.Branch,
+		Branch:             wt.Branch,
+		WorktreePath:       wt.Path,
+		ForkMode:           target.ForkMode,
+		ForkOwner:          target.ForkOwner,
+		UpstreamRepo:       target.UpstreamRepo,
+		PushRemote:         target.EffectivePushRemote(),
+		PushRepo:           target.PushRepo,
+		ReusedRemoteBranch: wt.ReusedRemoteBranch,
+		Status:             state.SessionStatusRunning,
+		ProcessID:          os.Getpid(),
+		StartedAt:          now,
+		LastHeartbeatAt:    now,
+		UpdatedAt:          now,
+	}
+	sessions = upsertSession(sessions, session)
+	if err := a.state.SaveSessions(sessions); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(a.stdout, "starting one-off session for %s issue #%d in %s\n", info.Repo, issueNumber, wt.Path)
+	fmt.Fprintf(a.stdout, "note: this is a one-off session — the repository was not added to watched targets\n")
+
+	// Run the session synchronously so the CLI blocks until completion.
+	result := issuerunner.RunIssueSession(ctx, a.env, a.state, issueTracker, target, ghIssue, session)
+
+	sessions, err = a.state.LoadSessions()
+	if err != nil {
+		a.logger.Error("start session result load failed", "repo", info.Repo, "issue", issueNumber, "err", err)
+		return fmt.Errorf("session completed with status %s but result could not be saved: %w", result.Status, err)
+	}
+	sessions = upsertSession(sessions, result)
+	if err := a.state.SaveSessions(sessions); err != nil {
+		a.logger.Error("start session result save failed", "repo", info.Repo, "issue", issueNumber, "err", err)
+	}
+
+	a.syncSessionIssueLabelsBestEffort(ctx, &result, nil, nil, nil)
+
+	switch result.Status {
+	case state.SessionStatusSuccess:
+		fmt.Fprintf(a.stdout, "session completed successfully for %s issue #%d\n", info.Repo, issueNumber)
+		return nil
+	case state.SessionStatusBlocked:
+		fmt.Fprintf(a.stdout, "session blocked for %s issue #%d: %s\n", info.Repo, issueNumber, result.ResumeHint)
+		return fmt.Errorf("session blocked: %s", result.BlockedReason.Summary)
+	default:
+		fmt.Fprintf(a.stdout, "session ended with status %s for %s issue #%d\n", result.Status, info.Repo, issueNumber)
+		if result.LastError != "" {
+			return fmt.Errorf("session failed: %s", result.LastError)
+		}
+		return fmt.Errorf("session ended with status %s", result.Status)
+	}
+}
+
+func labelsToBackendLabels(names []string) []ghcli.Label {
+	labels := make([]ghcli.Label, 0, len(names))
+	for _, name := range names {
+		labels = append(labels, ghcli.Label{Name: name})
+	}
+	return labels
 }
 
 func (a *App) runRecreateCommand(ctx context.Context, args []string) error {
@@ -6078,6 +6273,7 @@ func (a *App) issueCreate(ctx context.Context, repoSlug string, providerOverride
 
 func (a *App) printUsage(w io.Writer) {
 	fmt.Fprintln(w, "usage:")
+	fmt.Fprintln(w, "  vigilante start <repo-folder> --issue <n> [--provider value]")
 	fmt.Fprintln(w, "  vigilante setup [--provider value]")
 	fmt.Fprintln(w, "  vigilante clone [git-clone-flags...] [--] <repo> [<path>]")
 	fmt.Fprintln(w, "  vigilante watch [--label value] [--assignee value] [--max-parallel value] [--provider value] [--issue-tracker value] [--issue-tracker-stage value] [--branch value | --track-default-branch] [--fork [--fork-owner value]] <path>")

--- a/internal/app/start_test.go
+++ b/internal/app/start_test.go
@@ -1,0 +1,539 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	ghcli "github.com/nicobistolfi/vigilante/internal/github"
+	"github.com/nicobistolfi/vigilante/internal/skill"
+	"github.com/nicobistolfi/vigilante/internal/state"
+	"github.com/nicobistolfi/vigilante/internal/testutil"
+)
+
+// repoDiscoverOutputs returns the common git outputs needed for repo.Discover
+// to succeed against a test repository path.
+func repoDiscoverOutputs(repoPath string, repoSlug string, branch string) map[string]string {
+	return map[string]string{
+		"git rev-parse --is-inside-work-tree": "true",
+		"git remote get-url origin":           "https://github.com/" + repoSlug + ".git",
+		"git ls-remote --symref origin HEAD":  "ref: refs/heads/" + branch + "\tHEAD\nabcdef1234567890\tHEAD\n",
+	}
+}
+
+func TestStartOneOffSessionSuccess(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-10")
+	branch := "vigilante/issue-10-fix-something"
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.clock = func() time.Time { return time.Date(2026, 4, 6, 12, 0, 0, 0, time.UTC) }
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"codex": "/usr/bin/codex"},
+		Outputs: mergeStringMaps(
+			repoDiscoverOutputs(repoPath, "owner/repo", "main"),
+			freshBaseBranchOutputs(repoPath, "main"),
+			map[string]string{
+				"git worktree prune":            "ok",
+				"git worktree list --porcelain": "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
+				"git worktree add -b " + branch + " " + worktreePath + " origin/main": "ok",
+				"gh api repos/owner/repo/issues/10":                                   `{"title":"fix something","body":"fix it","html_url":"https://github.com/owner/repo/issues/10","state":"open","labels":[],"assignees":[]}`,
+				"gh auth status":                                                      "Logged in",
+				sessionStartCommentCommand("owner/repo", 10, worktreePath, state.Session{Branch: branch}):                                            "ok",
+				preflightPromptCommand(worktreePath, "owner/repo", repoPath, 10, "fix something", "https://github.com/owner/repo/issues/10", branch): "baseline ok",
+				issuePromptCommand(worktreePath, "owner/repo", repoPath, 10, "fix something", "https://github.com/owner/repo/issues/10", branch):     "done",
+			},
+		),
+		Errors: map[string]error{
+			"git show-ref --verify --quiet refs/heads/" + branch:          errors.New("exit status 1"),
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-10": errors.New("exit status 1"),
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify no watch targets exist before the call.
+	targets, err := app.state.LoadWatchTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 0 {
+		t.Fatal("expected no watch targets")
+	}
+
+	err = app.StartOneOffSession(context.Background(), repoPath, 10, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify session was saved.
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	if sessions[0].Status != state.SessionStatusSuccess {
+		t.Fatalf("expected success, got %s", sessions[0].Status)
+	}
+	if sessions[0].Repo != "owner/repo" || sessions[0].IssueNumber != 10 {
+		t.Fatalf("unexpected session: %#v", sessions[0])
+	}
+
+	// Verify no watch targets were added.
+	targets, err = app.state.LoadWatchTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 0 {
+		t.Fatalf("expected no watch targets after start, got %d", len(targets))
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "one-off session") {
+		t.Fatalf("expected one-off note in output, got: %s", output)
+	}
+	if !strings.Contains(output, "completed successfully") {
+		t.Fatalf("expected success message, got: %s", output)
+	}
+}
+
+func TestStartOneOffSessionDoesNotAddToWatchlist(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-5")
+	branch := "vigilante/issue-5-test-issue"
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.clock = func() time.Time { return time.Date(2026, 4, 6, 12, 0, 0, 0, time.UTC) }
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"codex": "/usr/bin/codex"},
+		Outputs: mergeStringMaps(
+			repoDiscoverOutputs(repoPath, "owner/repo", "main"),
+			freshBaseBranchOutputs(repoPath, "main"),
+			map[string]string{
+				"git worktree prune":            "ok",
+				"git worktree list --porcelain": "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
+				"git worktree add -b " + branch + " " + worktreePath + " origin/main": "ok",
+				"gh api repos/owner/repo/issues/5":                                    `{"title":"test issue","body":"test","html_url":"https://github.com/owner/repo/issues/5","state":"open","labels":[],"assignees":[]}`,
+				"gh auth status":                                                      "Logged in",
+				sessionStartCommentCommand("owner/repo", 5, worktreePath, state.Session{Branch: branch}):                                        "ok",
+				preflightPromptCommand(worktreePath, "owner/repo", repoPath, 5, "test issue", "https://github.com/owner/repo/issues/5", branch): "ok",
+				issuePromptCommand(worktreePath, "owner/repo", repoPath, 5, "test issue", "https://github.com/owner/repo/issues/5", branch):     "done",
+			},
+		),
+		Errors: map[string]error{
+			"git show-ref --verify --quiet refs/heads/" + branch:         errors.New("exit status 1"),
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-5": errors.New("exit status 1"),
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-populate a watch target for a different repo.
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{
+		Path: "/other/repo", Repo: "other/repo", Branch: "main", Provider: "codex",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.StartOneOffSession(context.Background(), repoPath, 5, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	targets, err := app.state.LoadWatchTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 || targets[0].Repo != "other/repo" {
+		t.Fatalf("watchlist was mutated: %#v", targets)
+	}
+}
+
+func TestStartOneOffSessionInvalidRepoPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Errors: map[string]error{
+			"git rev-parse --is-inside-work-tree": errors.New("not a git repo"),
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := app.StartOneOffSession(context.Background(), filepath.Join(home, "nonexistent"), 1, "")
+	if err == nil || !strings.Contains(err.Error(), "not a git repository") {
+		t.Fatalf("expected git repo error, got: %v", err)
+	}
+}
+
+func TestStartOneOffSessionIssueNotOpen(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: mergeStringMaps(
+			repoDiscoverOutputs(repoPath, "owner/repo", "main"),
+			map[string]string{
+				"gh api repos/owner/repo/issues/99": `{"title":"closed issue","body":"","html_url":"https://github.com/owner/repo/issues/99","state":"closed","labels":[],"assignees":[]}`,
+			},
+		),
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := app.StartOneOffSession(context.Background(), repoPath, 99, "")
+	if err == nil || !strings.Contains(err.Error(), "not open") {
+		t.Fatalf("expected not-open error, got: %v", err)
+	}
+}
+
+func TestStartOneOffSessionIssueResolutionFailure(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: repoDiscoverOutputs(repoPath, "owner/repo", "main"),
+		Errors: map[string]error{
+			"gh api repos/owner/repo/issues/404": errors.New("HTTP 404"),
+		},
+		ErrorOutputs: map[string]string{
+			"gh api repos/owner/repo/issues/404": "Not Found",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := app.StartOneOffSession(context.Background(), repoPath, 404, "")
+	if err == nil || !strings.Contains(err.Error(), "could not be resolved") {
+		t.Fatalf("expected resolution failure, got: %v", err)
+	}
+}
+
+func TestStartOneOffSessionReusesExistingSessionOrchestration(t *testing.T) {
+	// This test verifies the start command goes through the same
+	// issuerunner.RunIssueSession path as watched-repo sessions by
+	// checking that session state transitions follow the same pattern.
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-7")
+	branch := "vigilante/issue-7-blocked-test"
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", filepath.Join(home, ".codex"))
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.clock = func() time.Time { return time.Date(2026, 4, 6, 12, 0, 0, 0, time.UTC) }
+
+	// Set up runner where the preflight succeeds but the main invocation fails,
+	// which should result in a blocked session (same as watched repo behavior).
+	blockedComment := ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Blocked",
+		Emoji:      "🛑",
+		Percent:    95,
+		ETAMinutes: 10,
+		Items: []string{
+			fmt.Sprintf("The `codex` provider stopped before the issue implementation completed."),
+			"Cause: unknown (no specific cause category detected).",
+			fmt.Sprintf("Next step: fix the blocker, then run `vigilante resume --repo owner/repo --issue 7` or request resume from GitHub."),
+		},
+		Tagline: "Plans are only good intentions unless they immediately degenerate into hard work.",
+	})
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"codex": "/usr/bin/codex"},
+		Outputs: mergeStringMaps(
+			repoDiscoverOutputs(repoPath, "owner/repo", "main"),
+			freshBaseBranchOutputs(repoPath, "main"),
+			map[string]string{
+				"git worktree prune":            "ok",
+				"git worktree list --porcelain": "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
+				"git worktree add -b " + branch + " " + worktreePath + " origin/main": "ok",
+				"gh api repos/owner/repo/issues/7":                                    `{"title":"blocked test","body":"","html_url":"https://github.com/owner/repo/issues/7","state":"open","labels":[],"assignees":[]}`,
+				"gh auth status":                                                      "Logged in",
+				sessionStartCommentCommand("owner/repo", 7, worktreePath, state.Session{Branch: branch}):                                          "ok",
+				preflightPromptCommand(worktreePath, "owner/repo", repoPath, 7, "blocked test", "https://github.com/owner/repo/issues/7", branch): "baseline ok",
+				"gh issue comment --repo owner/repo 7 --body " + blockedComment:                                                                   "ok",
+			},
+		),
+		Errors: map[string]error{
+			"git show-ref --verify --quiet refs/heads/" + branch:                                                                          errors.New("exit status 1"),
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-7":                                                                  errors.New("exit status 1"),
+			issuePromptCommand(worktreePath, "owner/repo", repoPath, 7, "blocked test", "https://github.com/owner/repo/issues/7", branch): errors.New("provider crashed"),
+		},
+		ErrorOutputs: map[string]string{
+			issuePromptCommand(worktreePath, "owner/repo", repoPath, 7, "blocked test", "https://github.com/owner/repo/issues/7", branch): "some error output",
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := app.StartOneOffSession(context.Background(), repoPath, 7, "")
+	if err == nil {
+		t.Fatal("expected error for blocked session")
+	}
+	if !strings.Contains(err.Error(), "blocked") {
+		t.Fatalf("expected blocked error, got: %v", err)
+	}
+
+	// Verify session was saved with blocked status.
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	if sessions[0].Status != state.SessionStatusBlocked {
+		t.Fatalf("expected blocked, got %s", sessions[0].Status)
+	}
+}
+
+func TestStartCommandParsing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "missing repo path",
+			args:    []string{"--issue", "1"},
+			wantErr: "usage:",
+		},
+		{
+			name:    "missing issue flag",
+			args:    []string{"/some/path"},
+			wantErr: "usage:",
+		},
+		{
+			name:    "zero issue number",
+			args:    []string{"/some/path", "--issue", "0"},
+			wantErr: "usage:",
+		},
+		{
+			name:    "negative issue number",
+			args:    []string{"/some/path", "--issue", "-1"},
+			wantErr: "usage:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout.Reset()
+			err := app.runStartCommand(context.Background(), tt.args)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got: %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestStartCommandHelp(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+
+	if err := app.runStartCommand(context.Background(), []string{"--help"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), "one-off") {
+		t.Fatalf("expected help text with one-off, got: %s", stdout.String())
+	}
+}
+
+func TestStartOneOffSessionWithCustomProvider(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-3")
+	branch := "vigilante/issue-3-custom-provider"
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_HOME", filepath.Join(home, ".claude"))
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.clock = func() time.Time { return time.Date(2026, 4, 6, 12, 0, 0, 0, time.UTC) }
+
+	claudeSession := state.Session{WorktreePath: worktreePath, Branch: branch, Provider: "claude"}
+	claudeStartComment := sessionStartCommentForProvider("claude", "owner/repo", 3, worktreePath, claudeSession)
+	claudePreflightCmd := claudePreflightCommand(worktreePath, "owner/repo", repoPath, 3, "custom provider", "https://github.com/owner/repo/issues/3", claudeSession)
+	claudeIssueCmd := claudeIssueCommand(worktreePath, "owner/repo", repoPath, 3, "custom provider", "https://github.com/owner/repo/issues/3", claudeSession)
+
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"claude": "/usr/bin/claude"},
+		Outputs: mergeStringMaps(
+			repoDiscoverOutputs(repoPath, "owner/repo", "main"),
+			freshBaseBranchOutputs(repoPath, "main"),
+			map[string]string{
+				"git worktree prune":            "ok",
+				"git worktree list --porcelain": "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
+				"git worktree add -b " + branch + " " + worktreePath + " origin/main": "ok",
+				"gh api repos/owner/repo/issues/3":                                    `{"title":"custom provider","body":"","html_url":"https://github.com/owner/repo/issues/3","state":"open","labels":[],"assignees":[]}`,
+				"gh auth status":                                                      "Logged in",
+				"claude --version":                                                    "claude 2.1.0",
+				claudeStartComment:                                                    "ok",
+				claudePreflightCmd:                                                    "baseline ok",
+				claudeIssueCmd:                                                        "done",
+			},
+		),
+		Errors: map[string]error{
+			"git show-ref --verify --quiet refs/heads/" + branch:         errors.New("exit status 1"),
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-3": errors.New("exit status 1"),
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := app.StartOneOffSession(context.Background(), repoPath, 3, "claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(sessions))
+	}
+	if sessions[0].Provider != "claude" {
+		t.Fatalf("expected claude provider, got %s", sessions[0].Provider)
+	}
+}
+
+func TestStartUsageAppearsInHelp(t *testing.T) {
+	app := New()
+	var stdout bytes.Buffer
+	app.printUsage(&stdout)
+	if !strings.Contains(stdout.String(), "vigilante start") {
+		t.Fatalf("expected 'vigilante start' in usage, got: %s", stdout.String())
+	}
+}
+
+func TestStartOneOffSessionRejectsInvalidProvider(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: repoDiscoverOutputs(repoPath, "owner/repo", "main"),
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+
+	err := app.StartOneOffSession(context.Background(), repoPath, 1, "nonexistent-provider")
+	if err == nil {
+		t.Fatal("expected error for invalid provider")
+	}
+}
+
+// sessionStartCommentForProvider builds the expected session start comment command
+// for a specific provider.
+func sessionStartCommentForProvider(providerID string, repoSlug string, issueNumber int, worktreePath string, session state.Session) string {
+	displayName := "Codex"
+	switch providerID {
+	case "claude":
+		displayName = "Claude Code"
+	case "gemini":
+		displayName = "Gemini CLI"
+	}
+	items := []string{
+		"Vigilante launched this implementation session in `" + worktreePath + "`.",
+		"Branch: `" + session.Branch + "`.",
+		"Current stage: handing the issue off to the configured coding agent (`" + displayName + "`) for investigation and implementation.",
+		"Common issue-comment commands: `@vigilanteai resume` retries a blocked session after the underlying problem is fixed, and `@vigilanteai cleanup` removes the local session state for this issue.",
+	}
+	return "gh issue comment --repo " + repoSlug + " " + fmt.Sprintf("%d", issueNumber) + " --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Vigilante Session Start",
+		Emoji:      "🧢",
+		Percent:    20,
+		ETAMinutes: 25,
+		Items:      items,
+		Tagline:    "Make it simple, but significant.",
+	})
+}
+
+// claudePreflightCommand builds the expected claude preflight command.
+func claudePreflightCommand(worktreePath string, repoSlug string, repoPath string, issueNumber int, title string, issueURL string, session state.Session) string {
+	return testutil.Key("claude", "--print", "--dangerously-skip-permissions", skill.BuildIssuePreflightPrompt(
+		state.WatchTarget{Path: repoPath, Repo: repoSlug},
+		ghcli.Issue{Number: issueNumber, Title: title, URL: issueURL},
+		session,
+	))
+}
+
+// claudeIssueCommand builds the expected claude issue command.
+func claudeIssueCommand(worktreePath string, repoSlug string, repoPath string, issueNumber int, title string, issueURL string, session state.Session) string {
+	return testutil.Key("claude", "--print", "--dangerously-skip-permissions", skill.BuildIssuePromptForRuntime(
+		skill.RuntimeClaude,
+		state.WatchTarget{Path: repoPath, Repo: repoSlug},
+		ghcli.Issue{Number: issueNumber, Title: title, URL: issueURL},
+		session,
+	))
+}


### PR DESCRIPTION
## Summary

- Adds `vigilante start <repo-folder> --issue <n> [--provider value]` CLI command for running one-off issue implementation sessions against local repositories that are not in the watchlist
- The command resolves repository identity from the local git checkout, fetches the issue, creates a worktree, and runs the full issue session synchronously using the existing `issuerunner.RunIssueSession` orchestration path
- The repository is never added to the watchlist as a side effect — sessions are saved to `sessions.json` for inspectability via `logs`, `cleanup`, and `resume`

## Test plan

- [x] CLI argument parsing tests (missing path, missing issue, zero/negative issue)
- [x] Help text includes `--help` and `one-off` description
- [x] `vigilante start` appears in global usage output
- [x] Success path: session completes, saved to sessions.json, watchlist untouched
- [x] Watchlist non-mutation: pre-existing watch targets unchanged after start
- [x] Invalid repo path: clear git repository error
- [x] Closed issue: clear "not open" error
- [x] Issue resolution failure (404): clear error message
- [x] Blocked session: same orchestration path as watched repos (blocked status saved)
- [x] Custom provider (`--provider claude`): provider propagated to session
- [x] Invalid provider: rejected with error
- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` clean
- [x] `gofmt` clean

Closes #413