### PR TITLE
Fix nightly release: scope homebrew cask to vigilante archives, gate publish to main

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      # Temporary: remove once the goreleaser homebrew_casks fix is confirmed green.
+      - fix/goreleaser-homebrew-cask-ids
 
 permissions:
   contents: write
@@ -65,6 +67,7 @@ jobs:
         run: goreleaser release --snapshot --clean
 
       - name: Publish rolling prerelease
+        if: github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ github.token }}
           NIGHTLY_TAG: ${{ env.NIGHTLY_TAG }}
@@ -96,6 +99,7 @@ jobs:
             --prerelease
 
       - name: Verify nightly release publication
+        if: github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ github.token }}
           NIGHTLY_TAG: ${{ env.NIGHTLY_TAG }}
@@ -103,12 +107,14 @@ jobs:
         run: bash ./scripts/verify-nightly-release.sh
 
       - name: Check out Homebrew tap
+        if: github.ref == 'refs/heads/main'
         env:
           TAP_TOKEN: ${{ steps.tap_token.outputs.token }}
         run: |
           git clone "https://x-access-token:${TAP_TOKEN}@github.com/aliengiraffe/homebrew-spaceship.git" "$RUNNER_TEMP/homebrew-spaceship"
 
       - name: Update nightly Homebrew cask
+        if: github.ref == 'refs/heads/main'
         env:
           CHECKSUMS_FILE: dist/checksums.txt
           NIGHTLY_TAG: ${{ env.NIGHTLY_TAG }}
@@ -117,6 +123,7 @@ jobs:
         run: ./scripts/update-nightly-cask.sh
 
       - name: Push nightly Homebrew cask
+        if: github.ref == 'refs/heads/main'
         working-directory: ${{ runner.temp }}/homebrew-spaceship
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-      # Temporary: remove once the goreleaser homebrew_casks fix is confirmed green.
-      - fix/goreleaser-homebrew-cask-ids
 
 permissions:
   contents: write

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,9 @@ permissions:
 jobs:
   prerelease:
     runs-on: ubuntu-latest
-    environment: main
+    # Only gate production secrets behind the protected `main` environment on main pushes;
+    # verification runs on other branches build without access to publish credentials.
+    environment: ${{ github.ref == 'refs/heads/main' && 'main' || '' }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -50,6 +52,7 @@ jobs:
         run: goreleaser check
 
       - name: Get token for Homebrew tap
+        if: github.ref == 'refs/heads/main'
         uses: actions/create-github-app-token@v3
         id: tap_token
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,6 +69,8 @@ release:
 
 homebrew_casks:
   - name: vigilante
+    ids:
+      - release-archives
     repository:
       owner: aliengiraffe
       name: homebrew-spaceship


### PR DESCRIPTION
## Summary
Fix the Nightly Release job that has been failing on every push to `main` since `gh-sandbox` joined the goreleaser build. The homebrew cask stage errored with:

```
one tap can handle only one archive of an OS/Arch combination.
Consider using ids in the homebrew_casks section
```

because the unscoped `homebrew_casks` entry tried to template the Linux amd64/arm64 archives from both `vigilante` and `gh-sandbox` into a single cask.

## Changes
- **`.goreleaser.yml`** — scope the `homebrew_casks.vigilante` entry to `ids: [release-archives]`, which is already the `vigilante`-only archive. `gh-sandbox-archives` still ship as release assets, they just don't participate in the cask template.
- **`.github/workflows/nightly.yml`** — gate the side-effectful steps (rolling prerelease publish, nightly-release verification, homebrew tap checkout/update/push) to `github.ref == 'refs/heads/main'`. Non-main pushes now exercise `goreleaser check`, the snapshot build, and the snapshot cask template (the actual former failure point), but cannot overwrite the `main-nightly` tag, assets, or Homebrew tap. This is a permanent safety net and should stay after this PR.
- Adds the fix branch to `on.push.branches` **temporarily** so a nightly run fires on the branch to prove the build step works end-to-end. That trigger entry will be removed before merge.

## Local verification
- `goreleaser check` — pass.
- `NIGHTLY_VERSION=0.0.0-nightly.test.local ... goreleaser release --snapshot --clean --skip=publish` — pass. Generated `dist/homebrew/Casks/vigilante.rb` references only the vigilante archives (macOS amd64, macOS arm64, Linux amd64) — no gh-sandbox. No `one tap can handle only one archive` error.

## Rollout
1. Push this PR's branch — nightly workflow runs on the branch (build-only, publish gated off), verifies the fix.
2. Once the run is green, remove the branch from `on.push.branches` in a follow-up commit on this PR.
3. Merge. The next `main` push will resume successful nightly publishing.

Refs: https://github.com/aliengiraffe/vigilante/actions/runs/24843180124/job/72722701900 and the four previous nightly runs that hit the same error.
