### PR TITLE
feat: add OpenCode as a supported headless coding-agent provider

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -81,7 +81,7 @@ Quickstart requirements:
 
 - `git`
 - `gh` authenticated against the GitHub account you want Vigilante to operate with
-- one supported coding-agent CLI installed locally: `codex`, `claude`, or `gemini`
+- one supported coding-agent CLI installed locally: `codex`, `claude`, `gemini`, or `opencode`
 
 ## Product Goal
 
@@ -123,7 +123,7 @@ For each watched repository:
 3. Ensure required tools are available:
    - `git`
    - `gh`
-   - the configured coding-agent provider CLI (`codex`, `claude`, or `gemini`)
+   - the configured coding-agent provider CLI (`codex`, `claude`, `gemini`, or `opencode`)
 4. Ensure the bundled issue implementation skills from the repo `skills/` folder are installed during setup, including companion agent metadata.
 5. Query GitHub for open issues.
 6. Determine which issues are eligible for execution.
@@ -240,7 +240,7 @@ Upgrade later with:
 brew upgrade vigilante
 ```
 
-### `vigilante watch [--assignee <value>] [--max-parallel <value>] [--provider <codex|claude|gemini>] [--issue-tracker <github|linear>] [--issue-tracker-stage <value>] [--branch <name> | --track-default-branch] <path>`
+### `vigilante watch [--assignee <value>] [--max-parallel <value>] [--provider <codex|claude|gemini|opencode>] [--issue-tracker <github|linear>] [--issue-tracker-stage <value>] [--branch <name> | --track-default-branch] <path>`
 
 Register a local repository for issue monitoring.
 
@@ -286,6 +286,10 @@ vigilante watch --provider claude ~/hello-world-app
 
 ```sh
 vigilante watch --provider gemini ~/hello-world-app
+```
+
+```sh
+vigilante watch --provider opencode ~/hello-world-app
 ```
 
 ```sh
@@ -384,7 +388,7 @@ Remove a repository from the watchlist without deleting the repository itself.
 Run the long-lived watcher loop in the foreground. This is the process the OS service should execute.
 By default it scans watched repositories every 1 minute. Use `--interval` to override that cadence for manual runs.
 
-### `vigilante setup [--provider <codex|claude|gemini>]`
+### `vigilante setup [--provider <codex|claude|gemini|opencode>]`
 
 Prepare the machine for autonomous execution.
 
@@ -393,7 +397,7 @@ Expected behavior:
 - creates `~/.vigilante/`
 - initializes `watchlist.json`
 - verifies `git`, `gh`, and the selected coding-agent provider CLI
-- verifies the selected provider CLI reports a compatible build-supported version range, currently `>=0.114.0, <2.0.0` for `codex`, `>=2.0.0, <3.0.0` for `claude`, and `>=1.0.0, <2.0.0` for `gemini`
+- verifies the selected provider CLI reports a compatible build-supported version range, currently `>=0.114.0, <2.0.0` for `codex`, `>=2.0.0, <3.0.0` for `claude`, `>=0.34.0, <1.0.0` for `gemini`, and `>=1.0.0, <2.0.0` for `opencode`
 - installs the bundled coding-agent skills for regular runtime use, including any companion files under each skill directory
   - `vigilante-issue-implementation`
   - `vigilante-issue-implementation-on-monorepo`
@@ -634,7 +638,7 @@ Initial rules:
 - treat `max_parallel_sessions: 0` as unlimited parallel issue dispatch for that repository
 - count both running implementation sessions and open-PR maintenance sessions against that repository limit
 - avoid duplicate work across multiple daemon scans
-- allow an issue label that exactly matches a registered provider id, such as `codex`, `claude`, or `gemini`, to override the watch target provider for that issue only
+- allow an issue label that exactly matches a registered provider id, such as `codex`, `claude`, `gemini`, or `opencode`, to override the watch target provider for that issue only
 - if more than one provider-id label is present on the same issue, skip dispatch instead of choosing a provider arbitrarily
 - prefer oldest eligible open issue first unless later prioritization rules are added
 
@@ -714,14 +718,14 @@ Label ownership rules:
 
 - Work-classification labels such as `bug`, `feature`, and `good first issue` remain repository-managed and should not be changed by Vigilante.
 - `vigilante:*` lifecycle and intervention labels are primarily informational and should be set or cleared by Vigilante as the issue moves through execution.
-- Provider-routing labels `codex`, `claude`, and `gemini` keep their existing control semantics and remain human-managed overrides.
+- Provider-routing labels `codex`, `claude`, `gemini`, and `opencode` keep their existing control semantics and remain human-managed overrides.
 - `vigilante:resume` is the preferred control label for unblocking a paused session; `resume` remains a legacy-compatible alias.
 
 Proposed groups:
 
 - Execution state: `vigilante:queued`, `vigilante:running`, `vigilante:blocked`, `vigilante:ready-for-review`, `vigilante:awaiting-user-validation`, `vigilante:done`
 - Human-intervention state: `vigilante:needs-human-input`, `vigilante:needs-provider-fix`, `vigilante:needs-git-fix`
-- Provider routing controls: `codex`, `claude`, `gemini`
+- Provider routing controls: `codex`, `claude`, `gemini`, `opencode`
 - Explicit control labels: `vigilante:resume` and legacy `resume`
 
 Recommended lifecycle:
@@ -748,7 +752,7 @@ When `vigilante` launches a coding agent for an issue, it should:
 - instruct the agent not to add coding-agent `Co-authored by:` trailers or similar attribution
 - instruct the agent to report failures on the issue if execution aborts
 
-The agent invocation remains a subprocess wrapper around an installed coding CLI such as `codex`, `claude`, or `gemini`, while keeping the orchestration behavior provider-neutral.
+The agent invocation remains a subprocess wrapper around an installed coding CLI such as `codex`, `claude`, `gemini`, or `opencode`, while keeping the orchestration behavior provider-neutral.
 
 ## GitHub Integration
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ GitHub is the only fully implemented issue-tracking backend today. The backend i
 
 - **Worktree isolation.** Every issue gets its own branch and worktree so the main checkout stays untouched.
 - **Operator-visible lifecycle.** Start, progress, failure, and PR state are reflected through GitHub comments and local Vigilante state.
-- **Provider-neutral orchestration.** Works with supported headless coding-agent CLIs including `codex`, `claude`, and `gemini`.
+- **Provider-neutral orchestration.** Works with supported headless coding-agent CLIs including `codex`, `claude`, `gemini`, and `opencode`.
 - **Recovery tooling.** `resume`, `redispatch`, and `cleanup` are first-class flows, not ad hoc scripts.
 - **Rate-limit awareness.** Vigilante monitors GitHub API budget and delays additional work when quota gets tight.
 
@@ -74,7 +74,7 @@ Requirements:
 
 - `git`
 - `gh` authenticated against the GitHub account Vigilante should operate with
-- one supported coding-agent CLI installed locally: `codex`, `claude`, or `gemini`
+- one supported coding-agent CLI installed locally: `codex`, `claude`, `gemini`, or `opencode`
 
 Bootstrap the local machine and install the managed service:
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1615,6 +1615,7 @@ func (a *App) installBundledSkills() error {
 		{runtime: skill.RuntimeCodex, home: a.state.CodexHome()},
 		{runtime: skill.RuntimeClaude, home: a.state.ClaudeHome()},
 		{runtime: skill.RuntimeGemini, home: a.state.GeminiHome()},
+		{runtime: skill.RuntimeOpenCode, home: a.state.OpenCodeHome()},
 	} {
 		if err := skill.EnsureInstalled(runtimeHome.runtime, runtimeHome.home); err != nil {
 			return err
@@ -6207,6 +6208,16 @@ func buildResumeFailureSummaryInvocation(selectedProvider provider.Provider, wor
 				"--yolo",
 			},
 		}, nil
+	case provider.OpenCodeID:
+		return provider.Invocation{
+			Dir:  workdir,
+			Name: "opencode",
+			Args: []string{
+				"run",
+				"--dangerously-skip-permissions",
+				prompt,
+			},
+		}, nil
 	case provider.DefaultID:
 		fallthrough
 	default:
@@ -7380,6 +7391,7 @@ func sandboxConfigMounts(homeDir string, store *state.Store, enableSSHSigning bo
 	addMount(store.CodexHome(), "/root/.codex", false)
 	addMount(store.ClaudeHome(), "/root/.claude", false)
 	addMount(store.GeminiHome(), "/root/.gemini", false)
+	addMount(store.OpenCodeHome(), "/root/.config/opencode", false)
 
 	if homeDir != "" {
 		// Do not mount the operator's raw ~/.gitconfig: on macOS it commonly

--- a/internal/provider/compatibility.go
+++ b/internal/provider/compatibility.go
@@ -24,9 +24,10 @@ type compatibilityContract struct {
 }
 
 var compatibilityContracts = map[string]compatibilityContract{
-	DefaultID: {minInclusive: "0.114.0", maxExclusive: "2.0.0"},
-	ClaudeID:  {minInclusive: "2.0.0", maxExclusive: "3.0.0"},
-	GeminiID:  {minInclusive: "0.34.0", maxExclusive: "1.0.0"},
+	DefaultID:  {minInclusive: "0.114.0", maxExclusive: "2.0.0"},
+	ClaudeID:   {minInclusive: "2.0.0", maxExclusive: "3.0.0"},
+	GeminiID:   {minInclusive: "0.34.0", maxExclusive: "1.0.0"},
+	OpenCodeID: {minInclusive: "1.0.0", maxExclusive: "2.0.0"},
 }
 
 func ValidateRuntimeCompatibility(ctx context.Context, runner environment.Runner, selectedProvider Provider) error {

--- a/internal/provider/opencode.go
+++ b/internal/provider/opencode.go
@@ -1,0 +1,96 @@
+package provider
+
+import (
+	"github.com/nicobistolfi/vigilante/internal/skill"
+	"github.com/nicobistolfi/vigilante/internal/state"
+)
+
+type opencodeProvider struct{}
+
+func (opencodeProvider) ID() string {
+	return OpenCodeID
+}
+
+func (opencodeProvider) DisplayName() string {
+	return "OpenCode"
+}
+
+func (opencodeProvider) RequiredTools() []string {
+	return []string{"opencode"}
+}
+
+func (opencodeProvider) EnsureRuntimeInstalled(store *state.Store) error {
+	return skill.EnsureInstalled(skill.RuntimeOpenCode, store.OpenCodeHome())
+}
+
+func (opencodeProvider) BuildIssuePreflightInvocation(task IssueTask) (Invocation, error) {
+	return Invocation{
+		Dir:  task.Session.WorktreePath,
+		Name: "opencode",
+		Args: []string{
+			"run",
+			"--dangerously-skip-permissions",
+			skill.BuildIssuePreflightPrompt(task.Target, task.Issue, task.Session),
+		},
+	}, nil
+}
+
+func (opencodeProvider) BuildIssueInvocation(task IssueTask) (Invocation, error) {
+	return Invocation{
+		Dir:  task.Session.WorktreePath,
+		Name: "opencode",
+		Args: []string{
+			"run",
+			"--dangerously-skip-permissions",
+			skill.BuildIssuePromptForRuntime(skill.RuntimeOpenCode, task.Target, task.Issue, task.Session),
+		},
+	}, nil
+}
+
+func (opencodeProvider) BuildConflictResolutionInvocation(task ConflictTask) (Invocation, error) {
+	return Invocation{
+		Dir:  task.Session.WorktreePath,
+		Name: "opencode",
+		Args: []string{
+			"run",
+			"--dangerously-skip-permissions",
+			skill.BuildConflictResolutionPromptForRuntime(skill.RuntimeOpenCode, task.Target, task.Session, task.PR),
+		},
+	}, nil
+}
+
+func (opencodeProvider) BuildCIRemediationInvocation(task CIRemediationTask) (Invocation, error) {
+	return Invocation{
+		Dir:  task.Session.WorktreePath,
+		Name: "opencode",
+		Args: []string{
+			"run",
+			"--dangerously-skip-permissions",
+			skill.BuildCIRemediationPromptForRuntime(skill.RuntimeOpenCode, task.Target, task.Session, task.PR, task.FailingChecks),
+		},
+	}, nil
+}
+
+func (opencodeProvider) BuildIssueCreateInvocation(task IssueCreateTask) (Invocation, error) {
+	return Invocation{
+		Dir:  task.Target.Path,
+		Name: "opencode",
+		Args: []string{
+			"run",
+			"--dangerously-skip-permissions",
+			skill.BuildIssueCreatePrompt(skill.RuntimeOpenCode, task.Target, task.Prompt),
+		},
+	}, nil
+}
+
+func (opencodeProvider) BuildPackageRemediationInvocation(task PackageRemediationTask) (Invocation, error) {
+	return Invocation{
+		Dir:  task.Target.Path,
+		Name: "opencode",
+		Args: []string{
+			"run",
+			"--dangerously-skip-permissions",
+			skill.BuildPackageRemediationPrompt(task.Target, task.PRNumber, task.PRBranch, task.FindingsCount),
+		},
+	}, nil
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -12,6 +12,7 @@ import (
 const DefaultID = "codex"
 const ClaudeID = "claude"
 const GeminiID = "gemini"
+const OpenCodeID = "opencode"
 
 type Invocation struct {
 	Dir  string
@@ -67,9 +68,10 @@ type Provider interface {
 }
 
 var registry = map[string]Provider{
-	DefaultID: codexProvider{},
-	ClaudeID:  claudeProvider{},
-	GeminiID:  geminiProvider{},
+	DefaultID:  codexProvider{},
+	ClaudeID:   claudeProvider{},
+	GeminiID:   geminiProvider{},
+	OpenCodeID: opencodeProvider{},
 }
 
 func RegisteredIDs() []string {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -76,6 +76,105 @@ func TestResolveGeminiProvider(t *testing.T) {
 	}
 }
 
+func TestResolveOpenCodeProvider(t *testing.T) {
+	selectedProvider, err := Resolve(OpenCodeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selectedProvider.ID() != OpenCodeID {
+		t.Fatalf("unexpected provider id: %s", selectedProvider.ID())
+	}
+	if selectedProvider.DisplayName() != "OpenCode" {
+		t.Fatalf("unexpected provider: %#v", selectedProvider)
+	}
+	got := RequiredToolset(selectedProvider)
+	want := []string{"gh", "git", "opencode"}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected tool count: %#v", got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected toolset: %#v", got)
+		}
+	}
+}
+
+func TestOpenCodeInvocationUsesWorktreeDirAndRunCommand(t *testing.T) {
+	selectedProvider, err := Resolve(OpenCodeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
+	issue := ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}
+	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: OpenCodeID}
+	pr := ghcli.PullRequest{Number: 11, URL: "https://github.com/owner/repo/pull/11"}
+
+	preflight, err := selectedProvider.BuildIssuePreflightInvocation(IssueTask{Target: target, Issue: issue, Session: session})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preflight.Name != "opencode" {
+		t.Fatalf("expected opencode binary, got %q", preflight.Name)
+	}
+	if preflight.Dir != "/tmp/worktree" {
+		t.Fatalf("expected preflight dir to be worktree, got %#v", preflight)
+	}
+	wantPreflightArgs := []string{"run", "--dangerously-skip-permissions", skill.BuildIssuePreflightPrompt(target, issue, session)}
+	assertInvocationArgs(t, preflight.Args, wantPreflightArgs)
+
+	issueInvocation, err := selectedProvider.BuildIssueInvocation(IssueTask{Target: target, Issue: issue, Session: session})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if issueInvocation.Dir != "/tmp/worktree" {
+		t.Fatalf("expected issue dir to be worktree, got %#v", issueInvocation)
+	}
+	wantIssueArgs := []string{"run", "--dangerously-skip-permissions", skill.BuildIssuePromptForRuntime(skill.RuntimeOpenCode, target, issue, session)}
+	assertInvocationArgs(t, issueInvocation.Args, wantIssueArgs)
+
+	conflictInvocation, err := selectedProvider.BuildConflictResolutionInvocation(ConflictTask{Target: target, Session: session, PR: pr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conflictInvocation.Dir != "/tmp/worktree" {
+		t.Fatalf("expected conflict dir to be worktree, got %#v", conflictInvocation)
+	}
+	wantConflictArgs := []string{"run", "--dangerously-skip-permissions", skill.BuildConflictResolutionPromptForRuntime(skill.RuntimeOpenCode, target, session, pr)}
+	assertInvocationArgs(t, conflictInvocation.Args, wantConflictArgs)
+
+	remediationInvocation, err := selectedProvider.BuildCIRemediationInvocation(CIRemediationTask{
+		Target:        target,
+		Session:       session,
+		PR:            pr,
+		FailingChecks: []ghcli.StatusCheckRoll{{Context: "test", Conclusion: "FAILURE"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if remediationInvocation.Dir != "/tmp/worktree" {
+		t.Fatalf("expected remediation dir to be worktree, got %#v", remediationInvocation)
+	}
+	wantRemediationArgs := []string{"run", "--dangerously-skip-permissions", skill.BuildCIRemediationPromptForRuntime(skill.RuntimeOpenCode, target, session, pr, []ghcli.StatusCheckRoll{{Context: "test", Conclusion: "FAILURE"}})}
+	assertInvocationArgs(t, remediationInvocation.Args, wantRemediationArgs)
+
+	packageInvocation, err := selectedProvider.BuildPackageRemediationInvocation(PackageRemediationTask{
+		Target:        target,
+		PRNumber:      11,
+		PRBranch:      "vigilante/issue-7",
+		FindingsCount: 3,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packageInvocation.Dir != "/tmp/repo" {
+		t.Fatalf("expected package dir to be target path, got %#v", packageInvocation)
+	}
+	if packageInvocation.Args[0] != "run" || packageInvocation.Args[1] != "--dangerously-skip-permissions" {
+		t.Fatalf("expected opencode run flags, got %#v", packageInvocation.Args)
+	}
+}
+
 func TestClaudeInvocationUsesWorktreeDirForHeadlessRuns(t *testing.T) {
 	selectedProvider, err := Resolve(ClaudeID)
 	if err != nil {
@@ -181,6 +280,8 @@ func TestValidateVersionOutputAcceptsSupportedVersions(t *testing.T) {
 		{name: "codex", provider: DefaultID, output: "codex 1.2.3"},
 		{name: "claude 2.x", provider: ClaudeID, output: "Claude Code v2.1.3"},
 		{name: "gemini current supported 0.x", provider: GeminiID, output: "gemini-cli 0.34.0"},
+		{name: "opencode 1.x minimum", provider: OpenCodeID, output: "opencode 1.0.0"},
+		{name: "opencode 1.x current", provider: OpenCodeID, output: "opencode 1.15.13"},
 	}
 
 	for _, tc := range cases {
@@ -257,6 +358,38 @@ func TestValidateVersionOutputRejectsMalformedVersionOutput(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("expected error to contain %q, got %q", want, err.Error())
 		}
+	}
+}
+
+func TestValidateVersionOutputRejectsTooOldOpenCodeContract(t *testing.T) {
+	selectedProvider, err := Resolve(OpenCodeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ValidateVersionOutput(selectedProvider, "opencode 0.99.0")
+	if err == nil {
+		t.Fatal("expected compatibility error")
+	}
+	for _, want := range []string{"opencode CLI version 0.99.0 is incompatible", "supported: >=1.0.0, <2.0.0"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("expected error to contain %q, got %q", want, err.Error())
+		}
+	}
+}
+
+func TestValidateVersionOutputRejectsTooNewOpenCodeContract(t *testing.T) {
+	selectedProvider, err := Resolve(OpenCodeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ValidateVersionOutput(selectedProvider, "opencode 2.0.0")
+	if err == nil {
+		t.Fatal("expected compatibility error")
+	}
+	if !strings.Contains(err.Error(), "supported: >=1.0.0, <2.0.0") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -44,6 +44,7 @@ const DockerComposeLaunch = "docker-compose-launch"
 const RuntimeCodex = "codex"
 const RuntimeClaude = "claude"
 const RuntimeGemini = "gemini"
+const RuntimeOpenCode = "opencode"
 
 func VigilanteSkillNames() []string {
 	return []string{
@@ -112,6 +113,10 @@ func installTargets(runtime string, home string, name string) ([]string, error) 
 			filepath.Join(home, "commands", name),
 		}, nil
 	case RuntimeGemini:
+		return []string{
+			filepath.Join(home, "skills", name),
+		}, nil
+	case RuntimeOpenCode:
 		return []string{
 			filepath.Join(home, "skills", name),
 		}, nil
@@ -609,6 +614,8 @@ func displayProviderName(name string) string {
 		return "Codex"
 	case RuntimeGemini:
 		return "Gemini CLI"
+	case RuntimeOpenCode:
+		return "OpenCode"
 	}
 	parts := strings.FieldsFunc(name, func(r rune) bool {
 		return r == '-' || r == '_' || r == ' '
@@ -728,7 +735,7 @@ func BuildCIRemediationPromptForRuntime(runtime string, target state.WatchTarget
 
 func runtimeUsesInlineSkillHeader(runtime string) bool {
 	switch strings.TrimSpace(runtime) {
-	case RuntimeClaude, RuntimeGemini:
+	case RuntimeClaude, RuntimeGemini, RuntimeOpenCode:
 		return true
 	default:
 		return false

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -759,6 +759,53 @@ func TestBuildIssuePromptForGeminiInlinesSkillInstructions(t *testing.T) {
 	}
 }
 
+func TestEnsureInstalledForOpenCodeCreatesSkills(t *testing.T) {
+	dir := t.TempDir()
+	repoRoot := t.TempDir()
+	for _, name := range VigilanteSkillNames() {
+		skillSourceDir := filepath.Join(repoRoot, "skills", name)
+		if err := os.MkdirAll(skillSourceDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(skillSourceDir, "SKILL.md"), []byte("# repo skill\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.Chdir(wd)
+	}()
+
+	if err := EnsureInstalled(RuntimeOpenCode, dir); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range VigilanteSkillNames() {
+		path := filepath.Join(dir, "skills", name, "SKILL.md")
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("expected %s to exist: %v", path, err)
+		}
+	}
+}
+
+func TestBuildIssuePromptForOpenCodeInlinesSkillInstructions(t *testing.T) {
+	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
+	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
+	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "opencode"}
+	prompt := BuildIssuePromptForRuntime(RuntimeOpenCode, target, issue, session)
+	for _, text := range []string{"Follow these `vigilante-issue-implementation` skill instructions directly", "Coding Agent Launched: OpenCode", "@vigilanteai resume", "@vigilanteai cleanup", "Issue: #12 - Fix bug"} {
+		if !strings.Contains(prompt, text) {
+			t.Fatalf("prompt missing %q: %s", text, prompt)
+		}
+	}
+}
+
 func TestIssueImplementationSkillDefaultsToTraditional(t *testing.T) {
 	if got := IssueImplementationSkill(state.WatchTarget{}); got != VigilanteIssueImplementation {
 		t.Fatalf("unexpected default issue skill: %s", got)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -313,6 +313,20 @@ func (s *Store) GeminiHome() string {
 	return filepath.Join(home, ".gemini")
 }
 
+// OpenCodeHome returns the directory where OpenCode stores configuration and
+// extensions (skills, commands, agents). OPENCODE_HOME overrides the default,
+// which is the documented OpenCode config dir at ~/.config/opencode.
+func (s *Store) OpenCodeHome() string {
+	if value := os.Getenv("OPENCODE_HOME"); value != "" {
+		return value
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(s.root, ".config", "opencode")
+	}
+	return filepath.Join(home, ".config", "opencode")
+}
+
 func (s *Store) EnsureLayout() error {
 	for _, dir := range []string{s.root, s.LogsDir()} {
 		if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -264,6 +264,26 @@ func TestHardeningPRKey(t *testing.T) {
 	}
 }
 
+func TestOpenCodeHomeRespectsEnvOverride(t *testing.T) {
+	override := filepath.Join(t.TempDir(), "custom-opencode")
+	t.Setenv("OPENCODE_HOME", override)
+
+	store := NewStore()
+	if got := store.OpenCodeHome(); got != override {
+		t.Fatalf("OpenCodeHome = %q, want %q", got, override)
+	}
+}
+
+func TestOpenCodeHomeDefaultsToConfigOpencode(t *testing.T) {
+	t.Setenv("OPENCODE_HOME", "")
+
+	store := NewStore()
+	got := store.OpenCodeHome()
+	if !strings.HasSuffix(got, filepath.Join(".config", "opencode")) {
+		t.Fatalf("OpenCodeHome = %q, expected suffix .config/opencode", got)
+	}
+}
+
 func TestServiceConfigPackageHardeningPersistence(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))


### PR DESCRIPTION
## Summary

Adds OpenCode as a fourth supported headless coding-agent provider alongside Codex, Claude Code, and Gemini CLI, so users can pass `--provider opencode` to `vigilante setup`, `vigilante watch`, and `vigilante start`, and route per-issue work via an `opencode` label.

## Changes

- **`internal/provider/opencode.go`** — new `opencodeProvider{}` implementing all five `Build*Invocation` methods. Uses `opencode run --dangerously-skip-permissions <prompt>` with `Dir` set to the worktree path (OpenCode's `run` subcommand has no `--cd` equivalent).
- **`internal/provider/provider.go`** — registers `OpenCodeID = "opencode"` in the registry, so `provider.Resolve("opencode")` works and `resolveIssueProvider()` picks up the `opencode` label automatically.
- **`internal/provider/compatibility.go`** — pins OpenCode to `>=1.0.0, <2.0.0` (latest stable v1.15.13).
- **`internal/skill/skill.go`** — adds `RuntimeOpenCode` constant, installs skills under `<OpenCodeHome>/skills/<name>` (matching OpenCode's documented `~/.config/opencode/skills/` extension layout), uses the inline skill header (same as Claude / Gemini), and adds "OpenCode" to the display-name switch.
- **`internal/state/state.go`** — `OpenCodeHome()` honors the `OPENCODE_HOME` env var and defaults to `~/.config/opencode` (OpenCode's documented config dir).
- **`internal/app/app.go`** — includes OpenCode in `installBundledSkills`, the sandbox mount list (`/root/.config/opencode`), and the `buildResumeFailureSummaryInvocation` switch.
- **`README.md` / `DOCS.md`** — lists `opencode` as a fourth supported provider, documents the `>=1.0.0, <2.0.0` version range, and corrects a stale `>=1.0.0, <2.0.0` value that was previously misattributed to Gemini.

## Test plan

- [x] `gofmt -l internal/` — clean
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test ./...` — all packages pass, including new tests in `internal/provider`, `internal/skill`, and `internal/state`
- New tests cover:
  - `Resolve("opencode")` returns the OpenCode provider with correct display name and toolset
  - All five `Build*Invocation` methods produce non-empty invocations with `opencode run --dangerously-skip-permissions <prompt>` and `Dir` pointed at the worktree (or target path for issue create / package remediation)
  - Compatibility accepts `1.0.0` and `1.15.13`, rejects `0.99.0` and `2.0.0`
  - `EnsureInstalled(RuntimeOpenCode, ...)` installs every bundled skill under `<home>/skills/<name>`
  - `BuildIssuePromptForRuntime(RuntimeOpenCode, ...)` inlines the skill body and uses the "Coding Agent Launched: OpenCode" display name
  - `OpenCodeHome()` respects `OPENCODE_HOME` and defaults to `~/.config/opencode`

Closes #465