### PR TITLE
Fix false no-PR loop when the issue branch already has a PR

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -3771,6 +3771,25 @@ func (a *App) rerunIncompleteSessions(ctx context.Context, sessions []state.Sess
 		if strings.TrimSpace(session.WorktreePath) == "" || strings.TrimSpace(session.Branch) == "" {
 			continue
 		}
+		if pr, err := a.loadPullRequestForSession(ctx, *session); err != nil {
+			a.logger.Warn("incomplete session pull request reconciliation failed", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "err", err)
+		} else if pr != nil && (strings.EqualFold(strings.TrimSpace(pr.State), "OPEN") || pr.MergedAt != nil) {
+			previousStatus := session.Status
+			now := a.clock().Format(time.RFC3339)
+			session.Status = state.SessionStatusSuccess
+			session.IncompleteReason = ""
+			session.UpdatedAt = now
+			session.RecoveredAt = now
+			session.LastError = ""
+			updatePullRequestMaintenanceSnapshot(session, *pr)
+			if strings.EqualFold(strings.TrimSpace(pr.State), "OPEN") {
+				session.LastMaintainedAt = now
+				session.LastMaintenanceError = ""
+			}
+			a.emitSessionTransition(previousStatus, *session, "incomplete_github_reconciliation")
+			a.logger.Info("incomplete session recovered to pull request tracking", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "pr", pr.Number, "state", pr.State)
+			continue
+		}
 		if _, err := os.Stat(session.WorktreePath); err != nil {
 			a.logger.Info("incomplete session worktree missing, skipping rerun", "repo", session.Repo, "issue", session.IssueNumber, "worktree", session.WorktreePath)
 			continue

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4473,7 +4473,7 @@ func (a *App) resumeBlockedIssueExecution(ctx context.Context, session *state.Se
 		pr, err := a.loadPullRequestForSession(ctx, *session)
 		if err != nil {
 			a.logger.Warn("resume issue pull request reconciliation failed", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "err", err)
-		} else if pr != nil {
+		} else if pullRequestCountsAsCompletedImplementation(*pr) {
 			updatePullRequestTrackingFromLookup(session, *pr)
 			signal.HasPullRequest = true
 		}
@@ -4945,6 +4945,10 @@ func updatePullRequestTrackingFromLookup(session *state.Session, pr ghcli.PullRe
 	if pr.MergedAt != nil {
 		session.PullRequestMergedAt = pr.MergedAt.UTC().Format(time.RFC3339)
 	}
+}
+
+func pullRequestCountsAsCompletedImplementation(pr ghcli.PullRequest) bool {
+	return strings.EqualFold(strings.TrimSpace(pr.State), "OPEN") || pr.MergedAt != nil
 }
 
 func updatePullRequestMaintenanceSnapshot(session *state.Session, pr ghcli.PullRequest) string {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4469,6 +4469,15 @@ func (a *App) resumeBlockedIssueExecution(ctx context.Context, session *state.Se
 		return err
 	}
 	signal := issuerunner.EvaluateSessionProgress(ctx, a.env.Runner, *session)
+	if !signal.HasPullRequest {
+		pr, err := a.loadPullRequestForSession(ctx, *session)
+		if err != nil {
+			a.logger.Warn("resume issue pull request reconciliation failed", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "err", err)
+		} else if pr != nil {
+			updatePullRequestTrackingFromLookup(session, *pr)
+			signal.HasPullRequest = true
+		}
+	}
 	if signal.HasPullRequest {
 		session.Status = state.SessionStatusSuccess
 		session.IncompleteReason = ""

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -4213,6 +4213,78 @@ func TestResumeBlockedSessionSuppressesDuplicateDiagnosticComment(t *testing.T) 
 	}
 }
 
+func TestResumeBlockedSessionReconcilesExistingPullRequestAfterIssueExecution(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	recoveredComment := ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Recovered",
+		Emoji:      "🫡",
+		Percent:    92,
+		ETAMinutes: 5,
+		Items: []string{
+			"The previous `provider_auth` block was cleared for `vigilante/issue-1`.",
+			"Resume source: `comment`.",
+			"Next step: Vigilante resumed `issue_execution` successfully.",
+		},
+		Tagline: "Back on the wire.",
+	})
+	session := state.Session{
+		RepoPath:       repoPath,
+		Repo:           "owner/repo",
+		Provider:       "codex",
+		IssueNumber:    1,
+		IssueTitle:     "first",
+		IssueURL:       "https://github.com/owner/repo/issues/1",
+		Branch:         "vigilante/issue-1",
+		WorktreePath:   worktreePath,
+		Status:         state.SessionStatusBlocked,
+		BlockedStage:   "issue_execution",
+		BlockedReason:  state.BlockedReason{Kind: "provider_auth", Operation: "codex exec", Summary: "session expired", Detail: "session expired"},
+		ResumeRequired: true,
+		ResumeHint:     "vigilante resume --repo owner/repo --issue 1",
+	}
+
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"codex --version": "codex 1.0.0",
+			issuePromptCommand(worktreePath, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1"):                                  "done",
+			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt":                                                                 `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
+			"gh pr view --repo owner/repo 31 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,baseRefName": `{"number":31,"title":"PR","body":"Closes #1","url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null,"labels":[],"isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"","statusCheckRollup":[],"baseRefName":"main"}`,
+			"gh issue comment --repo owner/repo 1 --body " + recoveredComment:                                                                                                    "ok",
+			"git rev-list --count origin/main..HEAD": "1\n",
+			"git status --porcelain":                 "",
+		},
+	}
+
+	if err := app.resumeBlockedSession(context.Background(), &session, "comment"); err != nil {
+		t.Fatal(err)
+	}
+	if session.Status != state.SessionStatusSuccess {
+		t.Fatalf("expected resumed session to become successful after PR reconciliation: %#v", session)
+	}
+	if session.IncompleteReason != "" {
+		t.Fatalf("expected incomplete reason to clear after PR reconciliation: %#v", session)
+	}
+	if session.PullRequestNumber != 31 || session.PullRequestURL != "https://github.com/owner/repo/pull/31" {
+		t.Fatalf("expected resumed session to track reconciled PR metadata: %#v", session)
+	}
+	if session.PullRequestState != "OPEN" || session.PullRequestBaseBranch != "main" || session.PullRequestHeadBranch != "vigilante/issue-1" {
+		t.Fatalf("expected resumed session to capture reconciled PR state: %#v", session)
+	}
+}
+
 func TestScanOnceProcessesGitHubCommentCleanupRequest(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -4285,6 +4285,75 @@ func TestResumeBlockedSessionReconcilesExistingPullRequestAfterIssueExecution(t 
 	}
 }
 
+func TestResumeBlockedSessionLeavesIncompleteWhenBranchLookupFindsClosedPullRequest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	recoveredComment := ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Recovered",
+		Emoji:      "🫡",
+		Percent:    92,
+		ETAMinutes: 5,
+		Items: []string{
+			"The previous `provider_auth` block was cleared for `vigilante/issue-1`.",
+			"Resume source: `comment`.",
+			"Next step: Vigilante resumed `issue_execution` successfully.",
+		},
+		Tagline: "Back on the wire.",
+	})
+	session := state.Session{
+		RepoPath:       repoPath,
+		Repo:           "owner/repo",
+		Provider:       "codex",
+		IssueNumber:    1,
+		IssueTitle:     "first",
+		IssueURL:       "https://github.com/owner/repo/issues/1",
+		Branch:         "vigilante/issue-1",
+		WorktreePath:   worktreePath,
+		Status:         state.SessionStatusBlocked,
+		BlockedStage:   "issue_execution",
+		BlockedReason:  state.BlockedReason{Kind: "provider_auth", Operation: "codex exec", Summary: "session expired", Detail: "session expired"},
+		ResumeRequired: true,
+		ResumeHint:     "vigilante resume --repo owner/repo --issue 1",
+	}
+
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"codex --version": "codex 1.0.0",
+			issuePromptCommand(worktreePath, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1"):                                  "done",
+			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt":                                                                 `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"CLOSED","mergedAt":null}]`,
+			"gh pr view --repo owner/repo 31 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,baseRefName": `{"number":31,"title":"PR","body":"Closes #1","url":"https://github.com/owner/repo/pull/31","state":"CLOSED","mergedAt":null,"labels":[],"isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","reviewDecision":"","statusCheckRollup":[],"baseRefName":"main"}`,
+			"gh issue comment --repo owner/repo 1 --body " + recoveredComment:                                                                                                    "ok",
+			"git rev-list --count origin/main..HEAD": "1\n",
+			"git status --porcelain":                 "",
+		},
+	}
+
+	if err := app.resumeBlockedSession(context.Background(), &session, "comment"); err != nil {
+		t.Fatal(err)
+	}
+	if session.Status != state.SessionStatusIncomplete {
+		t.Fatalf("expected resumed session to stay incomplete when only a closed PR exists: %#v", session)
+	}
+	if session.IncompleteReason != "commits_without_pr" {
+		t.Fatalf("expected commits_without_pr when only a closed PR exists: %#v", session)
+	}
+	if session.PullRequestNumber != 0 {
+		t.Fatalf("expected closed PR lookup not to populate PR tracking: %#v", session)
+	}
+}
+
 func TestScanOnceProcessesGitHubCommentCleanupRequest(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -8571,6 +8571,83 @@ func TestScanOnceRecoversStalledSessionIntoPRMaintenance(t *testing.T) {
 	}
 }
 
+func TestScanOnceRecoversIncompleteSessionIntoPRMaintenanceWhenBranchPRExists(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	var stdout bytes.Buffer
+	app := New()
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	now := time.Date(2026, 3, 10, 15, 0, 0, 0, time.UTC)
+	app.clock = func() time.Time { return now }
+
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"gh api repos/owner/repo/issues/1": `{"title":"first","body":"Issue body","html_url":"https://github.com/owner/repo/issues/1","state":"open","labels":[]}`,
+			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt":                                                                 `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
+			"gh pr view --repo owner/repo 31 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,baseRefName": automergePRDetailsJSON("", "MERGEABLE", "CLEAN", "APPROVED", "COMPLETED", "SUCCESS"),
+			"gh api user --jq .login": "nicobistolfi\n",
+			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": `[{"number":1,"title":"first","createdAt":"2026-03-10T14:00:00Z","url":"https://github.com/owner/repo/issues/1","labels":[]}]`,
+		},
+	}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: repoPath, Repo: "owner/repo", Branch: "main"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:          repoPath,
+		Repo:              "owner/repo",
+		IssueNumber:       1,
+		IssueTitle:        "first",
+		IssueURL:          "https://github.com/owner/repo/issues/1",
+		Branch:            "vigilante/issue-1",
+		WorktreePath:      worktreePath,
+		Status:            state.SessionStatusIncomplete,
+		IncompleteReason:  "commits_without_pr",
+		PullRequestNumber: 0,
+		UpdatedAt:         now.Add(-20 * time.Minute).Format(time.RFC3339),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if sessions[0].Status != state.SessionStatusSuccess {
+		t.Fatalf("expected incomplete session to recover into success: %#v", sessions[0])
+	}
+	if sessions[0].IncompleteReason != "" {
+		t.Fatalf("expected incomplete reason to clear after recovery: %#v", sessions[0])
+	}
+	if sessions[0].PullRequestNumber != 31 || sessions[0].PullRequestState != "OPEN" || sessions[0].LastMaintainedAt == "" {
+		t.Fatalf("expected open PR tracking after recovery: %#v", sessions[0])
+	}
+	if strings.Contains(stdout.String(), "started issue #1") {
+		t.Fatalf("expected scan to avoid redispatching recovered issue, got output: %s", stdout.String())
+	}
+}
+
 func TestScanOnceReconcilesStaleRunningSessionAgainstClosedIssueAndMergedPullRequest(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -233,7 +233,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 		pr, err := reconcileSessionPullRequest(ctx, issueTracker, session)
 		if err != nil {
 			appendSessionLog(logPath, "pull request reconciliation failed", session, err.Error())
-		} else if pr != nil {
+		} else if pullRequestCountsAsCompletedImplementation(*pr) {
 			updateSessionPullRequestTracking(&session, *pr)
 			signal.HasPullRequest = true
 		}
@@ -292,6 +292,10 @@ func updateSessionPullRequestTracking(session *state.Session, pr backend.PullReq
 	} else {
 		session.PullRequestMergedAt = ""
 	}
+}
+
+func pullRequestCountsAsCompletedImplementation(pr backend.PullRequest) bool {
+	return strings.EqualFold(strings.TrimSpace(pr.State), "OPEN") || pr.MergedAt != nil
 }
 
 func sessionPullRequestHeadSelector(session state.Session) string {

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -229,6 +229,15 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 	session.IterationInProgress = false
 
 	signal := EvaluateSessionProgress(ctx, env.Runner, session)
+	if !signal.HasPullRequest {
+		pr, err := reconcileSessionPullRequest(ctx, issueTracker, session)
+		if err != nil {
+			appendSessionLog(logPath, "pull request reconciliation failed", session, err.Error())
+		} else if pr != nil {
+			updateSessionPullRequestTracking(&session, *pr)
+			signal.HasPullRequest = true
+		}
+	}
 	if signal.HasPullRequest {
 		session.Status = state.SessionStatusSuccess
 		session.IncompleteReason = ""
@@ -252,6 +261,48 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 		_ = issueTracker.CommentOnWorkItem(ctx, target.Repo, issue.Number, body)
 	}
 	return session
+}
+
+func reconcileSessionPullRequest(ctx context.Context, issueTracker backend.IssueTracker, session state.Session) (*backend.PullRequest, error) {
+	prManager, ok := issueTracker.(backend.PullRequestManager)
+	if !ok || session.Repo == "" {
+		return nil, nil
+	}
+	head := sessionPullRequestHeadSelector(session)
+	if head == "" {
+		return nil, nil
+	}
+	pr, err := prManager.FindPullRequestForBranch(ctx, session.Repo, head)
+	if err != nil || pr == nil {
+		return pr, err
+	}
+	return prManager.GetPullRequestDetails(ctx, session.Repo, pr.Number)
+}
+
+func updateSessionPullRequestTracking(session *state.Session, pr backend.PullRequest) {
+	session.PullRequestNumber = pr.Number
+	session.PullRequestURL = strings.TrimSpace(pr.URL)
+	session.PullRequestState = strings.TrimSpace(pr.State)
+	session.PullRequestHeadBranch = strings.TrimSpace(session.Branch)
+	if baseRef := strings.TrimSpace(pr.BaseRefName); baseRef != "" {
+		session.PullRequestBaseBranch = baseRef
+	}
+	if pr.MergedAt != nil {
+		session.PullRequestMergedAt = pr.MergedAt.UTC().Format(time.RFC3339)
+	} else {
+		session.PullRequestMergedAt = ""
+	}
+}
+
+func sessionPullRequestHeadSelector(session state.Session) string {
+	branch := strings.TrimSpace(session.Branch)
+	if branch == "" {
+		return ""
+	}
+	if owner := strings.TrimSpace(session.ForkOwner); owner != "" && strings.TrimSpace(session.PushRemote) != "" && strings.TrimSpace(session.PushRemote) != "origin" {
+		return owner + ":" + branch
+	}
+	return branch
 }
 
 func fallbackSessionText(value string, fallback string) string {

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -86,6 +86,58 @@ func TestRunIssueSessionSuccess(t *testing.T) {
 	}
 }
 
+func TestRunIssueSessionReconcilesExistingPullRequestAfterSuccessfulExit(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	baseRunner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"codex --version": "codex 0.114.0",
+			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Vigilante Session Start",
+				Emoji:      "🧢",
+				Percent:    20,
+				ETAMinutes: 25,
+				Items: []string{
+					"Vigilante launched this implementation session in `/tmp/worktree`.",
+					"Branch: `vigilante/issue-7`.",
+					"Current stage: handing the issue off to the configured coding agent (`Codex`) for investigation and implementation.",
+					"Common issue-comment commands: `@vigilanteai resume` retries a blocked session after the underlying problem is fixed, and `@vigilanteai cleanup` removes the local session state for this issue.",
+				},
+				Tagline: "Make it simple, but significant.",
+			}): "ok",
+			preflightPromptCommand("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", "vigilante/issue-7"):                         "baseline ok",
+			issuePromptCommand("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", "vigilante/issue-7"):                             "done",
+			"gh pr list --repo owner/repo --head vigilante/issue-7 --state all --json number,url,state,mergedAt":                                                                 `[{"number":42,"url":"https://github.com/owner/repo/pull/42","state":"OPEN","mergedAt":null}]`,
+			"gh pr view --repo owner/repo 42 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,baseRefName": `{"number":42,"title":"Demo","body":"Closes #7","url":"https://github.com/owner/repo/pull/42","state":"OPEN","mergedAt":null,"labels":[],"isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"","statusCheckRollup":[],"baseRefName":"main"}`,
+		},
+	}
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	env := &environment.Environment{
+		OS: "darwin",
+		Runner: environment.LoggingRunner{
+			Base:      baseRunner,
+			AccessLog: store.AppendAccessLogEntry,
+		},
+	}
+	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
+	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+	if got.Status != state.SessionStatusSuccess {
+		t.Fatalf("unexpected status: %s (expected success after PR reconciliation)", got.Status)
+	}
+	if got.IncompleteReason != "" {
+		t.Fatalf("expected empty IncompleteReason, got %q", got.IncompleteReason)
+	}
+	if got.PullRequestNumber != 42 || got.PullRequestURL != "https://github.com/owner/repo/pull/42" {
+		t.Fatalf("expected reconciled PR tracking, got %#v", got)
+	}
+	if got.PullRequestState != "OPEN" || got.PullRequestBaseBranch != "main" || got.PullRequestHeadBranch != "vigilante/issue-7" {
+		t.Fatalf("expected reconciled PR state, got %#v", got)
+	}
+}
+
 func TestRunIssueSessionSuccessWithPR(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -138,6 +138,68 @@ func TestRunIssueSessionReconcilesExistingPullRequestAfterSuccessfulExit(t *test
 	}
 }
 
+func TestRunIssueSessionLeavesIncompleteWhenBranchLookupFindsClosedPullRequest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	baseRunner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"codex --version": "codex 0.114.0",
+			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Vigilante Session Start",
+				Emoji:      "🧢",
+				Percent:    20,
+				ETAMinutes: 25,
+				Items: []string{
+					"Vigilante launched this implementation session in `/tmp/worktree`.",
+					"Branch: `vigilante/issue-7`.",
+					"Current stage: handing the issue off to the configured coding agent (`Codex`) for investigation and implementation.",
+					"Common issue-comment commands: `@vigilanteai resume` retries a blocked session after the underlying problem is fixed, and `@vigilanteai cleanup` removes the local session state for this issue.",
+				},
+				Tagline: "Make it simple, but significant.",
+			}): "ok",
+			preflightPromptCommand("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", "vigilante/issue-7"):                         "baseline ok",
+			issuePromptCommand("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", "vigilante/issue-7"):                             "done",
+			"gh pr list --repo owner/repo --head vigilante/issue-7 --state all --json number,url,state,mergedAt":                                                                 `[{"number":42,"url":"https://github.com/owner/repo/pull/42","state":"CLOSED","mergedAt":null}]`,
+			"gh pr view --repo owner/repo 42 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,baseRefName": `{"number":42,"title":"Demo","body":"Closes #7","url":"https://github.com/owner/repo/pull/42","state":"CLOSED","mergedAt":null,"labels":[],"isDraft":false,"mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","reviewDecision":"","statusCheckRollup":[],"baseRefName":"main"}`,
+			"git rev-list --count origin/main..HEAD": "1\n",
+			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Incomplete",
+				Emoji:      "⚠️",
+				Percent:    90,
+				ETAMinutes: 5,
+				Items: []string{
+					"The coding agent exited successfully, but no pull request is linked to this branch yet.",
+					"Detected new commits on the issue branch without a PR.",
+					"Next step: create or verify the pull request, then rerun Vigilante.",
+				},
+				Tagline: "Progress saved — not done yet.",
+			}): "ok",
+		},
+	}
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	env := &environment.Environment{
+		OS: "darwin",
+		Runner: environment.LoggingRunner{
+			Base:      baseRunner,
+			AccessLog: store.AppendAccessLogEntry,
+		},
+	}
+	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
+	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+	if got.Status != state.SessionStatusIncomplete {
+		t.Fatalf("unexpected status: %s (expected incomplete when only a closed PR exists)", got.Status)
+	}
+	if got.IncompleteReason != "commits_without_pr" {
+		t.Fatalf("expected commits_without_pr incomplete reason, got %#v", got)
+	}
+	if got.PullRequestNumber != 0 {
+		t.Fatalf("expected closed PR lookup not to mark pull request tracking, got %#v", got)
+	}
+}
+
 func TestRunIssueSessionSuccessWithPR(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))


### PR DESCRIPTION
## Summary
- reconcile a successful issue session against GitHub PR state before classifying it as incomplete
- persist recovered PR metadata onto the session so later scans stay in PR maintenance instead of redispatching implementation
- reconcile the blocked-resume issue-execution path the same way so resumed no-op runs cannot fall back to a false `commits_without_pr` result
- add regression coverage for both the post-run reconciliation path and the resumed issue-execution path

## Validation
- go test ./internal/runner ./internal/app
- go vet ./internal/runner ./internal/app
- go test ./...

Closes #456