### PR TITLE
Update README.md to align with website positioning and structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,49 @@
 [![License](https://img.shields.io/github/license/aliengiraffe/vigilante)](https://github.com/aliengiraffe/vigilante/blob/main/LICENSE)
 [![Release Workflow](https://img.shields.io/github/actions/workflow/status/aliengiraffe/vigilante/release.yml?label=release)](https://github.com/aliengiraffe/vigilante/actions/workflows/release.yml)
 
-`vigilante` is a local control plane for autonomous software delivery. It watches repositories, selects eligible work items, prepares isolated git worktrees, launches a supported coding-agent CLI, and keeps the issue tracker updated while the work moves toward a pull request.
+`vigilante` is a sandbox-first orchestration layer for coding agents. It treats agents as untrusted by default, isolates every issue in its own git worktree, enforces operator-controlled workflow boundaries, and drives work from GitHub issue to pull request with an audit trail.
 
-It is the orchestration layer around agents such as `codex`, `claude`, and `gemini`, not the model itself. Vigilante owns scheduling, worktree isolation, backend coordination, and recovery so a repository checkout behaves like a controlled worker instead of a loose collection of scripts.
+Vigilante is the control plane around tools such as `codex`, `claude`, and `gemini`, not the model itself. It owns issue selection, worktree setup, lifecycle management, recovery, and guardrails so a repository checkout behaves like a controlled worker instead of a loose collection of scripts.
 
-[Docs](DOCS.md) · [Closed Issues](https://github.com/aliengiraffe/vigilante/issues?q=is%3Aissue%20state%3Aclosed) · [Releases](https://github.com/aliengiraffe/vigilante/releases) · [Contributing](CONTRIBUTING.md)
+[Docs](DOCS.md) · [Sandbox](SANDBOX.md) · [Closed Issues](https://github.com/aliengiraffe/vigilante/issues?q=is%3Aissue%20state%3Aclosed) · [Releases](https://github.com/aliengiraffe/vigilante/releases) · [Contributing](CONTRIBUTING.md)
 
-Start here: install `vigilante`, run `vigilante setup`, then clone and auto-register a repo with `vigilante clone <repo>` or register an existing checkout with `vigilante watch /path/to/repo`.
+## Why Vigilante Exists
 
-## Install
+Coding agents need broad file, shell, network, and GitHub access to be useful. That is also what makes them risky.
 
-Install with Homebrew:
+Vigilante narrows that risk by making the orchestrator, not the agent, responsible for policy:
+
+- one isolated git worktree per issue
+- issue-tracker-driven execution instead of ad hoc prompts
+- explicit lifecycle controls for start, resume, redispatch, and cleanup
+- scoped execution with optional Docker sandboxing
+- issue and PR updates that leave an operator-visible trail
+
+## How It Works
+
+Vigilante keeps the path from issue to PR short and deterministic:
+
+1. Watch a local repository and connect it to GitHub.
+2. Select eligible issues using labels, assignees, and concurrency rules.
+3. Create a fresh branch in an isolated git worktree for that issue.
+4. Launch a supported coding-agent CLI with repository-aware instructions.
+5. Track progress, post issue comments, open or monitor the pull request, and recover or clean up sessions when needed.
+
+GitHub is the fully implemented backend today. The backend interfaces are separated so issue tracking, pull requests, labels, and rate limits do not have to be hard-wired into the core orchestration loop.
+
+## Guardrails And Capabilities
+
+- **Worktree isolation.** Every issue gets its own branch and worktree so the main checkout stays untouched.
+- **Operator-driven workflow.** Issues are the queue, comments are the control surface, and PRs remain the review boundary.
+- **Provider-neutral execution.** Use supported coding-agent CLIs such as `codex`, `claude`, or `gemini`.
+- **Recovery built in.** Resume, redispatch, recreate, and cleanup flows are part of the lifecycle instead of afterthought scripts.
+- **Auditability.** Vigilante keeps local session state and posts progress back to the issue tracker.
+- **Optional sandbox mode.** Run sessions inside isolated Docker containers for a second isolation layer beyond git worktrees.
+- **Package hardening checks.** Pull requests that change `package.json` can trigger deterministic dependency and workflow checks for JavaScript and TypeScript repositories.
+
+## Quick Start
+
+Install Vigilante:
 
 ```sh
 brew install vigilante
@@ -29,21 +61,25 @@ brew install vigilante
 Requirements:
 
 - `git`
-- `gh` authenticated against the GitHub account Vigilante should operate with
+- `gh` authenticated for the GitHub account Vigilante should operate with
 - one supported coding-agent CLI installed locally: `codex`, `claude`, or `gemini`
 
-Recommended machine setup:
+Prepare the machine:
 
 ```sh
 vigilante setup --provider codex
 ```
 
-## Quick Start
-
-Register a repository and let Vigilante manage it:
+Register a repository:
 
 ```sh
-vigilante clone git@github.com:owner/repo.git
+vigilante watch ~/path/to/repo
+```
+
+Run the watcher once in the foreground:
+
+```sh
+vigilante daemon run --once
 ```
 
 Useful follow-up commands:
@@ -51,162 +87,69 @@ Useful follow-up commands:
 ```sh
 vigilante list
 vigilante status
+vigilante logs
 vigilante service restart
-vigilante daemon run --once
 ```
 
-Typical first-run flow:
+If you want Vigilante to clone and register the repository in one step:
 
 ```sh
-brew install vigilante
-vigilante setup --provider codex
-vigilante clone git@github.com:owner/hello-world-app.git
-vigilante daemon run --once
+vigilante clone git@github.com:owner/repo.git
 ```
-
-## What Vigilante Does
-
-- Treats project-management work items as the queue for autonomous software delivery.
-- Selects eligible issues using repository configuration, assignees, labels, and concurrency limits.
-- Creates one isolated git worktree per issue so the main checkout stays stable.
-- Chooses the right execution skill from repository shape and local context.
-- Launches a supported coding-agent CLI under a consistent lifecycle.
-- Tracks progress, failures, and pull-request state through the issue tracker and local session state.
-- Recovers, resumes, redispatches, and cleans up runs without duplicating work.
-
-## How It Works
-
-At a high level, Vigilante runs this loop for each watched repository:
-
-1. Resolve the repository and discover its remote.
-2. Read the configured issue-tracking backend and fetch open work items.
-3. Filter to issues that are eligible and not already being handled.
-4. Create an isolated worktree and issue branch.
-5. Launch the selected coding-agent CLI with the repo-aware implementation skill.
-6. Track progress locally and post execution updates back to the issue tracker.
-7. Monitor the linked pull request and clean up or recover the session as needed.
-
-GitHub is the only fully implemented backend today. The architecture already separates issue tracking, pull requests, labels, and rate limits so backends such as Linear and Jira can be added without rewriting the orchestration loop.
-
-## Package Hardening
-
-Vigilante includes a deterministic, code-driven package hardening scan for pull requests that modify `package.json` files. When a PR branch is pushed, Vigilante checks for lockfile presence, runs `npm audit`, flags non-exact dependency ranges, and verifies that CI workflows use deterministic install commands. If issues are found, Vigilante posts a structured comment on the PR with findings and applies the `vigilante:flagged-security-review` label. The comment includes an **implement fixes** checkbox that triggers an automated remediation session when checked.
-
-> **Note:** Package hardening currently applies only to repositories with a supported JavaScript/TypeScript/Node.js tech stack. Support for additional ecosystems is expected to expand over time.
-
-The feature is enabled by default and can be toggled with the `package_hardening_enabled` field in `config.json`. For operational details including trigger conditions, checks performed, and remediation flow, see [DOCS.md](DOCS.md).
 
 ## Sandbox Mode
 
-Sandbox mode runs each coding-agent session inside an isolated Docker container instead of directly on the host. The container receives a bind-mounted repository worktree, scoped credentials, and a `gh` mirror binary that routes all GitHub CLI commands through a Vigilante reverse proxy enforcing repository-level access control.
+Sandbox mode adds a Docker isolation layer on top of worktree isolation:
 
-Enable sandbox mode globally in `~/.vigilante/config.json`:
+- the coding agent runs inside an isolated container
+- the assigned repository worktree is mounted into that container
+- GitHub access is mediated by Vigilante rather than handed over as broad host access
+- session cleanup is tied to the issue lifecycle
+
+Enable sandbox mode for a watched repository:
+
+```sh
+vigilante watch --sandbox ~/path/to/repo
+```
+
+Or set it globally in `~/.vigilante/config.json`:
 
 ```json
 {
   "sandbox_enabled": true,
-  "sandbox_image": "vigilante-sandbox:latest",
-  "sandbox_memory_limit": "8g",
-  "sandbox_cpus": "4"
+  "sandbox_image": "vigilante-sandbox:latest"
 }
 ```
 
-Or per repository when adding a watch target:
-
-```sh
-vigilante watch --sandbox ~/my-repo
-```
-
-What sandbox mode provides:
-
-- **Container isolation.** The coding agent runs inside a Docker container with only the assigned repository mounted. Host files, credentials, and processes are not accessible.
-- **Scoped GitHub access.** A reverse proxy intercepts every `gh` command from the container and rejects operations targeting repositories outside the assigned scope.
-- **Short-lived credentials.** Each session receives an HMAC-signed token with a TTL and an ephemeral SSH deploy key. Both are revoked at teardown.
-- **Docker-in-Docker.** The container supports starting local service dependencies (databases, caches) via `docker compose` without escaping the sandbox boundary.
-- **Guaranteed teardown.** Containers, credentials, and proxy sessions are cleaned up whether the agent completes, fails, or times out. A stale session reconciler runs on daemon startup to handle orphaned containers.
-
-Requirements for sandbox mode:
-
-- Docker (or a compatible container runtime) available on the host
-- The `vigilante-sandbox` base image (see below)
-
-### Building the Sandbox Image
-
-Build the image locally:
+Build the default sandbox image locally:
 
 ```sh
 docker build -t vigilante-sandbox:latest .
 ```
 
-Pre-built images are published to GitHub Container Registry on every release and main push:
-
-```sh
-docker pull ghcr.io/aliengiraffe/vigilante-sandbox:latest
-```
-
-For the full architecture and security model, see [SANDBOX.md](SANDBOX.md).
+For the deeper architecture, credential model, and design notes, see [SANDBOX.md](SANDBOX.md).
 
 ## Key Commands
 
-- `vigilante setup`: verify dependencies, install bundled skills, and install the managed service
-- `vigilante clone <repo> [<path>]`: clone a repository with `git clone` semantics and auto-add it to watch targets
-- `vigilante watch <path>`: register a local repository for issue monitoring
+- `vigilante setup`: verify local prerequisites and prepare the machine
+- `vigilante clone <repo> [<path>]`: clone a repository and register it as a watch target
+- `vigilante watch <path>`: register an existing local repository
 - `vigilante list`: show watched repositories
-- `vigilante status`: show service health, watched repos, active sessions, and rate-limit state
-- `vigilante logs`: inspect local daemon and per-issue logs
-- `vigilante cleanup`, `vigilante redispatch`, `vigilante resume`: recover or restart stuck work safely
+- `vigilante status`: show watched repos, service health, and running sessions
+- `vigilante logs`: inspect daemon and per-issue logs
+- `vigilante cleanup`, `vigilante redispatch`, `vigilante recreate`, `vigilante resume`: recover stuck or failed work safely
 - `vigilante daemon run`: run the watcher loop in the foreground
-
-### Fork Mode
-
-Use fork mode when the authenticated GitHub identity should open pull requests from a fork instead of pushing issue branches directly to the upstream watched repository.
-
-```sh
-vigilante watch --fork ~/hello-world-app
-```
-
-What changes in fork mode:
-
-- Vigilante uses `gh api user` to resolve the authenticated GitHub login when `--fork-owner` is not set.
-- It creates or reuses `<fork-owner>/<repo>` through the GitHub API and verifies that the existing repository is actually a fork of the watched upstream repository.
-- It adds or updates a local git remote named `fork` that points at the fork repository.
-- Issue worktrees still use the upstream repository for issue context, base branch selection, and pull request target selection.
-- Coding agents still use the normal issue-implementation skill flow, but pushes go to the `fork` remote and pull requests are opened back to the upstream repository.
-
-Use an explicit owner when the fork should live under a bot or organization account:
-
-```sh
-vigilante watch --fork --fork-owner my-bot-org ~/hello-world-app
-```
-
-Operational notes:
-
-- `--fork-owner` requires `--fork`.
-- The authenticated `gh` account must be able to create or access the selected fork and open a pull request back to the upstream repository.
-- Existing branch tracking stays deterministic inside the worktree: the issue branch pushes to `fork`, while the pull request base remains the watched repository's configured base branch.
-
-For command details and full flags, see [DOCS.md](DOCS.md).
-
-## Architecture At A Glance
-
-Vigilante keeps orchestration backend-neutral through a small set of interfaces:
-
-- `IssueTracker`: work item listing, details, comments, and operator commands
-- `PullRequestManager`: PR discovery, merge state, and branch lifecycle
-- `LabelManager`: repository and issue label synchronization
-- `RateLimiter`: optional API quota awareness
-
-That lets a watch target mix concerns such as issue tracking on one system and pull requests on another while keeping the execution loop stable.
+- `vigilante service restart`: restart the installed background service
+- `vigilante issue create`: turn a prompt into an implementation-ready GitHub issue
 
 ## More Docs
 
-The full reference moved to [DOCS.md](DOCS.md), including:
+The detailed reference lives in [DOCS.md](DOCS.md), including:
 
-- installation details and development mode
-- full command reference and expected behaviors
-- local state layout and logs
-- issue selection, labeling, and pull-request maintenance
-- package hardening trigger conditions, checks, remediation flow, and config toggle
-- headless agent execution contract
-- GitHub integration, worktree strategy, and service behavior
-- CI, releases, and implementation status notes
+- command reference and operational behavior
+- watch target configuration, issue selection, and backend support
+- fork mode and branch strategy
+- local state, logs, and recovery flows
+- package hardening behavior and configuration
+- provider execution contract and repository-aware skills
+- GitHub integration, PR lifecycle, and service behavior


### PR DESCRIPTION
## Summary
- rewrite the top-level README around sandbox-first orchestration, guardrails, and issue-to-PR workflow
- keep the CLI/service and sandbox messaging aligned with current product behavior instead of copying website simplifications verbatim
- trim reference-heavy sections and point readers to deeper docs

## Validation
- manually compared `README.md` against `website/src/components/*`
- verified current command surface with `vigilante --help`, `vigilante watch --help`, and `vigilante setup --help`
- checked local markdown link targets referenced by the updated README

Closes #455