### PR TITLE
Guard empty PR reconciliation results

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4473,7 +4473,7 @@ func (a *App) resumeBlockedIssueExecution(ctx context.Context, session *state.Se
 		pr, err := a.loadPullRequestForSession(ctx, *session)
 		if err != nil {
 			a.logger.Warn("resume issue pull request reconciliation failed", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "err", err)
-		} else if pullRequestCountsAsCompletedImplementation(*pr) {
+		} else if pr != nil && pullRequestCountsAsCompletedImplementation(*pr) {
 			updatePullRequestTrackingFromLookup(session, *pr)
 			signal.HasPullRequest = true
 		}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -4354,6 +4354,74 @@ func TestResumeBlockedSessionLeavesIncompleteWhenBranchLookupFindsClosedPullRequ
 	}
 }
 
+func TestResumeBlockedSessionLeavesIncompleteWhenBranchLookupFindsNoPullRequest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	recoveredComment := ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Recovered",
+		Emoji:      "🫡",
+		Percent:    92,
+		ETAMinutes: 5,
+		Items: []string{
+			"The previous `provider_auth` block was cleared for `vigilante/issue-1`.",
+			"Resume source: `comment`.",
+			"Next step: Vigilante resumed `issue_execution` successfully.",
+		},
+		Tagline: "Back on the wire.",
+	})
+	session := state.Session{
+		RepoPath:       repoPath,
+		Repo:           "owner/repo",
+		Provider:       "codex",
+		IssueNumber:    1,
+		IssueTitle:     "first",
+		IssueURL:       "https://github.com/owner/repo/issues/1",
+		Branch:         "vigilante/issue-1",
+		WorktreePath:   worktreePath,
+		Status:         state.SessionStatusBlocked,
+		BlockedStage:   "issue_execution",
+		BlockedReason:  state.BlockedReason{Kind: "provider_auth", Operation: "codex exec", Summary: "session expired", Detail: "session expired"},
+		ResumeRequired: true,
+		ResumeHint:     "vigilante resume --repo owner/repo --issue 1",
+	}
+
+	app.env.Runner = testutil.FakeRunner{
+		LookPaths: map[string]string{"codex": "/usr/bin/codex"},
+		Outputs: map[string]string{
+			"codex --version": "codex 1.0.0",
+			issuePromptCommand(worktreePath, "owner/repo", repoPath, 1, "first", "https://github.com/owner/repo/issues/1", "vigilante/issue-1"): "done",
+			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt":                                `[]`,
+			"gh issue comment --repo owner/repo 1 --body " + recoveredComment:                                                                   "ok",
+			"git rev-list --count origin/main..HEAD":                                                                                            "1\n",
+			"git status --porcelain":                                                                                                            "",
+		},
+	}
+
+	if err := app.resumeBlockedSession(context.Background(), &session, "comment"); err != nil {
+		t.Fatal(err)
+	}
+	if session.Status != state.SessionStatusIncomplete {
+		t.Fatalf("expected resumed session to stay incomplete when branch lookup finds no PR: %#v", session)
+	}
+	if session.IncompleteReason != "commits_without_pr" {
+		t.Fatalf("expected commits_without_pr when branch lookup finds no PR: %#v", session)
+	}
+	if session.PullRequestNumber != 0 {
+		t.Fatalf("expected empty PR tracking when branch lookup finds no PR: %#v", session)
+	}
+}
+
 func TestScanOnceProcessesGitHubCommentCleanupRequest(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -233,7 +233,7 @@ func RunIssueSession(ctx context.Context, env *environment.Environment, store *s
 		pr, err := reconcileSessionPullRequest(ctx, issueTracker, session)
 		if err != nil {
 			appendSessionLog(logPath, "pull request reconciliation failed", session, err.Error())
-		} else if pullRequestCountsAsCompletedImplementation(*pr) {
+		} else if pr != nil && pullRequestCountsAsCompletedImplementation(*pr) {
 			updateSessionPullRequestTracking(&session, *pr)
 			signal.HasPullRequest = true
 		}
@@ -297,7 +297,6 @@ func updateSessionPullRequestTracking(session *state.Session, pr backend.PullReq
 func pullRequestCountsAsCompletedImplementation(pr backend.PullRequest) bool {
 	return strings.EqualFold(strings.TrimSpace(pr.State), "OPEN") || pr.MergedAt != nil
 }
-
 func sessionPullRequestHeadSelector(session state.Session) string {
 	branch := strings.TrimSpace(session.Branch)
 	if branch == "" {

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -200,6 +200,67 @@ func TestRunIssueSessionLeavesIncompleteWhenBranchLookupFindsClosedPullRequest(t
 	}
 }
 
+func TestRunIssueSessionLeavesIncompleteWhenBranchLookupFindsNoPullRequest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	baseRunner := testutil.FakeRunner{
+		Outputs: map[string]string{
+			"codex --version": "codex 0.114.0",
+			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Vigilante Session Start",
+				Emoji:      "🧢",
+				Percent:    20,
+				ETAMinutes: 25,
+				Items: []string{
+					"Vigilante launched this implementation session in `/tmp/worktree`.",
+					"Branch: `vigilante/issue-7`.",
+					"Current stage: handing the issue off to the configured coding agent (`Codex`) for investigation and implementation.",
+					"Common issue-comment commands: `@vigilanteai resume` retries a blocked session after the underlying problem is fixed, and `@vigilanteai cleanup` removes the local session state for this issue.",
+				},
+				Tagline: "Make it simple, but significant.",
+			}): "ok",
+			preflightPromptCommand("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", "vigilante/issue-7"): "baseline ok",
+			issuePromptCommand("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", "vigilante/issue-7"):     "done",
+			"gh pr list --repo owner/repo --head vigilante/issue-7 --state all --json number,url,state,mergedAt":                                         `[]`,
+			"git rev-list --count origin/main..HEAD": "1\n",
+			"gh issue comment --repo owner/repo 7 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+				Stage:      "Incomplete",
+				Emoji:      "⚠️",
+				Percent:    90,
+				ETAMinutes: 5,
+				Items: []string{
+					"The coding agent exited successfully, but no pull request is linked to this branch yet.",
+					"Detected new commits on the issue branch without a PR.",
+					"Next step: create or verify the pull request, then rerun Vigilante.",
+				},
+				Tagline: "Progress saved — not done yet.",
+			}): "ok",
+		},
+	}
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	env := &environment.Environment{
+		OS: "darwin",
+		Runner: environment.LoggingRunner{
+			Base:      baseRunner,
+			AccessLog: store.AppendAccessLogEntry,
+		},
+	}
+	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
+	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
+	if got.Status != state.SessionStatusIncomplete {
+		t.Fatalf("unexpected status: %s (expected incomplete when branch lookup finds no PR)", got.Status)
+	}
+	if got.IncompleteReason != "commits_without_pr" {
+		t.Fatalf("expected commits_without_pr incomplete reason, got %#v", got)
+	}
+	if got.PullRequestNumber != 0 {
+		t.Fatalf("expected no pull request tracking when branch lookup is empty, got %#v", got)
+	}
+}
+
 func TestRunIssueSessionSuccessWithPR(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))


### PR DESCRIPTION
## Summary
- guard the post-run and resume PR reconciliation paths when branch lookup returns no PR
- keep true `commits_without_pr` sessions incomplete without panicking
- add regression tests for empty lookup results in both runner and app reconciliation flows

## Validation
- go test ./internal/runner ./internal/app
- go vet ./internal/runner ./internal/app
- go test ./...

Closes #456