### PR TITLE
Stop redispatch loop after blocked PR-maintenance session cleanup

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4613,6 +4613,7 @@ func (a *App) cleanupBlockedSessionForInactivity(ctx context.Context, session *s
 	now := a.clock().Format(time.RFC3339)
 	session.LastCleanupSource = "blocked_inactivity_timeout"
 	previousStatus := session.Status
+	previousStage := strings.TrimSpace(session.BlockedStage)
 	if err := worktree.CleanupIssueArtifacts(ctx, a.env.Runner, session.RepoPath, session.WorktreePath, session.Branch); err != nil {
 		session.CleanupError = err.Error()
 		session.LastError = fmt.Sprintf("blocked session exceeded inactivity timeout (%s) but cleanup failed: %s", timeout, err)
@@ -4621,9 +4622,22 @@ func (a *App) cleanupBlockedSessionForInactivity(ctx context.Context, session *s
 		return err
 	}
 
+	// Best-effort refresh of PR tracking before transitioning so SelectIssues can tell
+	// whether the associated PR is still open when deciding future redispatch.
+	if a.prManager != nil && strings.TrimSpace(session.Branch) != "" {
+		if pr, err := a.prManager.FindPullRequestForBranch(ctx, session.Repo, pullRequestHeadSelector(*session)); err != nil {
+			a.logger.Warn("blocked session inactivity cleanup: pull request refresh failed", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "err", err)
+		} else if pr != nil {
+			updatePullRequestTrackingFromLookup(session, *pr)
+		}
+	}
+
 	session.Status = state.SessionStatusFailed
 	session.ProcessID = 0
 	session.BlockedAt = ""
+	if previousStage != "" {
+		session.LastBlockedStage = previousStage
+	}
 	session.BlockedStage = ""
 	session.BlockedReason = state.BlockedReason{}
 	session.RetryPolicy = ""
@@ -4636,7 +4650,7 @@ func (a *App) cleanupBlockedSessionForInactivity(ctx context.Context, session *s
 	session.UpdatedAt = now
 	session.LastError = fmt.Sprintf("blocked session cleaned up after %s of inactivity", timeout)
 	a.emitSessionTransition(previousStatus, *session, "blocked_inactivity_timeout")
-	a.logger.Info("blocked session inactivity cleanup complete", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "timeout", timeout)
+	a.logger.Info("blocked session inactivity cleanup complete", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "timeout", timeout, "last_blocked_stage", previousStage)
 	return nil
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -4864,6 +4864,134 @@ func TestShouldAutoRecoverBlockedSession(t *testing.T) {
 	}
 }
 
+func TestCleanupBlockedSessionForInactivityPreservesLastBlockedStageAndRefreshesPRState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 4, 22, 18, 30, 0, 0, time.UTC)
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.clock = func() time.Time { return now }
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"git worktree prune":                                         "ok",
+			"git worktree remove --force " + worktreePath:                "ok",
+			"git worktree list --porcelain":                              "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": "ok",
+			"git branch -D vigilante/issue-1":                            "Deleted branch vigilante/issue-1\n",
+			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":351,"url":"https://github.com/owner/repo/pull/351","state":"OPEN","baseRefName":"main"}]`,
+		},
+	}
+	app.prManager = githubbackend.NewBackend(&app.env.Runner)
+
+	session := &state.Session{
+		RepoPath:          repoPath,
+		Repo:              "owner/repo",
+		IssueNumber:       1,
+		Branch:            "vigilante/issue-1",
+		WorktreePath:      worktreePath,
+		Status:            state.SessionStatusBlocked,
+		BlockedAt:         now.Add(-30 * time.Minute).Format(time.RFC3339),
+		BlockedStage:      "pr_maintenance",
+		BlockedReason:     state.BlockedReason{Kind: "unknown_operator_action_required"},
+		PullRequestNumber: 351,
+		UpdatedAt:         now.Add(-30 * time.Minute).Format(time.RFC3339),
+	}
+
+	if err := app.cleanupBlockedSessionForInactivity(context.Background(), session, 20*time.Minute); err != nil {
+		t.Fatal(err)
+	}
+
+	if session.Status != state.SessionStatusFailed {
+		t.Fatalf("expected status Failed, got %q", session.Status)
+	}
+	if session.CleanupCompletedAt == "" {
+		t.Fatal("expected CleanupCompletedAt to be set")
+	}
+	if session.BlockedStage != "" {
+		t.Fatalf("expected BlockedStage cleared, got %q", session.BlockedStage)
+	}
+	if session.LastBlockedStage != "pr_maintenance" {
+		t.Fatalf("expected LastBlockedStage preserved, got %q", session.LastBlockedStage)
+	}
+	if !strings.EqualFold(session.PullRequestState, "OPEN") {
+		t.Fatalf("expected PR state refreshed to OPEN, got %q", session.PullRequestState)
+	}
+	if session.PullRequestNumber != 351 {
+		t.Fatalf("expected PR number to remain 351, got %d", session.PullRequestNumber)
+	}
+}
+
+func TestCleanupBlockedSessionForInactivityToleratesPullRequestLookupFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 4, 22, 18, 30, 0, 0, time.UTC)
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.clock = func() time.Time { return now }
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"git worktree prune":                                         "ok",
+			"git worktree remove --force " + worktreePath:                "ok",
+			"git worktree list --porcelain":                              "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": "ok",
+			"git branch -D vigilante/issue-1":                            "Deleted branch vigilante/issue-1\n",
+		},
+		Errors: map[string]error{
+			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": errors.New("gh: transient network failure"),
+		},
+	}
+	app.prManager = githubbackend.NewBackend(&app.env.Runner)
+
+	session := &state.Session{
+		RepoPath:          repoPath,
+		Repo:              "owner/repo",
+		IssueNumber:       1,
+		Branch:            "vigilante/issue-1",
+		WorktreePath:      worktreePath,
+		Status:            state.SessionStatusBlocked,
+		BlockedAt:         now.Add(-30 * time.Minute).Format(time.RFC3339),
+		BlockedStage:      "ci_remediation",
+		BlockedReason:     state.BlockedReason{Kind: "unknown_operator_action_required"},
+		PullRequestNumber: 351,
+		PullRequestState:  "OPEN",
+		UpdatedAt:         now.Add(-30 * time.Minute).Format(time.RFC3339),
+	}
+
+	if err := app.cleanupBlockedSessionForInactivity(context.Background(), session, 20*time.Minute); err != nil {
+		t.Fatalf("cleanup must tolerate PR lookup failure, got %v", err)
+	}
+
+	if session.Status != state.SessionStatusFailed {
+		t.Fatalf("expected status Failed, got %q", session.Status)
+	}
+	if session.LastBlockedStage != "ci_remediation" {
+		t.Fatalf("expected LastBlockedStage preserved even on PR lookup failure, got %q", session.LastBlockedStage)
+	}
+	if !strings.EqualFold(session.PullRequestState, "OPEN") {
+		t.Fatalf("expected existing PR state to be retained on lookup failure, got %q", session.PullRequestState)
+	}
+}
+
 func TestNewAppClockReturnsLiveTime(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -141,6 +141,9 @@ func sessionPreventsRedispatch(session state.Session) bool {
 	if sessionConsumesDispatchCapacity(session) || session.Status == state.SessionStatusBlocked {
 		return true
 	}
+	if sessionSuppressesRedispatchAfterMaintenanceCleanup(session) {
+		return true
+	}
 	if session.Status != state.SessionStatusSuccess {
 		return false
 	}
@@ -148,6 +151,32 @@ func sessionPreventsRedispatch(session state.Session) bool {
 		return false
 	}
 	return true
+}
+
+// sessionSuppressesRedispatchAfterMaintenanceCleanup reports whether an inactivity-cleaned
+// blocked PR-maintenance-class session should still suppress redispatch while its
+// associated PR is open. Without this, cleanup flips the session to failed and the issue
+// becomes eligible again, producing a loop: blocked maintenance -> cleanup -> redispatch
+// on the existing branch -> blocked again. See issue #462.
+func sessionSuppressesRedispatchAfterMaintenanceCleanup(session state.Session) bool {
+	if session.Status != state.SessionStatusFailed {
+		return false
+	}
+	if session.CleanupCompletedAt == "" {
+		return false
+	}
+	if session.PullRequestNumber <= 0 {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(session.PullRequestState), "OPEN") {
+		return false
+	}
+	switch strings.TrimSpace(session.LastBlockedStage) {
+	case "pr_maintenance", "ci_remediation", "conflict_resolution":
+		return true
+	default:
+		return false
+	}
 }
 
 func sessionConsumesDispatchCapacity(session state.Session) bool {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -168,6 +168,130 @@ func TestSelectIssuesSkipsSessionAfterStaleAutoRestartLimitReached(t *testing.T)
 	}
 }
 
+func cleanedUpBlockedMaintenanceSession(issueNumber int, lastStage, prState string, prNumber int) state.Session {
+	return state.Session{
+		Repo:               "owner/repo",
+		IssueNumber:        issueNumber,
+		Status:             state.SessionStatusFailed,
+		Branch:             "vigilante/issue-1",
+		CleanupCompletedAt: "2026-04-22T18:00:00Z",
+		LastCleanupSource:  "blocked_inactivity_timeout",
+		LastBlockedStage:   lastStage,
+		PullRequestNumber:  prNumber,
+		PullRequestState:   prState,
+	}
+}
+
+func TestSelectIssuesSkipsCleanedUpBlockedPRMaintenanceSessionWithOpenPR(t *testing.T) {
+	issues := []Issue{
+		{Number: 1, Labels: []Label{{Name: "to-do"}}},
+		{Number: 2, Labels: []Label{{Name: "to-do"}}},
+	}
+
+	selected := SelectIssues(issues, []state.Session{
+		cleanedUpBlockedMaintenanceSession(1, "pr_maintenance", "OPEN", 351),
+	}, state.WatchTarget{Repo: "owner/repo", Labels: []string{"to-do"}}, 2)
+	if len(selected) != 1 || selected[0].Number != 2 {
+		t.Fatalf("expected issue 1 to be suppressed while PR #351 is open, got %#v", selected)
+	}
+}
+
+func TestSelectIssuesSkipsCleanedUpBlockedCIRemediationSessionWithOpenPR(t *testing.T) {
+	issues := []Issue{
+		{Number: 1, Labels: []Label{{Name: "to-do"}}},
+		{Number: 2, Labels: []Label{{Name: "to-do"}}},
+	}
+
+	selected := SelectIssues(issues, []state.Session{
+		cleanedUpBlockedMaintenanceSession(1, "ci_remediation", "OPEN", 351),
+	}, state.WatchTarget{Repo: "owner/repo", Labels: []string{"to-do"}}, 2)
+	if len(selected) != 1 || selected[0].Number != 2 {
+		t.Fatalf("expected ci_remediation cleanup to suppress redispatch, got %#v", selected)
+	}
+}
+
+func TestSelectIssuesSkipsCleanedUpBlockedConflictResolutionSessionWithOpenPR(t *testing.T) {
+	issues := []Issue{
+		{Number: 1, Labels: []Label{{Name: "to-do"}}},
+		{Number: 2, Labels: []Label{{Name: "to-do"}}},
+	}
+
+	selected := SelectIssues(issues, []state.Session{
+		cleanedUpBlockedMaintenanceSession(1, "conflict_resolution", "open", 351),
+	}, state.WatchTarget{Repo: "owner/repo", Labels: []string{"to-do"}}, 2)
+	if len(selected) != 1 || selected[0].Number != 2 {
+		t.Fatalf("expected conflict_resolution cleanup to suppress redispatch, got %#v", selected)
+	}
+}
+
+func TestSelectIssuesAllowsRedispatchForCleanedUpBlockedPRMaintenanceSessionWhenPRMerged(t *testing.T) {
+	issues := []Issue{
+		{Number: 1, Labels: []Label{{Name: "to-do"}}},
+	}
+
+	selected := SelectIssues(issues, []state.Session{
+		cleanedUpBlockedMaintenanceSession(1, "pr_maintenance", "MERGED", 351),
+	}, state.WatchTarget{Repo: "owner/repo", Labels: []string{"to-do"}}, 2)
+	if len(selected) != 1 || selected[0].Number != 1 {
+		t.Fatalf("expected issue 1 eligible after PR merged, got %#v", selected)
+	}
+}
+
+func TestSelectIssuesAllowsRedispatchForCleanedUpBlockedPRMaintenanceSessionWhenPRClosed(t *testing.T) {
+	issues := []Issue{
+		{Number: 1, Labels: []Label{{Name: "to-do"}}},
+	}
+
+	selected := SelectIssues(issues, []state.Session{
+		cleanedUpBlockedMaintenanceSession(1, "pr_maintenance", "CLOSED", 351),
+	}, state.WatchTarget{Repo: "owner/repo", Labels: []string{"to-do"}}, 2)
+	if len(selected) != 1 || selected[0].Number != 1 {
+		t.Fatalf("expected issue 1 eligible after PR closed, got %#v", selected)
+	}
+}
+
+func TestSelectIssuesAllowsRedispatchForCleanedUpBlockedPRMaintenanceSessionWithoutPR(t *testing.T) {
+	issues := []Issue{
+		{Number: 1, Labels: []Label{{Name: "to-do"}}},
+	}
+
+	selected := SelectIssues(issues, []state.Session{
+		cleanedUpBlockedMaintenanceSession(1, "pr_maintenance", "", 0),
+	}, state.WatchTarget{Repo: "owner/repo", Labels: []string{"to-do"}}, 2)
+	if len(selected) != 1 || selected[0].Number != 1 {
+		t.Fatalf("expected issue 1 eligible when no PR is tracked, got %#v", selected)
+	}
+}
+
+func TestSelectIssuesAllowsRedispatchForCleanedUpBlockedNonMaintenanceSession(t *testing.T) {
+	issues := []Issue{
+		{Number: 1, Labels: []Label{{Name: "to-do"}}},
+	}
+
+	selected := SelectIssues(issues, []state.Session{
+		cleanedUpBlockedMaintenanceSession(1, "issue_execution", "OPEN", 99),
+	}, state.WatchTarget{Repo: "owner/repo", Labels: []string{"to-do"}}, 2)
+	if len(selected) != 1 || selected[0].Number != 1 {
+		t.Fatalf("expected non-maintenance cleanup to remain eligible, got %#v", selected)
+	}
+}
+
+func TestSelectIssuesAllowsRedispatchForCleanedUpFailedSessionWithoutBlockedStageHistory(t *testing.T) {
+	issues := []Issue{
+		{Number: 1, Labels: []Label{{Name: "to-do"}}},
+	}
+
+	selected := SelectIssues(issues, []state.Session{{
+		Repo:               "owner/repo",
+		IssueNumber:        1,
+		Status:             state.SessionStatusFailed,
+		CleanupCompletedAt: "2026-04-22T18:00:00Z",
+	}}, state.WatchTarget{Repo: "owner/repo", Labels: []string{"to-do"}}, 2)
+	if len(selected) != 1 || selected[0].Number != 1 {
+		t.Fatalf("expected plain failed+cleaned session to remain eligible, got %#v", selected)
+	}
+}
+
 func TestListOpenIssuesSupportsExplicitAssignee(t *testing.T) {
 	runner := testutil.FakeRunner{
 		Outputs: map[string]string{

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -219,6 +219,7 @@ type Session struct {
 	LastCIRemediationAttemptedAt   string              `json:"last_ci_remediation_attempted_at,omitempty"`
 	BlockedAt                      string              `json:"blocked_at,omitempty"`
 	BlockedStage                   string              `json:"blocked_stage,omitempty"`
+	LastBlockedStage               string              `json:"last_blocked_stage,omitempty"`
 	BlockedReason                  BlockedReason       `json:"blocked_reason,omitempty"`
 	RetryPolicy                    string              `json:"retry_policy,omitempty"`
 	ResumeAfter                    string              `json:"resume_after,omitempty"`


### PR DESCRIPTION
## Summary
Fix the redispatch loop observed on #462 / teros-dev/platform#349. A blocked `pr_maintenance` (or `ci_remediation` / `conflict_resolution`) session that was cleaned up for inactivity flipped to `failed` with no surviving maintenance signal, so `SelectIssues` treated the underlying issue as a fresh implementation candidate and re-dispatched onto the same remote branch — which then blocked again. With an open PR on the branch, this produced an indefinite **blocked → cleanup → redispatch → blocked** loop.

Approach 1 from the issue (pure suppression). `shouldAutoRecoverBlockedSession` and the `dirty_worktree` path are untouched.

## Changes
- `internal/state/state.go`: new `Session.LastBlockedStage` field.
- `internal/app/app.go`: `cleanupBlockedSessionForInactivity` now
  - best-effort refreshes PR tracking via `prManager.FindPullRequestForBranch` before transitioning (tolerates lookup failure),
  - preserves the prior `BlockedStage` value into `LastBlockedStage` before clearing it.
- `internal/github/github.go`: `sessionPreventsRedispatch` now also returns true for a cleaned-up `failed` session whose `LastBlockedStage ∈ { pr_maintenance, ci_remediation, conflict_resolution }` and whose `PullRequestState` is still `OPEN`. When the PR is observed `MERGED` / `CLOSED`, the session becomes eligible again — suppression is never permanent.

## Tests
Added in `internal/github/github_test.go`:
- `TestSelectIssuesSkipsCleanedUpBlockedPRMaintenanceSessionWithOpenPR`
- `TestSelectIssuesSkipsCleanedUpBlockedCIRemediationSessionWithOpenPR`
- `TestSelectIssuesSkipsCleanedUpBlockedConflictResolutionSessionWithOpenPR`
- `TestSelectIssuesAllowsRedispatchForCleanedUpBlockedPRMaintenanceSessionWhenPRMerged`
- `TestSelectIssuesAllowsRedispatchForCleanedUpBlockedPRMaintenanceSessionWhenPRClosed`
- `TestSelectIssuesAllowsRedispatchForCleanedUpBlockedPRMaintenanceSessionWithoutPR`
- `TestSelectIssuesAllowsRedispatchForCleanedUpBlockedNonMaintenanceSession`
- `TestSelectIssuesAllowsRedispatchForCleanedUpFailedSessionWithoutBlockedStageHistory`

Added in `internal/app/app_test.go`:
- `TestCleanupBlockedSessionForInactivityPreservesLastBlockedStageAndRefreshesPRState`
- `TestCleanupBlockedSessionForInactivityToleratesPullRequestLookupFailure`

## Validation
- `go test ./internal/github/... -run 'TestSelect|TestSession|TestActiveSessionCount'` — pass.
- `go test ./internal/app/... -run 'TestCleanupBlockedSessionForInactivity|TestShouldAutoRecoverBlockedSession|TestScanOnceCleansUpBlockedSession|TestBlockedSessionExceededInactivityTimeout|TestBlockedDirtyWorktreeSession|TestScanOnceUsesOverriddenBlockedSessionInactivityTimeout'` — pass.
- `go test ./...` — full suite green.
- `go vet ./...` — clean.

Closes #462