### PR TITLE
Update README to align with website positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,57 @@
 [![License](https://img.shields.io/github/license/aliengiraffe/vigilante)](https://github.com/aliengiraffe/vigilante/blob/main/LICENSE)
 [![Release Workflow](https://img.shields.io/github/actions/workflow/status/aliengiraffe/vigilante/release.yml?label=release)](https://github.com/aliengiraffe/vigilante/actions/workflows/release.yml)
 
-`vigilante` is a local control plane for autonomous software delivery. It watches repositories, selects eligible work items, prepares isolated git worktrees, launches a supported coding-agent CLI, and keeps the issue tracker updated while the work moves toward a pull request.
+`vigilante` is a sandbox-first orchestration layer for coding agents.
 
-It is the orchestration layer around agents such as `codex`, `claude`, and `gemini`, not the model itself. Vigilante owns scheduling, worktree isolation, backend coordination, and recovery so a repository checkout behaves like a controlled worker instead of a loose collection of scripts.
+Treat the model as untrusted by default. Vigilante is the control plane that turns GitHub issues into a guarded issue-to-PR pipeline: one git worktree per task, deterministic lifecycle management, scoped execution, and a durable operator trail through issue comments, session state, and pull requests.
 
-[Docs](DOCS.md) · [Closed Issues](https://github.com/aliengiraffe/vigilante/issues?q=is%3Aissue%20state%3Aclosed) · [Releases](https://github.com/aliengiraffe/vigilante/releases) · [Contributing](CONTRIBUTING.md)
+It is not the model itself. Vigilante schedules work, prepares isolated worktrees, launches a supported coding-agent CLI, tracks progress, and recovers or cleans up stalled sessions so a repository behaves like a controlled worker instead of a loose collection of scripts.
 
-Start here: install `vigilante`, run `vigilante setup`, then clone and auto-register a repo with `vigilante clone <repo>` or register an existing checkout with `vigilante watch /path/to/repo`.
+[Docs](DOCS.md) · [Sandbox Design](SANDBOX.md) · [Closed Issues](https://github.com/aliengiraffe/vigilante/issues?q=is%3Aissue%20state%3Aclosed) · [Releases](https://github.com/aliengiraffe/vigilante/releases) · [Contributing](CONTRIBUTING.md)
+
+## Why Vigilante Exists
+
+Coding agents need broad tool access to be useful. That also means they can read the wrong files, use the wrong credentials, or leave behind hard-to-audit state if you run them with ambient access.
+
+Vigilante reduces that risk by making the orchestrator responsible for enforcement:
+
+- one isolated git worktree per issue
+- issue-driven execution with progress reported back to GitHub
+- repository-aware implementation skills selected from local context
+- local session tracking for cleanup, resume, redispatch, and recovery
+- optional package-hardening checks for supported Node.js repositories
+
+## How It Works
+
+Vigilante keeps the flow short and explicit:
+
+1. Watch a local repository tied to a GitHub remote.
+2. Read open issues and select only eligible work.
+3. Create a fresh git worktree and issue branch.
+4. Launch a supported coding-agent CLI in that worktree.
+5. Track progress through issue comments, local session state, and PR status.
+6. Clean up or recover the run without duplicating work.
+
+GitHub is the only fully implemented issue-tracking backend today. The backend interfaces are designed so support for systems such as Linear and Jira can be added without rewriting the orchestration loop.
+
+## Guardrails That Matter
+
+- **Worktree isolation.** Every issue gets its own branch and worktree so the main checkout stays untouched.
+- **Operator-visible lifecycle.** Start, progress, failure, and PR state are reflected through GitHub comments and local Vigilante state.
+- **Provider-neutral orchestration.** Works with supported headless coding-agent CLIs including `codex`, `claude`, and `gemini`.
+- **Recovery tooling.** `resume`, `redispatch`, and `cleanup` are first-class flows, not ad hoc scripts.
+- **Rate-limit awareness.** Vigilante monitors GitHub API budget and delays additional work when quota gets tight.
+
+## Sandbox Positioning
+
+Vigilante already isolates work at the git-worktree layer today. `SANDBOX.md` describes the next isolation layer: running each coding-agent session inside a repo-scoped Docker container with proxy-mediated GitHub access and short-lived credentials.
+
+In other words:
+
+- **Current state:** isolated worktrees, local session tracking, host-executed agent CLI
+- **Planned sandbox mode:** containerized execution, stronger credential scoping, repo-bounded GitHub proxying
+
+See [SANDBOX.md](SANDBOX.md) for the design and current status.
 
 ## Install
 
@@ -32,130 +76,51 @@ Requirements:
 - `gh` authenticated against the GitHub account Vigilante should operate with
 - one supported coding-agent CLI installed locally: `codex`, `claude`, or `gemini`
 
-Recommended machine setup:
+Bootstrap the local machine and install the managed service:
 
 ```sh
-vigilante setup --provider codex
+vigilante setup -d --provider codex
 ```
 
 ## Quick Start
 
-Register a repository and let Vigilante manage it:
+Register a repository and let Vigilante manage the issue-to-PR loop:
 
 ```sh
-vigilante clone git@github.com:owner/repo.git
-```
-
-Useful follow-up commands:
-
-```sh
-vigilante list
-vigilante status
-vigilante service restart
-vigilante daemon run --once
+vigilante watch ~/path/to/repo
 ```
 
 Typical first-run flow:
 
 ```sh
 brew install vigilante
-vigilante setup --provider codex
-vigilante clone git@github.com:owner/hello-world-app.git
+vigilante setup -d --provider codex
+vigilante watch ~/hello-world-app
 vigilante daemon run --once
 ```
 
-## What Vigilante Does
-
-- Treats project-management work items as the queue for autonomous software delivery.
-- Selects eligible issues using repository configuration, assignees, labels, and concurrency limits.
-- Creates one isolated git worktree per issue so the main checkout stays stable.
-- Chooses the right execution skill from repository shape and local context.
-- Launches a supported coding-agent CLI under a consistent lifecycle.
-- Tracks progress, failures, and pull-request state through the issue tracker and local session state.
-- Recovers, resumes, redispatches, and cleans up runs without duplicating work.
-
-## How It Works
-
-At a high level, Vigilante runs this loop for each watched repository:
-
-1. Resolve the repository and discover its remote.
-2. Read the configured issue-tracking backend and fetch open work items.
-3. Filter to issues that are eligible and not already being handled.
-4. Create an isolated worktree and issue branch.
-5. Launch the selected coding-agent CLI with the repo-aware implementation skill.
-6. Track progress locally and post execution updates back to the issue tracker.
-7. Monitor the linked pull request and clean up or recover the session as needed.
-
-GitHub is the only fully implemented backend today. The architecture already separates issue tracking, pull requests, labels, and rate limits so backends such as Linear and Jira can be added without rewriting the orchestration loop.
-
-## Package Hardening
-
-Vigilante includes a deterministic, code-driven package hardening scan for pull requests that modify `package.json` files. When a PR branch is pushed, Vigilante checks for lockfile presence, runs `npm audit`, flags non-exact dependency ranges, and verifies that CI workflows use deterministic install commands. If issues are found, Vigilante posts a structured comment on the PR with findings and applies the `vigilante:flagged-security-review` label. The comment includes an **implement fixes** checkbox that triggers an automated remediation session when checked.
-
-> **Note:** Package hardening currently applies only to repositories with a supported JavaScript/TypeScript/Node.js tech stack. Support for additional ecosystems is expected to expand over time.
-
-The feature is enabled by default and can be toggled with the `package_hardening_enabled` field in `config.json`. For operational details including trigger conditions, checks performed, and remediation flow, see [DOCS.md](DOCS.md).
-
-## Sandbox Mode
-
-Sandbox mode runs each coding-agent session inside an isolated Docker container instead of directly on the host. The container receives a bind-mounted repository worktree, scoped credentials, and a `gh` mirror binary that routes all GitHub CLI commands through a Vigilante reverse proxy enforcing repository-level access control.
-
-Enable sandbox mode globally in `~/.vigilante/config.json`:
-
-```json
-{
-  "sandbox_enabled": true,
-  "sandbox_image": "vigilante-sandbox:latest",
-  "sandbox_memory_limit": "8g",
-  "sandbox_cpus": "4"
-}
-```
-
-Or per repository when adding a watch target:
+Useful follow-up commands:
 
 ```sh
-vigilante watch --sandbox ~/my-repo
+vigilante list
+vigilante list --running
+vigilante status
+vigilante logs
+vigilante service restart
 ```
-
-What sandbox mode provides:
-
-- **Container isolation.** The coding agent runs inside a Docker container with only the assigned repository mounted. Host files, credentials, and processes are not accessible.
-- **Scoped GitHub access.** A reverse proxy intercepts every `gh` command from the container and rejects operations targeting repositories outside the assigned scope.
-- **Short-lived credentials.** Each session receives an HMAC-signed token with a TTL and an ephemeral SSH deploy key. Both are revoked at teardown.
-- **Docker-in-Docker.** The container supports starting local service dependencies (databases, caches) via `docker compose` without escaping the sandbox boundary.
-- **Guaranteed teardown.** Containers, credentials, and proxy sessions are cleaned up whether the agent completes, fails, or times out. A stale session reconciler runs on daemon startup to handle orphaned containers.
-
-Requirements for sandbox mode:
-
-- Docker (or a compatible container runtime) available on the host
-- The `vigilante-sandbox` base image (see below)
-
-### Building the Sandbox Image
-
-Build the image locally:
-
-```sh
-docker build -t vigilante-sandbox:latest .
-```
-
-Pre-built images are published to GitHub Container Registry on every release and main push:
-
-```sh
-docker pull ghcr.io/aliengiraffe/vigilante-sandbox:latest
-```
-
-For the full architecture and security model, see [SANDBOX.md](SANDBOX.md).
 
 ## Key Commands
 
-- `vigilante setup`: verify dependencies, install bundled skills, and install the managed service
-- `vigilante clone <repo> [<path>]`: clone a repository with `git clone` semantics and auto-add it to watch targets
+- `vigilante setup`: verify dependencies, install bundled skills, and install or refresh the managed service
 - `vigilante watch <path>`: register a local repository for issue monitoring
-- `vigilante list`: show watched repositories
-- `vigilante status`: show service health, watched repos, active sessions, and rate-limit state
-- `vigilante logs`: inspect local daemon and per-issue logs
-- `vigilante cleanup`, `vigilante redispatch`, `vigilante resume`: recover or restart stuck work safely
+- `vigilante clone <repo> [<path>]`: clone a repository and auto-add it to the watch list
+- `vigilante list`: show watched repositories and optionally active runs
+- `vigilante status`: show service health, watched repos, sessions, and rate-limit state
+- `vigilante logs`: inspect daemon and per-issue logs
+- `vigilante resume`, `vigilante redispatch`, `vigilante cleanup`: recover or restart stuck work safely
 - `vigilante daemon run`: run the watcher loop in the foreground
+
+## Additional Capabilities
 
 ### Fork Mode
 
@@ -165,48 +130,22 @@ Use fork mode when the authenticated GitHub identity should open pull requests f
 vigilante watch --fork ~/hello-world-app
 ```
 
-What changes in fork mode:
+Use `--fork-owner` with `--fork` when the fork should live under a bot or organization account. For the full behavior, see [DOCS.md](DOCS.md).
 
-- Vigilante uses `gh api user` to resolve the authenticated GitHub login when `--fork-owner` is not set.
-- It creates or reuses `<fork-owner>/<repo>` through the GitHub API and verifies that the existing repository is actually a fork of the watched upstream repository.
-- It adds or updates a local git remote named `fork` that points at the fork repository.
-- Issue worktrees still use the upstream repository for issue context, base branch selection, and pull request target selection.
-- Coding agents still use the normal issue-implementation skill flow, but pushes go to the `fork` remote and pull requests are opened back to the upstream repository.
+### Package Hardening
 
-Use an explicit owner when the fork should live under a bot or organization account:
+Vigilante includes a deterministic package-hardening scan for watched repositories classified with the `nodejs` tech stack. It checks lockfile presence, audits npm dependencies when applicable, and reviews CI install posture without relying on an LLM.
 
-```sh
-vigilante watch --fork --fork-owner my-bot-org ~/hello-world-app
-```
-
-Operational notes:
-
-- `--fork-owner` requires `--fork`.
-- The authenticated `gh` account must be able to create or access the selected fork and open a pull request back to the upstream repository.
-- Existing branch tracking stays deterministic inside the worktree: the issue branch pushes to `fork`, while the pull request base remains the watched repository's configured base branch.
-
-For command details and full flags, see [DOCS.md](DOCS.md).
-
-## Architecture At A Glance
-
-Vigilante keeps orchestration backend-neutral through a small set of interfaces:
-
-- `IssueTracker`: work item listing, details, comments, and operator commands
-- `PullRequestManager`: PR discovery, merge state, and branch lifecycle
-- `LabelManager`: repository and issue label synchronization
-- `RateLimiter`: optional API quota awareness
-
-That lets a watch target mix concerns such as issue tracking on one system and pull requests on another while keeping the execution loop stable.
+For trigger conditions, findings, and remediation flow, see [DOCS.md](DOCS.md#package-hardening).
 
 ## More Docs
 
-The full reference moved to [DOCS.md](DOCS.md), including:
+The full reference lives in [DOCS.md](DOCS.md), including:
 
 - installation details and development mode
 - full command reference and expected behaviors
-- local state layout and logs
-- issue selection, labeling, and pull-request maintenance
-- package hardening trigger conditions, checks, remediation flow, and config toggle
-- headless agent execution contract
+- backend architecture and current implementation status
+- local state layout, logs, and recovery workflows
+- package hardening behavior and config
 - GitHub integration, worktree strategy, and service behavior
-- CI, releases, and implementation status notes
+- CI, releases, and implementation notes


### PR DESCRIPTION
## Summary
- rewrite the top-level README around the website's sandbox-first positioning and issue-to-PR workflow
- shorten the README structure while keeping install, quick start, and docs entry points easy to find
- make sandbox wording accurate by distinguishing current worktree isolation from the planned containerized sandbox design

## Validation
- manually reviewed `README.md` against `website/src/components/`, `DOCS.md`, and `SANDBOX.md`
- manually verified local docs links resolve
- `markdown-link-check` was not available in this environment

Closes #460