### PR TITLE
Suppress duplicate blocked comments for matching blockers

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -540,6 +540,57 @@ func (a *App) commentOnIssue(ctx context.Context, repo string, issue int, body s
 	return nil
 }
 
+func normalizeBlockedFingerprintPart(value string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(value)), " ")
+}
+
+func blockedCommentFingerprint(stage string, reason state.BlockedReason) string {
+	return strings.Join([]string{
+		normalizeBlockedFingerprintPart(stage),
+		normalizeBlockedFingerprintPart(reason.Kind),
+		normalizeBlockedFingerprintPart(reason.Operation),
+		normalizeBlockedFingerprintPart(reason.Summary),
+		normalizeBlockedFingerprintPart(reason.Detail),
+	}, "|")
+}
+
+func hasBlockedCommentFingerprint(stage string, reason state.BlockedReason) bool {
+	return normalizeBlockedFingerprintPart(stage) != "" ||
+		normalizeBlockedFingerprintPart(reason.Kind) != "" ||
+		normalizeBlockedFingerprintPart(reason.Operation) != "" ||
+		normalizeBlockedFingerprintPart(reason.Summary) != "" ||
+		normalizeBlockedFingerprintPart(reason.Detail) != ""
+}
+
+func carryBlockedCommentState(session *state.Session, previous state.Session) {
+	session.LastBlockedCommentFingerprint = previous.LastBlockedCommentFingerprint
+	session.LastBlockedCommentedAt = previous.LastBlockedCommentedAt
+}
+
+func clearBlockedCommentState(session *state.Session) {
+	session.LastBlockedCommentFingerprint = ""
+	session.LastBlockedCommentedAt = ""
+}
+
+func (a *App) commentBlockedIssue(ctx context.Context, session *state.Session, body string, source string) error {
+	if session == nil {
+		return nil
+	}
+	fingerprint := blockedCommentFingerprint(session.BlockedStage, session.BlockedReason)
+	if hasBlockedCommentFingerprint(session.BlockedStage, session.BlockedReason) && fingerprint == session.LastBlockedCommentFingerprint {
+		a.logger.Info("blocked comment suppressed", "repo", session.Repo, "issue", session.IssueNumber, "stage", session.BlockedStage, "fingerprint", fingerprint, "source", source)
+		return nil
+	}
+	if err := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, body, "blocked", source); err != nil {
+		return err
+	}
+	if hasBlockedCommentFingerprint(session.BlockedStage, session.BlockedReason) {
+		session.LastBlockedCommentFingerprint = fingerprint
+		session.LastBlockedCommentedAt = a.clock().Format(time.RFC3339)
+	}
+	return nil
+}
+
 func (a *App) withIssueAccessLogContext(ctx context.Context, executionContext string, repo string, issue int, branch string, worktreePath string) context.Context {
 	return environment.WithAccessLogContext(ctx, environment.AccessLogContext{
 		ExecutionContext: executionContext,
@@ -2232,6 +2283,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 				}
 				if previous, ok := findSession(sessions, target.Repo, next.Number); ok {
 					carryStaleAutoRestartState(&session, previous)
+					carryBlockedCommentState(&session, previous)
 				}
 				sessions = upsertSession(sessions, session)
 				if err := a.state.SaveSessions(sessions); err != nil {
@@ -2822,7 +2874,7 @@ func (a *App) runPullRequestMaintenance(ctx context.Context, session *state.Sess
 					},
 					Tagline: "Difficulties strengthen the mind, as labor does the body.",
 				})
-				if commentErr := a.commentOnIssue(sessionCtx, session.Repo, session.IssueNumber, body, "blocked", "pr_maintenance"); commentErr != nil {
+				if commentErr := a.commentBlockedIssue(sessionCtx, session, body, "pr_maintenance"); commentErr != nil {
 					a.logger.Error("pr maintenance failure comment failed", "repo", session.Repo, "issue", session.IssueNumber, "pr", pr.Number, "err", commentErr)
 				}
 				session.LastMaintenanceError = err.Error()
@@ -3981,6 +4033,7 @@ func (a *App) RedispatchSession(ctx context.Context, repoSlug string, issue int,
 		} else {
 			carryStaleAutoRestartState(&session, previous)
 		}
+		carryBlockedCommentState(&session, previous)
 	}
 	sessions = upsertSession(sessions, session)
 	if err := a.state.SaveSessions(sessions); err != nil {
@@ -4726,7 +4779,7 @@ func (a *App) autoRecoverBlockedMaintenanceSession(ctx context.Context, session 
 			},
 			Tagline: "The retry stopped at the gate.",
 		})
-		if commentErr := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, failureBody, "blocked", autoRecoverySource); commentErr != nil {
+		if commentErr := a.commentBlockedIssue(ctx, session, failureBody, autoRecoverySource); commentErr != nil {
 			a.logger.Error("auto recovery failure comment failed", "repo", session.Repo, "issue", session.IssueNumber, "pr", pr.Number, "err", commentErr)
 		}
 		return err
@@ -4755,7 +4808,7 @@ func (a *App) autoRecoverBlockedMaintenanceSession(ctx context.Context, session 
 			},
 			Tagline: "Clean slate, real blocker.",
 		})
-		if commentErr := a.commentOnIssue(ctx, session.Repo, session.IssueNumber, failureBody, "blocked", autoRecoverySource); commentErr != nil {
+		if commentErr := a.commentBlockedIssue(ctx, session, failureBody, autoRecoverySource); commentErr != nil {
 			a.logger.Error("auto recovery blocked comment failed", "repo", session.Repo, "issue", session.IssueNumber, "pr", pr.Number, "err", commentErr)
 		}
 		return resumeErr
@@ -5286,6 +5339,7 @@ func clearBlockedState(session *state.Session, now time.Time, source string) {
 	session.LastCIRemediationFingerprint = ""
 	session.LastCIRemediationAttemptedAt = ""
 	session.LastResumeSource = source
+	clearBlockedCommentState(session)
 	session.LastResumeFailureFingerprint = ""
 	session.LastResumeFailureCommentedAt = ""
 	session.LastDispatchFailureFingerprint = ""
@@ -5627,6 +5681,7 @@ func reuseExistingIterationSession(target state.WatchTarget, issue ghcli.Issue, 
 	session.IterationInProgress = true
 	session.LastResumeSource = ""
 	session.LastResumeCommentAt = ""
+	clearBlockedCommentState(&session)
 	session.LastResumeFailureFingerprint = ""
 	session.LastResumeFailureCommentedAt = ""
 	session.LastDispatchFailureFingerprint = ""

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1712,6 +1712,126 @@ func TestCommentOnIssueEmitsTypedTelemetry(t *testing.T) {
 	}
 }
 
+func TestCommentBlockedIssueSuppressesDuplicateFingerprint(t *testing.T) {
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	now := time.Date(2026, 6, 1, 18, 0, 0, 0, time.UTC)
+	app.clock = func() time.Time { return now }
+	session := state.Session{
+		Repo:                   "owner/repo",
+		IssueNumber:            7,
+		BlockedStage:           "pr_maintenance",
+		BlockedReason:          state.BlockedReason{Kind: "git_auth", Operation: "git fetch origin main", Summary: "fetch failed", Detail: "fetch failed"},
+		LastBlockedCommentedAt: now.Add(-time.Hour).Format(time.RFC3339),
+	}
+	session.LastBlockedCommentFingerprint = blockedCommentFingerprint(session.BlockedStage, session.BlockedReason)
+
+	if err := app.commentBlockedIssue(context.Background(), &session, "body", "pr_maintenance"); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := session.LastBlockedCommentedAt, now.Add(-time.Hour).Format(time.RFC3339); got != want {
+		t.Fatalf("LastBlockedCommentedAt = %q, want %q", got, want)
+	}
+}
+
+func TestRunPullRequestMaintenanceSuppressesDuplicateBlockedCommentForSameFingerprint(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	now := time.Date(2026, 6, 1, 18, 5, 0, 0, time.UTC)
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.clock = func() time.Time { return now }
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
+		},
+		Errors: map[string]error{
+			"git fetch origin main": errors.New("fetch failed"),
+		},
+	}
+
+	session := state.Session{
+		RepoPath:               repoPath,
+		Repo:                   "owner/repo",
+		IssueNumber:            1,
+		IssueTitle:             "first",
+		IssueURL:               "https://github.com/owner/repo/issues/1",
+		Branch:                 "vigilante/issue-1",
+		WorktreePath:           worktreePath,
+		ResumeHint:             "vigilante resume --repo owner/repo --issue 1",
+		Status:                 state.SessionStatusSuccess,
+		LastBlockedCommentedAt: now.Add(-2 * time.Hour).Format(time.RFC3339),
+	}
+	blocked := classifyBlockedReason("pr_maintenance", "git fetch origin main", errors.New("fetch failed"))
+	session.LastBlockedCommentFingerprint = blockedCommentFingerprint("pr_maintenance", blocked)
+
+	pr, _, err := app.runPullRequestMaintenance(context.Background(), &session, nil)
+	if err == nil {
+		t.Fatal("expected maintenance failure")
+	}
+	if pr == nil || pr.Number != 31 {
+		t.Fatalf("unexpected pull request: %#v", pr)
+	}
+	if got, want := session.LastBlockedCommentedAt, now.Add(-2*time.Hour).Format(time.RFC3339); got != want {
+		t.Fatalf("expected duplicate blocked comment to be suppressed: %#v", session)
+	}
+}
+
+func TestCleanupBlockedSessionForInactivityPreservesBlockedCommentFingerprint(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	now := time.Date(2026, 6, 1, 18, 10, 0, 0, time.UTC)
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.clock = func() time.Time { return now }
+	app.prManager = nil
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			"git worktree prune":                                         "ok",
+			"git worktree remove --force " + worktreePath:                "ok",
+			"git ls-remote --exit-code --heads origin vigilante/issue-1": "abc123\trefs/heads/vigilante/issue-1",
+			"git fetch origin vigilante/issue-1:vigilante/issue-1":       "ok",
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": "ok",
+			"git branch -D vigilante/issue-1":                            "Deleted branch vigilante/issue-1 (was abc123).",
+			"git worktree list --porcelain":                              "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
+		},
+	}
+	session := state.Session{
+		RepoPath:                      repoPath,
+		Repo:                          "owner/repo",
+		IssueNumber:                   1,
+		IssueTitle:                    "first",
+		Branch:                        "vigilante/issue-1",
+		WorktreePath:                  worktreePath,
+		Status:                        state.SessionStatusBlocked,
+		BlockedStage:                  "pr_maintenance",
+		BlockedReason:                 state.BlockedReason{Kind: "git_auth", Operation: "git fetch origin main", Summary: "fetch failed", Detail: "fetch failed"},
+		LastBlockedCommentFingerprint: "pr_maintenance|git_auth|git fetch origin main|fetch failed|fetch failed",
+		LastBlockedCommentedAt:        now.Add(-30 * time.Minute).Format(time.RFC3339),
+	}
+
+	if err := app.cleanupBlockedSessionForInactivity(context.Background(), &session, 20*time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := session.LastBlockedCommentFingerprint, "pr_maintenance|git_auth|git fetch origin main|fetch failed|fetch failed"; got != want {
+		t.Fatalf("LastBlockedCommentFingerprint = %q, want %q", got, want)
+	}
+	if got, want := session.LastBlockedCommentedAt, now.Add(-30*time.Minute).Format(time.RFC3339); got != want {
+		t.Fatalf("LastBlockedCommentedAt = %q, want %q", got, want)
+	}
+}
+
 func TestRecordSessionFailureEmitsSessionTransitionTelemetry(t *testing.T) {
 	capture, shutdownTelemetry := setupTelemetryCapture(t)
 	app := New()

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -228,6 +228,8 @@ type Session struct {
 	LastResumeSource               string              `json:"last_resume_source,omitempty"`
 	LastResumeCommentID            int64               `json:"last_resume_comment_id,omitempty"`
 	LastResumeCommentAt            string              `json:"last_resume_comment_at,omitempty"`
+	LastBlockedCommentFingerprint  string              `json:"last_blocked_comment_fingerprint,omitempty"`
+	LastBlockedCommentedAt         string              `json:"last_blocked_commented_at,omitempty"`
 	LastResumeFailureFingerprint   string              `json:"last_resume_failure_fingerprint,omitempty"`
 	LastResumeFailureCommentedAt   string              `json:"last_resume_failure_commented_at,omitempty"`
 	LastDispatchFailureFingerprint string              `json:"last_dispatch_failure_fingerprint,omitempty"`


### PR DESCRIPTION
## Summary
- persist a blocked-comment fingerprint in session state so matching blockers survive cleanup and redispatch
- suppress duplicate maintenance-style blocked comments when the new blocker matches the most recent blocked comment for the issue
- add coverage for suppression, maintenance reuse, and inactivity-cleanup persistence

## Validation
- go test ./...
- go vet ./internal/app ./internal/state

Closes #434