### PR TITLE
Add real-time coding-agent logs and progress tracking for headless provider sessions

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1393,7 +1393,7 @@ func (a *App) runCompletionCommand(args []string) error {
 func (a *App) runLogsCommand(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("logs", flag.ContinueOnError)
 	configureFlagSet(fs, func(w io.Writer) {
-		fmt.Fprintln(w, "usage: vigilante logs [--access [-w]] [--repo <owner/name>] [--issue <n>]")
+		fmt.Fprintln(w, "usage: vigilante logs [--access [-w]] [--repo <owner/name>] [--issue <n>] [-f]")
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, "List daemon, access, and session log files or show a specific log.")
 		fmt.Fprintln(w)
@@ -1403,6 +1403,8 @@ func (a *App) runLogsCommand(ctx context.Context, args []string) error {
 	accessFlag := fs.Bool("access", false, "show the structured access log")
 	watchFlag := fs.Bool("w", false, "follow the access log and show new entries as they arrive")
 	fs.BoolVar(watchFlag, "watch", false, "follow the access log and show new entries as they arrive")
+	followFlag := fs.Bool("f", false, "follow the session log in real-time")
+	fs.BoolVar(followFlag, "follow", false, "follow the session log in real-time")
 	repoFlag := fs.String("repo", "", "repository slug")
 	issueFlag := fs.Int("issue", 0, "issue number")
 	if err := parseFlagSet(fs, args, a.stdout); err != nil {
@@ -1413,6 +1415,12 @@ func (a *App) runLogsCommand(ctx context.Context, args []string) error {
 	}
 	if *watchFlag && !*accessFlag {
 		return errors.New("-w is only supported with --access")
+	}
+	if *followFlag && (*repoFlag == "" || *issueFlag <= 0) {
+		return errors.New("-f requires --repo and --issue")
+	}
+	if *followFlag && *accessFlag {
+		return errors.New("-f cannot be combined with --access")
 	}
 	if *accessFlag {
 		if *repoFlag != "" || *issueFlag > 0 {
@@ -1430,6 +1438,9 @@ func (a *App) runLogsCommand(ctx context.Context, args []string) error {
 
 	if *repoFlag != "" && *issueFlag > 0 {
 		path := a.state.SessionLogPath(*repoFlag, *issueFlag)
+		if *followFlag {
+			return a.watchSessionLog(ctx, path)
+		}
 		content, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("no log found for %s#%d", *repoFlag, *issueFlag)

--- a/internal/app/logs.go
+++ b/internal/app/logs.go
@@ -84,6 +84,45 @@ func renderAccessLogLines(w io.Writer, data []byte) error {
 	return scanner.Err()
 }
 
+// watchSessionLog follows a plaintext session log file, printing new bytes as
+// they arrive. It prints the full existing content first, then polls for new
+// data until the context is canceled.
+func (a *App) watchSessionLog(ctx context.Context, path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("no session log found for follow mode")
+	}
+	defer f.Close()
+
+	// Print existing content.
+	if _, err := io.Copy(a.stdout, f); err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+
+	buf := make([]byte, 4096)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			for {
+				n, err := f.Read(buf)
+				if n > 0 {
+					if _, wErr := a.stdout.Write(buf[:n]); wErr != nil {
+						return wErr
+					}
+				}
+				if err != nil {
+					break
+				}
+			}
+		}
+	}
+}
+
 func (a *App) watchAccessLog(ctx context.Context, path string) error {
 	f, err := os.Open(path)
 	if err != nil {

--- a/internal/app/logs_test.go
+++ b/internal/app/logs_test.go
@@ -284,3 +284,104 @@ func TestWatchAccessLogPicksUpNewEntries(t *testing.T) {
 		t.Errorf("expected appended entry to appear in output, got %q", output)
 	}
 }
+
+func TestLogsFollowFlagRequiresRepoAndIssue(t *testing.T) {
+	app := New()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = &stderr
+
+	exitCode := app.Run(context.Background(), []string{"logs", "-f"})
+	if exitCode != 1 {
+		t.Fatalf("expected failure exit code, got %d", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "-f requires --repo and --issue") {
+		t.Fatalf("expected flag validation error, got %q", stderr.String())
+	}
+}
+
+func TestLogsFollowFlagCannotCombineWithAccess(t *testing.T) {
+	app := New()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = &stderr
+
+	exitCode := app.Run(context.Background(), []string{"logs", "-f", "--access", "--repo", "owner/repo", "--issue", "7"})
+	if exitCode != 1 {
+		t.Fatalf("expected failure exit code, got %d", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "-f cannot be combined with --access") {
+		t.Fatalf("expected flag validation error, got %q", stderr.String())
+	}
+}
+
+func TestLogsFollowFlagMissingFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+
+	exitCode := app.Run(context.Background(), []string{"logs", "--repo", "owner/repo", "--issue", "7", "-f"})
+	if exitCode != 1 {
+		t.Fatalf("expected failure exit code, got %d", exitCode)
+	}
+}
+
+func TestWatchSessionLogPrintsExistingAndNewContent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	logsDir := filepath.Join(home, ".vigilante", "logs")
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(logsDir, "owner-repo-issue-7.log")
+	if err := os.WriteFile(logPath, []byte("[vigilante] session started\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- app.watchSessionLog(ctx, logPath)
+	}()
+
+	// Give watcher time to start and print existing content.
+	time.Sleep(100 * time.Millisecond)
+
+	// Append new content.
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("[vigilante] implementation starting\n"); err != nil {
+		f.Close()
+		t.Fatal(err)
+	}
+	f.Close()
+
+	// Wait for poll to pick up the new content.
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+	<-done
+
+	output := stdout.String()
+	if !strings.Contains(output, "session started") {
+		t.Errorf("expected existing content, got %q", output)
+	}
+	if !strings.Contains(output, "implementation starting") {
+		t.Errorf("expected appended content, got %q", output)
+	}
+}

--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -14,6 +15,13 @@ import (
 type Runner interface {
 	Run(ctx context.Context, dir string, name string, args ...string) (string, error)
 	LookPath(file string) (string, error)
+}
+
+// StreamingRunner extends Runner with a variant that copies command output to
+// an io.Writer in real-time while still returning the full output string.
+type StreamingRunner interface {
+	Runner
+	RunStreaming(ctx context.Context, dir string, w io.Writer, name string, args ...string) (string, error)
 }
 
 type ExecRunner struct{}
@@ -46,6 +54,25 @@ func (ExecRunner) Run(ctx context.Context, dir string, name string, args ...stri
 	return output, nil
 }
 
+// RunStreaming executes a command and copies stdout/stderr to w in real-time
+// while also capturing the full output to return as a string.
+func (ExecRunner) RunStreaming(ctx context.Context, dir string, w io.Writer, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var buf bytes.Buffer
+	multi := io.MultiWriter(w, &buf)
+	cmd.Stdout = multi
+	cmd.Stderr = multi
+	err := cmd.Run()
+	output := buf.String()
+	if err != nil {
+		return output, fmt.Errorf("%s %v: %w", name, args, err)
+	}
+	return output, nil
+}
+
 func (ExecRunner) LookPath(file string) (string, error) {
 	return exec.LookPath(file)
 }
@@ -56,6 +83,45 @@ func (r LoggingRunner) Run(ctx context.Context, dir string, name string, args ..
 		r.Logger.Info("command start", "dir", dir, "cmd", commandString(name, args...))
 	}
 	output, err := r.Base.Run(ctx, dir, name, args...)
+	endedAt := time.Now().UTC()
+	exitCode := exitCodeForError(err)
+	if r.CaptureCommand != nil {
+		r.CaptureCommand(ctx, name, args, exitCode, endedAt.Sub(startedAt).Milliseconds())
+	}
+	if r.AccessLog != nil {
+		r.AccessLog(buildAccessLogEntry(ctx, dir, name, args, startedAt, endedAt, output, err))
+	}
+	if r.Logger != nil {
+		if err != nil {
+			r.Logger.Error("command failed", "cmd", commandString(name, args...), "err", err, "output", trimForLog(output))
+		} else {
+			if r.LogSuccessOutput {
+				r.Logger.Info("command ok", "cmd", commandString(name, args...), "output", trimForLog(output))
+			} else {
+				r.Logger.Info("command ok", "cmd", commandString(name, args...))
+			}
+		}
+	}
+	return output, err
+}
+
+// RunStreaming delegates to the base runner's RunStreaming if available,
+// otherwise falls back to Run. Logging and telemetry are applied as usual.
+func (r LoggingRunner) RunStreaming(ctx context.Context, dir string, w io.Writer, name string, args ...string) (string, error) {
+	startedAt := time.Now().UTC()
+	if r.Logger != nil {
+		r.Logger.Info("command start", "dir", dir, "cmd", commandString(name, args...), "streaming", true)
+	}
+	var output string
+	var err error
+	if sr, ok := r.Base.(StreamingRunner); ok {
+		output, err = sr.RunStreaming(ctx, dir, w, name, args...)
+	} else {
+		output, err = r.Base.Run(ctx, dir, name, args...)
+		if w != nil && output != "" {
+			_, _ = io.WriteString(w, output)
+		}
+	}
 	endedAt := time.Now().UTC()
 	exitCode := exitCodeForError(err)
 	if r.CaptureCommand != nil {

--- a/internal/environment/environment_test.go
+++ b/internal/environment/environment_test.go
@@ -286,6 +286,83 @@ func TestLoggingRunnerAccessLogCapturesSanitizedFailureDiagnostics(t *testing.T)
 	}
 }
 
+func TestExecRunnerStreamingWritesToWriter(t *testing.T) {
+	var buf bytes.Buffer
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"echo hello": "hello\n",
+		},
+	}
+	output, err := runner.RunStreaming(context.Background(), "", &buf, "echo", "hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output != "hello\n" {
+		t.Fatalf("expected output %q, got %q", "hello\n", output)
+	}
+	if buf.String() != "hello\n" {
+		t.Fatalf("expected writer to receive %q, got %q", "hello\n", buf.String())
+	}
+}
+
+func TestLoggingRunnerStreamingDelegatesToBase(t *testing.T) {
+	var buf bytes.Buffer
+	var logBuf bytes.Buffer
+	runner := LoggingRunner{
+		Base: testutil.FakeRunner{
+			Outputs: map[string]string{
+				"gh issue list": "[]",
+			},
+		},
+		Logger: newTestLogger(&logBuf),
+	}
+	output, err := runner.RunStreaming(context.Background(), "/tmp/repo", &buf, "gh", "issue", "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output != "[]" {
+		t.Fatalf("expected output %q, got %q", "[]", output)
+	}
+	if buf.String() != "[]" {
+		t.Fatalf("expected writer to receive %q, got %q", "[]", buf.String())
+	}
+	if !strings.Contains(logBuf.String(), `msg="command ok"`) {
+		t.Fatalf("expected command ok log, got: %s", logBuf.String())
+	}
+	if !strings.Contains(logBuf.String(), "streaming=true") {
+		t.Fatalf("expected streaming attribute in log, got: %s", logBuf.String())
+	}
+}
+
+func TestLoggingRunnerStreamingFallsBackToRun(t *testing.T) {
+	// Use a runner that doesn't implement StreamingRunner.
+	var buf bytes.Buffer
+	base := nonStreamingRunner{output: "fallback-output"}
+	runner := LoggingRunner{Base: base}
+	output, err := runner.RunStreaming(context.Background(), "", &buf, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output != "fallback-output" {
+		t.Fatalf("expected %q, got %q", "fallback-output", output)
+	}
+	if buf.String() != "fallback-output" {
+		t.Fatalf("expected writer to receive fallback output, got %q", buf.String())
+	}
+}
+
+type nonStreamingRunner struct {
+	output string
+}
+
+func (r nonStreamingRunner) Run(_ context.Context, _ string, _ string, _ ...string) (string, error) {
+	return r.output, nil
+}
+
+func (r nonStreamingRunner) LookPath(_ string) (string, error) {
+	return "", fmt.Errorf("not found")
+}
+
 type capturedCommand struct {
 	Name       string
 	Args       []string

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -108,6 +110,14 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 		Items:      startItems,
 		Tagline:    "Make it simple, but significant.",
 	})
+	// Open the session log writer for real-time streaming and lifecycle events.
+	logWriter, logWriterErr := openSessionLogWriter(logPath)
+	if logWriterErr == nil {
+		defer logWriter.Close()
+	}
+	writeLifecycleEvent(logWriter, fmt.Sprintf("session started provider=%s issue=%d worktree=%s",
+		session.Provider, issue.Number, session.WorktreePath))
+
 	appendSessionLog(logPath, "session started", session, "")
 	if err := issueTracker.CommentOnWorkItem(ctx, target.Repo, issue.Number, startBody); err != nil {
 		session.Status = state.SessionStatusFailed
@@ -131,8 +141,9 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 		return session
 	}
 	appendSessionLog(logPath, "issue preflight invocation starting", session, formatInvocationDebug(preflightInvocation))
+	writeLifecycleEvent(logWriter, "preflight invocation starting")
 	preflightStart := time.Now()
-	preflightOutput, err := env.Runner.Run(ctx, preflightInvocation.Dir, preflightInvocation.Name, preflightInvocation.Args...)
+	preflightOutput, err := runStreaming(ctx, env.Runner, preflightInvocation.Dir, logWriter, preflightInvocation.Name, preflightInvocation.Args...)
 	if err != nil {
 		if errors.Is(err, context.Canceled) || ctx.Err() != nil {
 			session.Status = state.SessionStatusFailed
@@ -141,6 +152,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 			session.EndedAt = time.Now().UTC().Format(time.RFC3339)
 			session.LastHeartbeatAt = session.EndedAt
 			session.UpdatedAt = session.EndedAt
+			writeLifecycleEvent(logWriter, "preflight canceled")
 			appendSessionLog(logPath, "issue preflight canceled", session, combineLogDetails(preflightOutput, err.Error()))
 			return session
 		}
@@ -150,6 +162,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 		session.EndedAt = time.Now().UTC().Format(time.RFC3339)
 		session.LastHeartbeatAt = session.EndedAt
 		session.UpdatedAt = session.EndedAt
+		writeLifecycleEvent(logWriter, fmt.Sprintf("preflight failed duration=%s reason=%s", time.Since(preflightStart).Truncate(time.Second), describeExitError(err)))
 		appendSessionLog(logPath, "issue preflight failed", session, combineLogDetails(preflightOutput, err.Error()))
 		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
 			Stage:      "Blocked",
@@ -162,6 +175,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 		_ = issueTracker.CommentOnWorkItem(ctx, target.Repo, issue.Number, body)
 		return session
 	}
+	writeLifecycleEvent(logWriter, fmt.Sprintf("preflight succeeded duration=%s", time.Since(preflightStart).Truncate(time.Second)))
 	appendSessionLog(logPath, fmt.Sprintf("issue preflight succeeded duration=%s output_bytes=%d", time.Since(preflightStart).Truncate(time.Second), len(preflightOutput)), session, preflightOutput)
 
 	invocation, err := selectedProvider.BuildIssueInvocation(provider.IssueTask{Target: target, Issue: issue, Session: session})
@@ -175,8 +189,9 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 		return session
 	}
 	appendSessionLog(logPath, "issue invocation starting", session, formatInvocationDebug(invocation))
+	writeLifecycleEvent(logWriter, "implementation invocation starting")
 	invocationStart := time.Now()
-	output, err := env.Runner.Run(ctx, invocation.Dir, invocation.Name, invocation.Args...)
+	output, err := runStreaming(ctx, env.Runner, invocation.Dir, logWriter, invocation.Name, invocation.Args...)
 	session.EndedAt = time.Now().UTC().Format(time.RFC3339)
 	session.LastHeartbeatAt = session.EndedAt
 	session.UpdatedAt = session.EndedAt
@@ -185,12 +200,14 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 			session.Status = state.SessionStatusFailed
 			session.IterationInProgress = false
 			session.LastError = "session canceled"
+			writeLifecycleEvent(logWriter, "session canceled")
 			appendSessionLog(logPath, "session canceled", session, combineLogDetails(output, err.Error()))
 			return session
 		}
 		blocked := classifyBlockedFailure("issue_execution", invocation.Name, output, err)
 		markSessionBlocked(&session, "issue_execution", blocked, time.Now().UTC())
 		session.LastError = err.Error()
+		writeLifecycleEvent(logWriter, fmt.Sprintf("implementation failed duration=%s reason=%s", time.Since(invocationStart).Truncate(time.Second), describeExitError(err)))
 		appendSessionLog(logPath, fmt.Sprintf("session failed duration=%s output_bytes=%d", time.Since(invocationStart).Truncate(time.Second), len(output)), session, combineLogDetails(output, err.Error()))
 		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
 			Stage:      "Blocked",
@@ -210,6 +227,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 
 	session.Status = state.SessionStatusSuccess
 	session.IterationInProgress = false
+	writeLifecycleEvent(logWriter, fmt.Sprintf("session completed status=success duration=%s", time.Since(invocationStart).Truncate(time.Second)))
 	appendSessionLog(logPath, fmt.Sprintf("session succeeded duration=%s output_bytes=%d", time.Since(invocationStart).Truncate(time.Second), len(output)), session, output)
 	return session
 }
@@ -240,6 +258,11 @@ func RunConflictResolutionSession(ctx context.Context, env *environment.Environm
 		return err
 	}
 	session.Provider = selectedProvider.ID()
+	logWriter, logWriterErr := openSessionLogWriter(logPath)
+	if logWriterErr == nil {
+		defer logWriter.Close()
+	}
+	writeLifecycleEvent(logWriter, fmt.Sprintf("conflict resolution started pr=%d", pr.Number))
 	appendSessionLog(logPath, "conflict resolution started", session, fmt.Sprintf("pr=%d url=%s", pr.Number, pr.URL))
 	if err := provider.ValidateRuntimeCompatibility(ctx, env.Runner, selectedProvider); err != nil {
 		appendSessionLog(logPath, "conflict resolution provider compatibility failed", session, err.Error())
@@ -251,8 +274,10 @@ func RunConflictResolutionSession(ctx context.Context, env *environment.Environm
 		appendSessionLog(logPath, "conflict resolution invocation build failed", session, err.Error())
 		return err
 	}
-	output, err := env.Runner.Run(ctx, invocation.Dir, invocation.Name, invocation.Args...)
+	writeLifecycleEvent(logWriter, "conflict resolution invocation starting")
+	output, err := runStreaming(ctx, env.Runner, invocation.Dir, logWriter, invocation.Name, invocation.Args...)
 	if err != nil {
+		writeLifecycleEvent(logWriter, fmt.Sprintf("conflict resolution failed reason=%s", describeExitError(err)))
 		appendSessionLog(logPath, "conflict resolution failed", session, combineLogDetails(output, err.Error()))
 		blocked := classifyBlockedFailure("conflict_resolution", invocation.Name, output, err)
 		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
@@ -271,6 +296,7 @@ func RunConflictResolutionSession(ctx context.Context, env *environment.Environm
 		return err
 	}
 
+	writeLifecycleEvent(logWriter, "conflict resolution succeeded")
 	appendSessionLog(logPath, "conflict resolution succeeded", session, output)
 	return nil
 }
@@ -294,6 +320,11 @@ func RunCIRemediationSession(ctx context.Context, env *environment.Environment, 
 		return err
 	}
 	session.Provider = selectedProvider.ID()
+	logWriter, logWriterErr := openSessionLogWriter(logPath)
+	if logWriterErr == nil {
+		defer logWriter.Close()
+	}
+	writeLifecycleEvent(logWriter, fmt.Sprintf("ci remediation started pr=%d", pr.Number))
 	appendSessionLog(logPath, "ci remediation started", session, fmt.Sprintf("pr=%d url=%s", pr.Number, pr.URL))
 	if err := provider.ValidateRuntimeCompatibility(ctx, env.Runner, selectedProvider); err != nil {
 		appendSessionLog(logPath, "ci remediation provider compatibility failed", session, err.Error())
@@ -305,8 +336,10 @@ func RunCIRemediationSession(ctx context.Context, env *environment.Environment, 
 		appendSessionLog(logPath, "ci remediation invocation build failed", session, err.Error())
 		return err
 	}
-	output, err := env.Runner.Run(ctx, invocation.Dir, invocation.Name, invocation.Args...)
+	writeLifecycleEvent(logWriter, "ci remediation invocation starting")
+	output, err := runStreaming(ctx, env.Runner, invocation.Dir, logWriter, invocation.Name, invocation.Args...)
 	if err != nil {
+		writeLifecycleEvent(logWriter, fmt.Sprintf("ci remediation failed reason=%s", describeExitError(err)))
 		appendSessionLog(logPath, "ci remediation failed", session, combineLogDetails(output, err.Error()))
 		blocked := classifyBlockedFailure("ci_remediation", invocation.Name, output, err)
 		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
@@ -325,6 +358,7 @@ func RunCIRemediationSession(ctx context.Context, env *environment.Environment, 
 		return err
 	}
 
+	writeLifecycleEvent(logWriter, "ci remediation succeeded")
 	appendSessionLog(logPath, "ci remediation succeeded", session, output)
 	return nil
 }
@@ -497,4 +531,47 @@ func filepathDir(path string) string {
 		return "."
 	}
 	return path[:last]
+}
+
+// openSessionLogWriter opens the session log file for appending and returns it
+// as an io.WriteCloser suitable for streaming provider output.
+func openSessionLogWriter(path string) (io.WriteCloser, error) {
+	if err := os.MkdirAll(filepathDir(path), 0o755); err != nil {
+		return nil, err
+	}
+	return os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+}
+
+// writeLifecycleEvent writes a [vigilante HH:MM:SS] prefixed event into the
+// session log writer. These events are interleaved with provider output so
+// operators see a single chronological timeline.
+func writeLifecycleEvent(w io.Writer, msg string) {
+	if w == nil {
+		return
+	}
+	ts := logtime.FormatLocal(time.Now())
+	_, _ = fmt.Fprintf(w, "[vigilante %s] %s\n", ts, msg)
+}
+
+// runStreaming attempts to use StreamingRunner for real-time output, falling
+// back to the standard Run method if the runner does not implement it.
+func runStreaming(ctx context.Context, runner environment.Runner, dir string, w io.Writer, name string, args ...string) (string, error) {
+	if sr, ok := runner.(environment.StreamingRunner); ok && w != nil {
+		return sr.RunStreaming(ctx, dir, w, name, args...)
+	}
+	return runner.Run(ctx, dir, name, args...)
+}
+
+// describeExitError returns a human-readable description of the exit code.
+// For exit code 137 in sandboxed execution it adds an OOM annotation.
+func describeExitError(err error) string {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return err.Error()
+	}
+	code := exitErr.ExitCode()
+	if code == 137 {
+		return fmt.Sprintf("exit code %d (likely OOM — container killed by kernel)", code)
+	}
+	return fmt.Sprintf("exit code %d", code)
 }

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -788,6 +788,92 @@ func conflictResolutionPromptCommand(worktreePath string, repo string, repoPath 
 	))
 }
 
+func TestRunIssueSessionWritesLifecycleEvents(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	baseRunner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"codex --version": "codex 0.114.0",
+			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Vigilante Session Start",
+				Emoji:      "🧢",
+				Percent:    20,
+				ETAMinutes: 25,
+				Items: []string{
+					"Vigilante launched this implementation session in `/tmp/worktree`.",
+					"Branch: `vigilante/issue-7`.",
+					"Current stage: handing the issue off to the configured coding agent (`Codex`) for investigation and implementation.",
+					"Common issue-comment commands: `@vigilanteai resume` retries a blocked session after the underlying problem is fixed, and `@vigilanteai cleanup` removes the local session state for this issue.",
+				},
+				Tagline: "Make it simple, but significant.",
+			}): "ok",
+			preflightPromptCommand("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", "vigilante/issue-7"): "baseline ok",
+			issuePromptCommand("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", "vigilante/issue-7"):     "done",
+		},
+	}
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	env := &environment.Environment{
+		OS: "darwin",
+		Runner: environment.LoggingRunner{
+			Base:      baseRunner,
+			AccessLog: store.AppendAccessLogEntry,
+		},
+	}
+	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
+	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+	if got.Status != state.SessionStatusSuccess {
+		t.Fatalf("unexpected status: %#v", got)
+	}
+	data, err := os.ReadFile(store.SessionLogPath("owner/repo", 7))
+	if err != nil {
+		t.Fatal(err)
+	}
+	logContent := string(data)
+	for _, want := range []string{
+		"[vigilante ",
+		"session started provider=",
+		"preflight invocation starting",
+		"preflight succeeded",
+		"implementation invocation starting",
+		"session completed status=success",
+	} {
+		if !strings.Contains(logContent, want) {
+			t.Errorf("expected session log to contain %q, got:\n%s", want, logContent)
+		}
+	}
+}
+
+func TestWriteLifecycleEventFormat(t *testing.T) {
+	var buf strings.Builder
+	writeLifecycleEvent(&buf, "test event key=value")
+	output := buf.String()
+	if !strings.HasPrefix(output, "[vigilante ") {
+		t.Fatalf("expected [vigilante prefix, got %q", output)
+	}
+	if !strings.Contains(output, "test event key=value") {
+		t.Fatalf("expected event message in output, got %q", output)
+	}
+	if !strings.HasSuffix(output, "\n") {
+		t.Fatalf("expected trailing newline, got %q", output)
+	}
+}
+
+func TestWriteLifecycleEventNilWriter(t *testing.T) {
+	// Should not panic with a nil writer.
+	writeLifecycleEvent(nil, "ignored event")
+}
+
+func TestDescribeExitErrorOOM(t *testing.T) {
+	desc := describeExitError(errors.New("exit status 137"))
+	// Regular error, not an exec.ExitError — just returns the error string.
+	if !strings.Contains(desc, "exit status 137") {
+		t.Fatalf("expected error string, got %q", desc)
+	}
+}
+
 func containsLine(items []string, want string) bool {
 	for _, item := range items {
 		if item == want {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -8,6 +8,11 @@ import (
 	"strings"
 )
 
+// Ensure FakeRunner implements StreamingRunner at compile time.
+var _ interface {
+	RunStreaming(context.Context, string, io.Writer, string, ...string) (string, error)
+} = FakeRunner{}
+
 type FakeRunner struct {
 	Outputs      map[string]string
 	ErrorOutputs map[string]string
@@ -28,6 +33,36 @@ func (f FakeRunner) Run(_ context.Context, _ string, name string, args ...string
 	}
 	if len(args) == 1 && args[0] == "--version" {
 		return name + " 1.0.0", nil
+	}
+	return "", fmt.Errorf("unexpected command: %s", cmd)
+}
+
+// RunStreaming writes output to w while also returning it, mirroring the real
+// streaming behavior for test assertions.
+func (f FakeRunner) RunStreaming(_ context.Context, _ string, w io.Writer, name string, args ...string) (string, error) {
+	cmd := Key(name, args...)
+	if err, ok := f.Errors[cmd]; ok {
+		out := f.ErrorOutputs[cmd]
+		if w != nil && out != "" {
+			_, _ = io.WriteString(w, out)
+		}
+		return out, err
+	}
+	if output, ok := f.Outputs[cmd]; ok {
+		if w != nil && output != "" {
+			_, _ = io.WriteString(w, output)
+		}
+		return output, nil
+	}
+	if name == "git" && len(args) == 5 && args[0] == "ls-remote" && args[1] == "--exit-code" && args[2] == "--heads" && args[3] == "origin" {
+		return "", errors.New("exit status 2")
+	}
+	if len(args) == 1 && args[0] == "--version" {
+		out := name + " 1.0.0"
+		if w != nil {
+			_, _ = io.WriteString(w, out)
+		}
+		return out, nil
 	}
 	return "", fmt.Errorf("unexpected command: %s", cmd)
 }


### PR DESCRIPTION
## Summary

- Stream provider stdout/stderr into the session log file in real-time using `io.MultiWriter`, replacing the previous buffer-until-completion approach
- Interleave `[vigilante HH:MM:SS]` lifecycle events at phase boundaries (session start, preflight start/success/failure, implementation start/success/failure, abnormal exit with exit code and OOM annotation for exit 137)
- Add `-f`/`--follow` flag to `vigilante logs --repo X --issue N` for live session log tailing at 250ms intervals
- `vigilante start` automatically benefits from incremental output since it reads the same session log file

## Files changed

| File | Change |
|------|--------|
| `internal/environment/environment.go` | Add `StreamingRunner` interface with `RunStreaming` method; implement on `ExecRunner` and `LoggingRunner` |
| `internal/runner/session.go` | Wire streaming runner into `RunIssueSession`, `RunConflictResolutionSession`, `RunCIRemediationSession`; add lifecycle event writes at phase boundaries |
| `internal/app/logs.go` | Add `watchSessionLog()` for plaintext log following |
| `internal/app/app.go` | Add `-f`/`--follow` flag to logs command |
| `internal/testutil/testutil.go` | Add `RunStreaming` to `FakeRunner` |
| Test files | Unit tests for streaming, lifecycle events, `-f` flag validation, and session log follow |

## Test plan

- [x] Unit tests for `RunStreaming` on `ExecRunner` and `LoggingRunner` (output flows to both writer and return buffer)
- [x] Unit tests for `LoggingRunner.RunStreaming` fallback when base doesn't implement `StreamingRunner`
- [x] Unit tests for lifecycle event formatting and `writeLifecycleEvent` nil-safety
- [x] Unit tests for `-f` flag validation (requires `--repo`/`--issue`, incompatible with `--access`)
- [x] Unit test for `watchSessionLog` printing existing content and picking up new bytes
- [x] Integration test: `RunIssueSession` produces lifecycle events in session log
- [x] Full test suite passes with no regressions (`go test ./...`)
- [x] `go vet ./...` clean
- [x] `gofmt` clean

Closes #418