### PR TITLE
Deterministic progress tracking and rerunnable worktree sessions

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -467,6 +467,8 @@ func (a *App) emitSessionTransition(previous state.SessionStatus, session state.
 		properties["transition"] = "resuming"
 	case state.SessionStatusSuccess:
 		properties["transition"] = "succeeded"
+	case state.SessionStatusIncomplete:
+		properties["transition"] = "incomplete"
 	case state.SessionStatusFailed:
 		properties["transition"] = "failed"
 	case state.SessionStatusClosed:
@@ -1276,6 +1278,9 @@ func (a *App) StartOneOffSession(ctx context.Context, rawPath string, issueNumbe
 	case state.SessionStatusSuccess:
 		fmt.Fprintf(a.stdout, "session completed successfully for %s issue #%d\n", info.Repo, issueNumber)
 		return nil
+	case state.SessionStatusIncomplete:
+		fmt.Fprintf(a.stdout, "session incomplete for %s issue #%d: %s (no PR created)\n", info.Repo, issueNumber, result.IncompleteReason)
+		return fmt.Errorf("session incomplete: %s", result.IncompleteReason)
 	case state.SessionStatusBlocked:
 		fmt.Fprintf(a.stdout, "session blocked for %s issue #%d: %s\n", info.Repo, issueNumber, result.ResumeHint)
 		return fmt.Errorf("session blocked: %s", result.BlockedReason.Summary)
@@ -1964,6 +1969,10 @@ func (a *App) ScanOnce(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		sessions, err = a.rerunIncompleteSessions(ctx, sessions, issueDetailsCache)
+		if err != nil {
+			return err
+		}
 		sessions, err = a.processGitHubResumeRequests(ctx, sessions, issueDetailsCache)
 		if err != nil {
 			return err
@@ -2529,13 +2538,13 @@ func (a *App) cleanupClosedIssueSessions(ctx context.Context, sessions []state.S
 	for i := range sessions {
 		session := &sessions[i]
 		sessionCtx := withSessionAccessLogContext(ctx, "maintenance", *session)
-		if session.Status != state.SessionStatusSuccess || session.CleanupCompletedAt != "" || session.MonitoringStoppedAt != "" {
+		if (session.Status != state.SessionStatusSuccess && session.Status != state.SessionStatusIncomplete) || session.CleanupCompletedAt != "" || session.MonitoringStoppedAt != "" {
 			continue
 		}
 		if session.PullRequestMaintenanceInFlight {
 			continue
 		}
-		if shouldDelaySuccessfulSessionPoll(*session, a.clock()) {
+		if session.Status == state.SessionStatusSuccess && shouldDelaySuccessfulSessionPoll(*session, a.clock()) {
 			continue
 		}
 
@@ -3683,6 +3692,57 @@ func (a *App) CleanupSession(ctx context.Context, repo string, issue int, source
 	return nil
 }
 
+func (a *App) rerunIncompleteSessions(ctx context.Context, sessions []state.Session, issueCache scanIssueDetailsCache) ([]state.Session, error) {
+	for i := range sessions {
+		session := &sessions[i]
+		if session.Status != state.SessionStatusIncomplete {
+			continue
+		}
+		if session.CleanupCompletedAt != "" || session.MonitoringStoppedAt != "" {
+			continue
+		}
+		if !issuerunner.IsRerunEligible(*session) {
+			continue
+		}
+		if strings.TrimSpace(session.WorktreePath) == "" || strings.TrimSpace(session.Branch) == "" {
+			continue
+		}
+		if _, err := os.Stat(session.WorktreePath); err != nil {
+			a.logger.Info("incomplete session worktree missing, skipping rerun", "repo", session.Repo, "issue", session.IssueNumber, "worktree", session.WorktreePath)
+			continue
+		}
+		target, ok := a.watchTargetByRepo(session.Repo)
+		if !ok {
+			continue
+		}
+		a.logger.Info("rerunning incomplete session", "repo", session.Repo, "issue", session.IssueNumber, "reason", session.IncompleteReason)
+
+		previousStatus := session.Status
+		now := a.clock().Format(time.RFC3339)
+		session.Status = state.SessionStatusRunning
+		session.StartedAt = now
+		session.EndedAt = ""
+		session.LastHeartbeatAt = now
+		session.UpdatedAt = now
+		session.ProcessID = os.Getpid()
+		session.LastError = ""
+
+		diffSummary, _ := summarizeIssueBranchDiff(ctx, a.env.Runner, session.RepoPath, effectiveSessionBaseBranch(*session, target), session.Branch)
+		session.BranchDiffSummary = diffSummary
+		session.ReusedRemoteBranch = session.Branch
+
+		a.emitSessionTransition(previousStatus, *session, "incomplete_rerun")
+
+		ghIssue := ghcli.Issue{
+			Number: session.IssueNumber,
+			Title:  session.IssueTitle,
+			URL:    session.IssueURL,
+		}
+		a.launchIssueSession(ctx, target, ghIssue, *session)
+	}
+	return sessions, nil
+}
+
 func (a *App) ResumeSession(ctx context.Context, repo string, issue int, source string) error {
 	if err := a.state.EnsureLayout(); err != nil {
 		return err
@@ -4317,9 +4377,16 @@ func (a *App) resumeBlockedIssueExecution(ctx context.Context, session *state.Se
 		a.logger.Error("resume issue execution failed", "repo", session.Repo, "issue", session.IssueNumber, "err", err, "output", summarizeText(output))
 		return err
 	}
-	session.Status = state.SessionStatusSuccess
+	signal := issuerunner.EvaluateSessionProgress(ctx, a.env.Runner, *session)
+	if signal.HasPullRequest {
+		session.Status = state.SessionStatusSuccess
+		session.IncompleteReason = ""
+	} else {
+		session.Status = state.SessionStatusIncomplete
+		session.IncompleteReason = issuerunner.ClassifyIncompleteReason(signal)
+	}
 	session.LastError = ""
-	a.logger.Info("resume issue execution succeeded", "repo", session.Repo, "issue", session.IssueNumber, "output", summarizeText(output))
+	a.logger.Info("resume issue execution completed", "repo", session.Repo, "issue", session.IssueNumber, "status", session.Status, "output", summarizeText(output))
 	return nil
 }
 
@@ -5083,7 +5150,9 @@ func markSessionBlocked(session *state.Session, stage string, blocked state.Bloc
 }
 
 func clearBlockedState(session *state.Session, now time.Time, source string) {
-	session.Status = state.SessionStatusSuccess
+	if session.Status != state.SessionStatusIncomplete {
+		session.Status = state.SessionStatusSuccess
+	}
 	session.BlockedAt = ""
 	session.BlockedReason = state.BlockedReason{}
 	session.BlockedStage = ""
@@ -5221,7 +5290,7 @@ func sessionSupportsIteration(session state.Session) bool {
 	switch session.Status {
 	case state.SessionStatusRunning, state.SessionStatusResuming:
 		return false
-	case state.SessionStatusBlocked, state.SessionStatusSuccess, state.SessionStatusFailed:
+	case state.SessionStatusBlocked, state.SessionStatusSuccess, state.SessionStatusIncomplete, state.SessionStatusFailed:
 		return true
 	case state.SessionStatusClosed:
 		return false
@@ -5545,10 +5614,15 @@ func desiredSessionLabels(session state.Session, pr *ghcli.PullRequest) (string,
 		if strings.TrimSpace(session.PullRequestMergedAt) != "" {
 			return labelDone, ""
 		}
+		if session.PullRequestNumber <= 0 {
+			return labelBlocked, ""
+		}
 		if pr != nil && shouldAwaitUserValidation(*pr) {
 			return labelAwaitingUserValidation, ""
 		}
 		return labelReadyForReview, ""
+	case state.SessionStatusIncomplete:
+		return labelBlocked, ""
 	default:
 		return "", ""
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1008,14 +1008,26 @@ func TestDesiredSessionLabels(t *testing.T) {
 			wantIntervention: labelNeedsHumanInput,
 		},
 		{
-			name:             "success ready for review",
+			name:             "success without PR blocked",
 			session:          state.Session{Status: state.SessionStatusSuccess},
+			wantState:        labelBlocked,
+			wantIntervention: "",
+		},
+		{
+			name:             "success with PR ready for review",
+			session:          state.Session{Status: state.SessionStatusSuccess, PullRequestNumber: 10},
 			wantState:        labelReadyForReview,
 			wantIntervention: "",
 		},
 		{
+			name:             "incomplete blocked",
+			session:          state.Session{Status: state.SessionStatusIncomplete, IncompleteReason: "commits_without_pr"},
+			wantState:        labelBlocked,
+			wantIntervention: "",
+		},
+		{
 			name:    "success awaiting validation",
-			session: state.Session{Status: state.SessionStatusSuccess},
+			session: state.Session{Status: state.SessionStatusSuccess, PullRequestNumber: 17},
 			pr: &ghcli.PullRequest{
 				Number:           17,
 				ReviewDecision:   "APPROVED",
@@ -3336,8 +3348,8 @@ func TestRedispatchSessionRunningIssue(t *testing.T) {
 	if len(sessions) != 1 {
 		t.Fatalf("unexpected sessions: %#v", sessions)
 	}
-	if sessions[0].Status != state.SessionStatusSuccess || sessions[0].Branch != branch {
-		t.Fatalf("expected fresh redispatched session, got: %#v", sessions[0])
+	if sessions[0].Status != state.SessionStatusIncomplete || sessions[0].Branch != branch {
+		t.Fatalf("expected fresh redispatched session (incomplete without PR), got: %#v", sessions[0])
 	}
 	if got := stdout.String(); !strings.Contains(got, "redispatched owner/repo issue #44 in "+worktreePath) {
 		t.Fatalf("unexpected output: %s", got)
@@ -3582,8 +3594,8 @@ func TestScanOnceProcessesGitHubCommentResumeRequest(t *testing.T) {
 	if len(sessions) != 1 {
 		t.Fatalf("unexpected sessions: %#v", sessions)
 	}
-	if sessions[0].Status != state.SessionStatusSuccess {
-		t.Fatalf("expected resumed session to be successful: %#v", sessions[0])
+	if sessions[0].Status != state.SessionStatusIncomplete {
+		t.Fatalf("expected resumed session to complete (incomplete without PR): %#v", sessions[0])
 	}
 	if sessions[0].LastResumeCommentID != 101 || sessions[0].LastResumeSource != "comment" {
 		t.Fatalf("expected claimed comment metadata to be persisted: %#v", sessions[0])
@@ -5125,7 +5137,7 @@ func TestScanOnceAutoRecoversStaleBlockedMaintenanceSession(t *testing.T) {
 		t.Fatal(err)
 	}
 	if sessions[0].Status != state.SessionStatusSuccess {
-		t.Fatalf("expected session to recover successfully: %#v", sessions[0])
+		t.Fatalf("expected session to recover to success with tracked PR: %#v", sessions[0])
 	}
 	if sessions[0].RecoveredAt == "" || sessions[0].BlockedStage != "" || sessions[0].BlockedReason.Kind != "" {
 		t.Fatalf("expected blocked state to be cleared after auto recovery: %#v", sessions[0])
@@ -5194,8 +5206,8 @@ func TestScanOnceSelectsEligibleIssueAndPersistsSession(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(sessions) != 1 || sessions[0].Status != state.SessionStatusSuccess {
-		t.Fatalf("unexpected sessions: %#v", sessions)
+	if len(sessions) != 1 || sessions[0].Status != state.SessionStatusIncomplete {
+		t.Fatalf("unexpected sessions (expected incomplete without PR): %#v", sessions)
 	}
 }
 
@@ -5789,8 +5801,8 @@ func TestScanOnceMaintainedIssueDoesNotConsumeOnlyDispatchSlot(t *testing.T) {
 	if sessions[0].IssueNumber != 1 || sessions[0].PullRequestState != "OPEN" {
 		t.Fatalf("expected issue #1 to stay under maintenance: %#v", sessions[0])
 	}
-	if sessions[1].IssueNumber != 2 || sessions[1].Status != state.SessionStatusSuccess {
-		t.Fatalf("expected issue #2 to complete a new session: %#v", sessions[1])
+	if sessions[1].IssueNumber != 2 || sessions[1].Status != state.SessionStatusIncomplete {
+		t.Fatalf("expected issue #2 to complete a new session (incomplete without PR): %#v", sessions[1])
 	}
 }
 
@@ -5975,8 +5987,8 @@ func TestScanOnceWithMaxParallelOnePreservesSerialBehavior(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(sessions) != 1 || sessions[0].IssueNumber != 1 || sessions[0].Status != state.SessionStatusSuccess {
-		t.Fatalf("unexpected sessions: %#v", sessions)
+	if len(sessions) != 1 || sessions[0].IssueNumber != 1 || sessions[0].Status != state.SessionStatusIncomplete {
+		t.Fatalf("unexpected sessions (expected incomplete without PR): %#v", sessions)
 	}
 }
 
@@ -6038,8 +6050,8 @@ func TestScanOnceWithUnlimitedMaxParallelStartsAllEligibleIssues(t *testing.T) {
 		t.Fatalf("unexpected sessions: %#v", sessions)
 	}
 	for _, session := range sessions {
-		if session.Status != state.SessionStatusSuccess {
-			t.Fatalf("expected successful sessions: %#v", sessions)
+		if session.Status != state.SessionStatusIncomplete {
+			t.Fatalf("expected completed sessions (incomplete without PR): %#v", sessions)
 		}
 	}
 }
@@ -6097,8 +6109,8 @@ func TestScanOnceStartsMultipleIssuesUpToConfiguredLimit(t *testing.T) {
 		t.Fatalf("unexpected sessions: %#v", sessions)
 	}
 	for _, session := range sessions {
-		if session.Status != state.SessionStatusSuccess {
-			t.Fatalf("expected successful sessions: %#v", sessions)
+		if session.Status != state.SessionStatusIncomplete {
+			t.Fatalf("expected completed sessions (incomplete without PR): %#v", sessions)
 		}
 	}
 }
@@ -6241,8 +6253,8 @@ func TestScanOnceBlocksFailedIssueDispatchAndContinuesToNextIssue(t *testing.T) 
 	if sessions[0].LastDispatchFailureFingerprint == "" || sessions[0].LastDispatchFailureCommentedAt == "" {
 		t.Fatalf("expected dispatch failure comment tracking: %#v", sessions[0])
 	}
-	if sessions[1].IssueNumber != 2 || sessions[1].Status != state.SessionStatusSuccess {
-		t.Fatalf("expected second issue to succeed, got: %#v", sessions[1])
+	if sessions[1].IssueNumber != 2 || sessions[1].Status != state.SessionStatusIncomplete {
+		t.Fatalf("expected second issue to complete (incomplete without PR), got: %#v", sessions[1])
 	}
 }
 
@@ -6544,8 +6556,8 @@ func TestScanOnceContinuesWhenOneRepositoryScanFails(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(sessions) != 1 || sessions[0].Repo != "owner/repo-b" || sessions[0].Status != state.SessionStatusSuccess {
-		t.Fatalf("unexpected sessions: %#v", sessions)
+	if len(sessions) != 1 || sessions[0].Repo != "owner/repo-b" || sessions[0].Status != state.SessionStatusIncomplete {
+		t.Fatalf("unexpected sessions (expected incomplete without PR): %#v", sessions)
 	}
 }
 
@@ -8375,8 +8387,8 @@ func TestScanOnceAutoRestartsStaleSessionAfterDelay(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(sessions) != 1 || sessions[0].Status != state.SessionStatusSuccess {
-		t.Fatalf("unexpected sessions: %#v", sessions)
+	if len(sessions) != 1 || sessions[0].Status != state.SessionStatusIncomplete {
+		t.Fatalf("unexpected sessions (expected incomplete without PR): %#v", sessions)
 	}
 	if sessions[0].StaleAutoRestartAttempts != 1 {
 		t.Fatalf("expected one persisted auto-restart attempt, got: %#v", sessions[0])
@@ -8552,7 +8564,7 @@ func TestScanOnceRecoversStalledSessionIntoPRMaintenance(t *testing.T) {
 		t.Fatalf("unexpected sessions: %#v", sessions)
 	}
 	if sessions[0].Status != state.SessionStatusSuccess {
-		t.Fatalf("expected success session after recovery: %#v", sessions[0])
+		t.Fatalf("expected success session after recovery with tracked PR: %#v", sessions[0])
 	}
 	if sessions[0].PullRequestNumber != 31 || sessions[0].LastMaintainedAt == "" {
 		t.Fatalf("expected PR maintenance tracking after recovery: %#v", sessions[0])

--- a/internal/app/start_test.go
+++ b/internal/app/start_test.go
@@ -75,8 +75,12 @@ func TestStartOneOffSessionSuccess(t *testing.T) {
 	}
 
 	err = app.StartOneOffSession(context.Background(), repoPath, 10, "")
-	if err != nil {
-		t.Fatal(err)
+	// Without a tracked PR the session is incomplete, which StartOneOffSession reports as an error.
+	if err == nil {
+		t.Fatal("expected error for incomplete session without PR")
+	}
+	if !strings.Contains(err.Error(), "incomplete") {
+		t.Fatalf("expected incomplete error, got: %s", err)
 	}
 
 	// Verify session was saved.
@@ -87,8 +91,8 @@ func TestStartOneOffSessionSuccess(t *testing.T) {
 	if len(sessions) != 1 {
 		t.Fatalf("expected 1 session, got %d", len(sessions))
 	}
-	if sessions[0].Status != state.SessionStatusSuccess {
-		t.Fatalf("expected success, got %s", sessions[0].Status)
+	if sessions[0].Status != state.SessionStatusIncomplete {
+		t.Fatalf("expected incomplete, got %s", sessions[0].Status)
 	}
 	if sessions[0].Repo != "owner/repo" || sessions[0].IssueNumber != 10 {
 		t.Fatalf("unexpected session: %#v", sessions[0])
@@ -107,8 +111,8 @@ func TestStartOneOffSessionSuccess(t *testing.T) {
 	if !strings.Contains(output, "one-off session") {
 		t.Fatalf("expected one-off note in output, got: %s", output)
 	}
-	if !strings.Contains(output, "completed successfully") {
-		t.Fatalf("expected success message, got: %s", output)
+	if !strings.Contains(output, "incomplete") {
+		t.Fatalf("expected incomplete message, got: %s", output)
 	}
 }
 
@@ -157,8 +161,8 @@ func TestStartOneOffSessionDoesNotAddToWatchlist(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := app.StartOneOffSession(context.Background(), repoPath, 5, ""); err != nil {
-		t.Fatal(err)
+	if err := app.StartOneOffSession(context.Background(), repoPath, 5, ""); err == nil {
+		t.Fatal("expected error for incomplete session without PR")
 	}
 
 	targets, err := app.state.LoadWatchTargets()
@@ -446,8 +450,8 @@ func TestStartOneOffSessionWithCustomProvider(t *testing.T) {
 	}
 
 	err := app.StartOneOffSession(context.Background(), repoPath, 3, "claude")
-	if err != nil {
-		t.Fatal(err)
+	if err == nil {
+		t.Fatal("expected error for incomplete session without PR")
 	}
 
 	sessions, err := app.state.LoadSessions()

--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -31,7 +31,7 @@ type watchedRepoStatus struct {
 }
 
 func groupSessions(sessions []state.Session, now time.Time, inactivityTimeout time.Duration) []sessionGroup {
-	var active, prTracking, issueTracking, stale, completed, failed []state.Session
+	var active, prTracking, issueTracking, incomplete, stale, completed, failed []state.Session
 
 	staleBlockedThreshold := time.Duration(staleBlockedMultiplier) * inactivityTimeout
 
@@ -54,6 +54,8 @@ func groupSessions(sessions []state.Session, now time.Time, inactivityTimeout ti
 			}
 		case state.SessionStatusSuccess:
 			completed = append(completed, s)
+		case state.SessionStatusIncomplete:
+			incomplete = append(incomplete, s)
 		case state.SessionStatusFailed:
 			failed = append(failed, s)
 		}
@@ -68,6 +70,9 @@ func groupSessions(sessions []state.Session, now time.Time, inactivityTimeout ti
 	}
 	if len(issueTracking) > 0 {
 		groups = append(groups, sessionGroup{Label: "Paused, tracking issues", Sessions: issueTracking})
+	}
+	if len(incomplete) > 0 {
+		groups = append(groups, sessionGroup{Label: "Incomplete, pending rerun", Sessions: incomplete})
 	}
 	if len(stale) > 0 {
 		groups = append(groups, sessionGroup{Label: "Stale sessions", Sessions: stale})
@@ -154,6 +159,9 @@ func formatSessionRow(s state.Session) string {
 	}
 	if s.BlockedStage != "" {
 		fmt.Fprintf(&b, ", stage %s", s.BlockedStage)
+	}
+	if s.IncompleteReason != "" {
+		fmt.Fprintf(&b, ", reason %s", s.IncompleteReason)
 	}
 	return b.String()
 }

--- a/internal/app/status_test.go
+++ b/internal/app/status_test.go
@@ -237,6 +237,39 @@ func TestIsPRTrackingIssueExecution(t *testing.T) {
 	}
 }
 
+func TestGroupSessionsIncomplete(t *testing.T) {
+	now := time.Date(2026, 3, 19, 12, 0, 0, 0, time.UTC)
+	sessions := []state.Session{
+		{Repo: "owner/repo", IssueNumber: 80, Status: state.SessionStatusIncomplete, IncompleteReason: "commits_without_pr"},
+	}
+	groups := groupSessions(sessions, now, 20*time.Minute)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	if groups[0].Label != "Incomplete, pending rerun" {
+		t.Fatalf("expected 'Incomplete, pending rerun', got %q", groups[0].Label)
+	}
+	if len(groups[0].Sessions) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(groups[0].Sessions))
+	}
+}
+
+func TestFormatSessionRowIncomplete(t *testing.T) {
+	s := state.Session{
+		Repo:             "owner/repo",
+		IssueNumber:      99,
+		Status:           state.SessionStatusIncomplete,
+		IncompleteReason: "commits_without_pr",
+	}
+	row := formatSessionRow(s)
+	if !strings.Contains(row, "incomplete") {
+		t.Errorf("expected incomplete status in row: %s", row)
+	}
+	if !strings.Contains(row, "reason commits_without_pr") {
+		t.Errorf("expected incomplete reason in row: %s", row)
+	}
+}
+
 func TestStatusCommandOutputPreservesServiceState(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/runner/progress.go
+++ b/internal/runner/progress.go
@@ -1,0 +1,95 @@
+package runner
+
+import (
+	"context"
+	"strings"
+
+	"github.com/nicobistolfi/vigilante/internal/environment"
+	"github.com/nicobistolfi/vigilante/internal/state"
+)
+
+// ProgressSignal describes the deterministic progress classification of a
+// session after the coding agent exits successfully.
+type ProgressSignal struct {
+	// HasPullRequest is true when the session already tracks a PR number.
+	HasPullRequest bool
+	// HasNewCommits is true when the issue branch has commits ahead of the base branch.
+	HasNewCommits bool
+	// HasWorktreeChanges is true when git status reports modified/staged files.
+	HasWorktreeChanges bool
+}
+
+const (
+	incompleteReasonNoDurableProgress = "no_durable_progress"
+	incompleteReasonUncommittedOnly   = "uncommitted_changes"
+	incompleteReasonCommitsWithoutPR  = "commits_without_pr"
+)
+
+// EvaluateSessionProgress inspects deterministic local and git signals to
+// classify what durable progress a session made. The caller uses the result
+// to decide between SessionStatusSuccess and SessionStatusIncomplete.
+func EvaluateSessionProgress(ctx context.Context, runner environment.Runner, session state.Session) ProgressSignal {
+	signal := ProgressSignal{
+		HasPullRequest: session.PullRequestNumber > 0,
+	}
+	if signal.HasPullRequest {
+		return signal
+	}
+	signal.HasNewCommits = detectNewCommits(ctx, runner, session)
+	signal.HasWorktreeChanges = detectWorktreeChanges(ctx, runner, session)
+	return signal
+}
+
+// ClassifyIncompleteReason returns the deterministic reason string for a
+// session that exited successfully but did not create a PR.
+func ClassifyIncompleteReason(signal ProgressSignal) string {
+	switch {
+	case signal.HasNewCommits:
+		return incompleteReasonCommitsWithoutPR
+	case signal.HasWorktreeChanges:
+		return incompleteReasonUncommittedOnly
+	default:
+		return incompleteReasonNoDurableProgress
+	}
+}
+
+// IsRerunEligible returns true when a session is incomplete but has partial
+// progress that makes rerunning in the same worktree worthwhile.
+func IsRerunEligible(session state.Session) bool {
+	if session.Status != state.SessionStatusIncomplete {
+		return false
+	}
+	return session.IncompleteReason == incompleteReasonCommitsWithoutPR ||
+		session.IncompleteReason == incompleteReasonUncommittedOnly ||
+		session.IncompleteReason == incompleteReasonNoDurableProgress
+}
+
+// detectNewCommits returns true if the issue branch has commits ahead of the
+// base branch (or origin/base).
+func detectNewCommits(ctx context.Context, runner environment.Runner, session state.Session) bool {
+	if strings.TrimSpace(session.WorktreePath) == "" {
+		return false
+	}
+	baseBranch := strings.TrimSpace(session.BaseBranch)
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
+	output, err := runner.Run(ctx, session.WorktreePath, "git", "rev-list", "--count", "origin/"+baseBranch+"..HEAD")
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(output) != "0" && strings.TrimSpace(output) != ""
+}
+
+// detectWorktreeChanges returns true when there are uncommitted modifications
+// (staged or unstaged) in the worktree.
+func detectWorktreeChanges(ctx context.Context, runner environment.Runner, session state.Session) bool {
+	if strings.TrimSpace(session.WorktreePath) == "" {
+		return false
+	}
+	output, err := runner.Run(ctx, session.WorktreePath, "git", "status", "--porcelain")
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(output) != ""
+}

--- a/internal/runner/progress_test.go
+++ b/internal/runner/progress_test.go
@@ -1,0 +1,167 @@
+package runner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nicobistolfi/vigilante/internal/state"
+	"github.com/nicobistolfi/vigilante/internal/testutil"
+)
+
+func TestEvaluateSessionProgressWithPR(t *testing.T) {
+	session := state.Session{
+		PullRequestNumber: 42,
+		WorktreePath:      "/tmp/worktree",
+		Branch:            "vigilante/issue-1",
+		BaseBranch:        "main",
+	}
+	signal := EvaluateSessionProgress(context.Background(), testutil.FakeRunner{}, session)
+	if !signal.HasPullRequest {
+		t.Fatal("expected HasPullRequest to be true")
+	}
+}
+
+func TestEvaluateSessionProgressNewCommitsNoPR(t *testing.T) {
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"git rev-list --count origin/main..HEAD": "3",
+			"git status --porcelain":                 "",
+		},
+	}
+	session := state.Session{
+		WorktreePath: "/tmp/worktree",
+		Branch:       "vigilante/issue-1",
+		BaseBranch:   "main",
+	}
+	signal := EvaluateSessionProgress(context.Background(), runner, session)
+	if signal.HasPullRequest {
+		t.Fatal("expected HasPullRequest to be false")
+	}
+	if !signal.HasNewCommits {
+		t.Fatal("expected HasNewCommits to be true")
+	}
+	if signal.HasWorktreeChanges {
+		t.Fatal("expected HasWorktreeChanges to be false")
+	}
+}
+
+func TestEvaluateSessionProgressUncommittedChanges(t *testing.T) {
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"git rev-list --count origin/main..HEAD": "0",
+			"git status --porcelain":                 " M file.go\n",
+		},
+	}
+	session := state.Session{
+		WorktreePath: "/tmp/worktree",
+		Branch:       "vigilante/issue-1",
+		BaseBranch:   "main",
+	}
+	signal := EvaluateSessionProgress(context.Background(), runner, session)
+	if signal.HasPullRequest {
+		t.Fatal("expected HasPullRequest to be false")
+	}
+	if signal.HasNewCommits {
+		t.Fatal("expected HasNewCommits to be false")
+	}
+	if !signal.HasWorktreeChanges {
+		t.Fatal("expected HasWorktreeChanges to be true")
+	}
+}
+
+func TestEvaluateSessionProgressNoDurableProgress(t *testing.T) {
+	runner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"git rev-list --count origin/main..HEAD": "0",
+			"git status --porcelain":                 "",
+		},
+	}
+	session := state.Session{
+		WorktreePath: "/tmp/worktree",
+		Branch:       "vigilante/issue-1",
+		BaseBranch:   "main",
+	}
+	signal := EvaluateSessionProgress(context.Background(), runner, session)
+	if signal.HasPullRequest || signal.HasNewCommits || signal.HasWorktreeChanges {
+		t.Fatal("expected no progress signals")
+	}
+}
+
+func TestClassifyIncompleteReason(t *testing.T) {
+	tests := []struct {
+		name   string
+		signal ProgressSignal
+		want   string
+	}{
+		{
+			name:   "commits without PR",
+			signal: ProgressSignal{HasNewCommits: true},
+			want:   "commits_without_pr",
+		},
+		{
+			name:   "uncommitted changes only",
+			signal: ProgressSignal{HasWorktreeChanges: true},
+			want:   "uncommitted_changes",
+		},
+		{
+			name:   "commits and uncommitted changes",
+			signal: ProgressSignal{HasNewCommits: true, HasWorktreeChanges: true},
+			want:   "commits_without_pr",
+		},
+		{
+			name:   "no durable progress",
+			signal: ProgressSignal{},
+			want:   "no_durable_progress",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyIncompleteReason(tc.signal)
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsRerunEligible(t *testing.T) {
+	tests := []struct {
+		name    string
+		session state.Session
+		want    bool
+	}{
+		{
+			name:    "incomplete with commits",
+			session: state.Session{Status: state.SessionStatusIncomplete, IncompleteReason: "commits_without_pr"},
+			want:    true,
+		},
+		{
+			name:    "incomplete with uncommitted changes",
+			session: state.Session{Status: state.SessionStatusIncomplete, IncompleteReason: "uncommitted_changes"},
+			want:    true,
+		},
+		{
+			name:    "incomplete no progress",
+			session: state.Session{Status: state.SessionStatusIncomplete, IncompleteReason: "no_durable_progress"},
+			want:    true,
+		},
+		{
+			name:    "success status",
+			session: state.Session{Status: state.SessionStatusSuccess},
+			want:    false,
+		},
+		{
+			name:    "blocked status",
+			session: state.Session{Status: state.SessionStatusBlocked},
+			want:    false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsRerunEligible(tc.session)
+			if got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -225,10 +225,31 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 		return session
 	}
 
-	session.Status = state.SessionStatusSuccess
 	session.IterationInProgress = false
-	writeLifecycleEvent(logWriter, fmt.Sprintf("session completed status=success duration=%s", time.Since(invocationStart).Truncate(time.Second)))
-	appendSessionLog(logPath, fmt.Sprintf("session succeeded duration=%s output_bytes=%d", time.Since(invocationStart).Truncate(time.Second), len(output)), session, output)
+
+	signal := EvaluateSessionProgress(ctx, env.Runner, session)
+	if signal.HasPullRequest {
+		session.Status = state.SessionStatusSuccess
+		session.IncompleteReason = ""
+		writeLifecycleEvent(logWriter, fmt.Sprintf("session completed status=success duration=%s", time.Since(invocationStart).Truncate(time.Second)))
+		appendSessionLog(logPath, fmt.Sprintf("session succeeded duration=%s output_bytes=%d", time.Since(invocationStart).Truncate(time.Second), len(output)), session, output)
+	} else {
+		reason := ClassifyIncompleteReason(signal)
+		session.Status = state.SessionStatusIncomplete
+		session.IncompleteReason = reason
+		writeLifecycleEvent(logWriter, fmt.Sprintf("session completed status=incomplete reason=%s duration=%s commits=%t worktree_changes=%t",
+			reason, time.Since(invocationStart).Truncate(time.Second), signal.HasNewCommits, signal.HasWorktreeChanges))
+		appendSessionLog(logPath, fmt.Sprintf("session incomplete reason=%s duration=%s output_bytes=%d", reason, time.Since(invocationStart).Truncate(time.Second), len(output)), session, output)
+		body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+			Stage:      "Incomplete",
+			Emoji:      "⚠️",
+			Percent:    90,
+			ETAMinutes: 5,
+			Items:      incompleteSessionItems(session, signal),
+			Tagline:    "Progress saved — not done yet.",
+		})
+		_ = issueTracker.CommentOnWorkItem(ctx, target.Repo, issue.Number, body)
+	}
 	return session
 }
 
@@ -422,6 +443,24 @@ func blockedPreflightItems(blocked state.BlockedReason, providerID string, prefl
 		}
 	}
 	items = append(items, fmt.Sprintf("Next step: restore the repository baseline, then run `%s` or request resume from GitHub.", resumeHint))
+	return items
+}
+
+func incompleteSessionItems(session state.Session, signal ProgressSignal) []string {
+	items := []string{
+		fmt.Sprintf("The coding agent exited successfully but no pull request was created for `%s`.", session.Branch),
+	}
+	switch {
+	case signal.HasNewCommits && signal.HasWorktreeChanges:
+		items = append(items, "New commits were pushed to the branch and uncommitted changes remain in the worktree.")
+	case signal.HasNewCommits:
+		items = append(items, "New commits were pushed to the branch but no PR was opened.")
+	case signal.HasWorktreeChanges:
+		items = append(items, "Uncommitted changes exist in the worktree but no commits were made.")
+	default:
+		items = append(items, "No durable progress was detected: no new commits and no modified files.")
+	}
+	items = append(items, "Next step: Vigilante will attempt to rerun the session in the existing worktree to continue from the current state.")
 	return items
 }
 

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -59,14 +59,18 @@ func TestRunIssueSessionSuccess(t *testing.T) {
 	}
 	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
 	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
-	if got.Status != state.SessionStatusSuccess {
-		t.Fatalf("unexpected status: %#v", got)
+	// No PR was tracked, so the session is incomplete rather than success.
+	if got.Status != state.SessionStatusIncomplete {
+		t.Fatalf("unexpected status: %s (expected incomplete without PR)", got.Status)
+	}
+	if got.IncompleteReason == "" {
+		t.Fatal("expected IncompleteReason to be set")
 	}
 	data, err := os.ReadFile(store.SessionLogPath("owner/repo", 7))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(data), "session succeeded") || !strings.Contains(string(data), "done") {
+	if !strings.Contains(string(data), "session incomplete") || !strings.Contains(string(data), "done") {
 		t.Fatalf("unexpected log: %s", string(data))
 	}
 	accessLog, err := os.ReadFile(store.AccessLogPath())
@@ -79,6 +83,58 @@ func TestRunIssueSessionSuccess(t *testing.T) {
 	}
 	if !strings.Contains(text, `"repo":"owner/repo"`) || !strings.Contains(text, `"issue_number":7`) {
 		t.Fatalf("expected repo and issue metadata in access log, got %s", text)
+	}
+}
+
+func TestRunIssueSessionSuccessWithPR(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	baseRunner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"codex --version": "codex 0.114.0",
+			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Vigilante Session Start",
+				Emoji:      "🧢",
+				Percent:    20,
+				ETAMinutes: 25,
+				Items: []string{
+					"Vigilante launched this implementation session in `/tmp/worktree`.",
+					"Branch: `vigilante/issue-7`.",
+					"Current stage: handing the issue off to the configured coding agent (`Codex`) for investigation and implementation.",
+					"Common issue-comment commands: `@vigilanteai resume` retries a blocked session after the underlying problem is fixed, and `@vigilanteai cleanup` removes the local session state for this issue.",
+				},
+				Tagline: "Make it simple, but significant.",
+			}): "ok",
+			preflightPromptCommand("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", "vigilante/issue-7"): "baseline ok",
+			issuePromptCommand("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", "vigilante/issue-7"):     "done",
+		},
+	}
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	env := &environment.Environment{
+		OS: "darwin",
+		Runner: environment.LoggingRunner{
+			Base:      baseRunner,
+			AccessLog: store.AppendAccessLogEntry,
+		},
+	}
+	// Session already has a tracked PR, so progress evaluation should classify it as success.
+	session := state.Session{
+		RepoPath:          "/tmp/repo",
+		IssueNumber:       7,
+		WorktreePath:      "/tmp/worktree",
+		Branch:            "vigilante/issue-7",
+		Status:            state.SessionStatusRunning,
+		PullRequestNumber: 42,
+	}
+	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+	if got.Status != state.SessionStatusSuccess {
+		t.Fatalf("unexpected status: %s (expected success with tracked PR)", got.Status)
+	}
+	if got.IncompleteReason != "" {
+		t.Fatalf("expected empty IncompleteReason, got %q", got.IncompleteReason)
 	}
 }
 
@@ -121,8 +177,8 @@ func TestRunIssueSessionStartCommentIncludesReusedRemoteBranchContext(t *testing
 		Status:             state.SessionStatusRunning,
 	}
 	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
-	if got.Status != state.SessionStatusSuccess {
-		t.Fatalf("unexpected status: %#v", got)
+	if got.Status != state.SessionStatusIncomplete {
+		t.Fatalf("unexpected status (expected incomplete without PR): %s", got.Status)
 	}
 }
 
@@ -315,8 +371,8 @@ func TestRunIssueSessionSuccessWithClaudeProvider(t *testing.T) {
 	}
 	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "claude", Status: state.SessionStatusRunning}
 	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
-	if got.Status != state.SessionStatusSuccess {
-		t.Fatalf("unexpected status: %#v", got)
+	if got.Status != state.SessionStatusIncomplete {
+		t.Fatalf("unexpected status (expected incomplete without PR): %s", got.Status)
 	}
 }
 
@@ -359,8 +415,8 @@ func TestRunIssueSessionSuccessWithGeminiProvider(t *testing.T) {
 	}
 	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "gemini", Status: state.SessionStatusRunning}
 	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
-	if got.Status != state.SessionStatusSuccess {
-		t.Fatalf("unexpected status: %#v", got)
+	if got.Status != state.SessionStatusIncomplete {
+		t.Fatalf("unexpected status (expected incomplete without PR): %s", got.Status)
 	}
 }
 
@@ -412,8 +468,8 @@ func TestRunIssueSessionUsesMonorepoSkillWhenClassified(t *testing.T) {
 
 	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), target, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 
-	if got.Status != state.SessionStatusSuccess {
-		t.Fatalf("unexpected status: %#v", got)
+	if got.Status != state.SessionStatusIncomplete {
+		t.Fatalf("unexpected status (expected incomplete without PR): %s", got.Status)
 	}
 }
 
@@ -465,8 +521,8 @@ func TestRunIssueSessionUsesNxSkillWhenClassified(t *testing.T) {
 
 	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), target, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 
-	if got.Status != state.SessionStatusSuccess {
-		t.Fatalf("unexpected status: %#v", got)
+	if got.Status != state.SessionStatusIncomplete {
+		t.Fatalf("unexpected status (expected incomplete without PR): %s", got.Status)
 	}
 }
 
@@ -518,8 +574,8 @@ func TestRunIssueSessionUsesRushMonorepoSkillWhenClassified(t *testing.T) {
 
 	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), target, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 
-	if got.Status != state.SessionStatusSuccess {
-		t.Fatalf("unexpected status: %#v", got)
+	if got.Status != state.SessionStatusIncomplete {
+		t.Fatalf("unexpected status (expected incomplete without PR): %s", got.Status)
 	}
 }
 
@@ -824,8 +880,8 @@ func TestRunIssueSessionWritesLifecycleEvents(t *testing.T) {
 	}
 	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
 	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
-	if got.Status != state.SessionStatusSuccess {
-		t.Fatalf("unexpected status: %#v", got)
+	if got.Status != state.SessionStatusIncomplete {
+		t.Fatalf("unexpected status (expected incomplete without PR): %s", got.Status)
 	}
 	data, err := os.ReadFile(store.SessionLogPath("owner/repo", 7))
 	if err != nil {
@@ -838,7 +894,7 @@ func TestRunIssueSessionWritesLifecycleEvents(t *testing.T) {
 		"preflight invocation starting",
 		"preflight succeeded",
 		"implementation invocation starting",
-		"session completed status=success",
+		"session completed status=incomplete",
 	} {
 		if !strings.Contains(logContent, want) {
 			t.Errorf("expected session log to contain %q, got:\n%s", want, logContent)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -137,12 +137,13 @@ func (c ServiceConfig) IsPackageHardeningEnabled() bool {
 type SessionStatus string
 
 const (
-	SessionStatusRunning  SessionStatus = "running"
-	SessionStatusBlocked  SessionStatus = "blocked"
-	SessionStatusResuming SessionStatus = "resuming"
-	SessionStatusSuccess  SessionStatus = "success"
-	SessionStatusFailed   SessionStatus = "failed"
-	SessionStatusClosed   SessionStatus = "closed"
+	SessionStatusRunning    SessionStatus = "running"
+	SessionStatusBlocked    SessionStatus = "blocked"
+	SessionStatusResuming   SessionStatus = "resuming"
+	SessionStatusSuccess    SessionStatus = "success"
+	SessionStatusIncomplete SessionStatus = "incomplete"
+	SessionStatusFailed     SessionStatus = "failed"
+	SessionStatusClosed     SessionStatus = "closed"
 )
 
 type BlockedReason struct {
@@ -227,6 +228,7 @@ type Session struct {
 	LastRecreateSource             string              `json:"last_recreate_source,omitempty"`
 	LastRecreateCommentID          int64               `json:"last_recreate_comment_id,omitempty"`
 	LastRecreateCommentAt          string              `json:"last_recreate_comment_at,omitempty"`
+	IncompleteReason               string              `json:"incomplete_reason,omitempty"`
 	RecreatedAsIssue               int                 `json:"recreated_as_issue,omitempty"`
 	RecreatedAsIssueURL            string              `json:"recreated_as_issue_url,omitempty"`
 	StaleAutoRestartAttempts       int                 `json:"stale_auto_restart_attempts,omitempty"`


### PR DESCRIPTION
## Summary

- Introduces deterministic progress evaluation for coding-agent sessions: `vigilante:ready-for-review` is now only applied when a PR has actually been created and tracked by the session.
- Adds `SessionStatusIncomplete` for sessions that exit successfully but produce no PR, with classification of the incomplete reason (`commits_without_pr`, `uncommitted_changes`, `no_durable_progress`).
- Adds `rerunIncompleteSessions` in the scan loop to automatically re-dispatch the coding agent in the same worktree when partial progress exists but no PR was created.
- Updates `desiredSessionLabels` so success-without-PR maps to `vigilante:blocked` instead of `vigilante:ready-for-review`.
- Updates status display to show incomplete sessions in their own group with reason details.

## Test plan

- [x] Unit tests for `EvaluateSessionProgress` covering: PR present, new commits without PR, uncommitted changes only, no durable progress
- [x] Unit tests for `ClassifyIncompleteReason` and `IsRerunEligible`
- [x] Updated `desiredSessionLabels` tests: success-without-PR → blocked, success-with-PR → ready-for-review, incomplete → blocked
- [x] Updated session runner tests to verify incomplete status when no PR is tracked
- [x] Added `TestRunIssueSessionSuccessWithPR` to verify success when PR is present
- [x] Updated `start_test.go` tests for incomplete-without-PR behavior
- [x] Status grouping and formatting tests for incomplete sessions
- [x] Full test suite passes with `go test ./...`, `go vet ./...`, and `gofmt` clean

Closes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)