### PR TITLE
Support stacked-PR base branches in implementation skills

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -653,6 +653,19 @@ For pull requests tied to an active Vigilante session:
 - keep the legacy plain `automerge` PR label working as a compatibility alias during migration to the namespaced label
 - never force through branch protection, required reviews, or failing checks
 
+## Stacked-PR Base Branches
+
+Issue authors can request that an issue be implemented on top of an existing in-flight branch (a stacked PR) by adding a single top-level line to the issue body of the form `Base branch: <branch-name>`. The label is case-insensitive and the branch name may be surrounded by backticks.
+
+When that directive is present:
+
+- the implementation skill fetches `origin/<branch-name>` and re-roots the work branch onto it before changing code
+- the resulting pull request targets `<branch-name>` instead of the watch target's base branch
+- the PR body and the PR-opened issue comment state that the PR is stacked on `<branch-name>`
+- the maintenance loop keeps the branch updated against `<branch-name>` through the same path used for default-branch PRs
+
+When the directive is absent, Vigilante uses the watch target's base branch as today. Only an explicit top-level `Base branch:` line triggers stacking; prose mentions of other branches, linked issue numbers, and native sub-issue relationships are ignored. If the specified branch does not exist on the remote, the session is reported as failed on the issue rather than silently falling back to the default branch.
+
 ## Package Hardening
 
 Vigilante runs a deterministic, code-driven package hardening scan for watched repositories classified with the `nodejs` tech stack. The scan is not LLM-driven — all checks use static analysis of manifest files, lockfiles, and CI configuration.

--- a/skills/vigilante-create-issue/SKILL.md
+++ b/skills/vigilante-create-issue/SKILL.md
@@ -125,6 +125,12 @@ Every issue draft should cover these sections when relevant:
 - Do include non-goals so the eventual implementation stays narrow.
 - Do include exact commands, files, components, or workflows when they are already known.
 
+## Stacked-PR Base Branch
+- When the user wants the new issue to be implemented on top of an existing in-flight branch (a stacked PR), add a single top-level line to the issue body of the form `Base branch: <branch-name>`.
+- Use this line only when the user explicitly asks to stack on another branch. Do not infer stacking from prose mentions of other branches, related issue numbers, or native sub-issue relationships.
+- The branch name must exist on the repository remote when implementation runs; the implementation skills will fail the session if it does not.
+- Without this line, Vigilante branches off and targets the watch target's base branch as today.
+
 ## Recommended Questions To Ask
 Use these to tighten the issue before drafting:
 

--- a/skills/vigilante-issue-implementation-on-bazel-monorepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-bazel-monorepo/SKILL.md
@@ -32,27 +32,39 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - After inspecting the issue and repository constraints, post a concise implementation plan to the issue using `vigilante gh issue comment`.
 - The plan comment should describe the intended development steps before substantial coding work begins.
 
-4. Implement inside the assigned worktree only
+4. Detect a stacked base branch
+- Scan the issue body for an explicit, single-line directive of the form `Base branch: <branch-name>` (label is case-insensitive; `<branch-name>` is trimmed and may be surrounded by backticks).
+- Only honor the directive when it appears as its own top-level line in the issue body. Do not infer a stacked base from prose or sub-issue links.
+- If no directive is present, branch from and target the watch target's base branch as today.
+- When the directive is present:
+  - Run `git fetch origin <base>` inside the assigned worktree before code changes.
+  - If the fetch fails because the branch does not exist on the remote, stop work, post a failure comment on the issue, and do not silently fall back to the default branch.
+  - Re-root the work branch onto `origin/<base>` with `git reset --hard origin/<base>` (no commits yet) or `git rebase origin/<base>` (commits present).
+  - Use `<base>` as the PR target later and mention it in the implementation-plan comment.
+
+5. Implement inside the assigned worktree only
 - Use only the provided worktree path.
 - Never edit the root checkout when a worktree was assigned.
 - Keep changes scoped to the Bazel packages and source files required for the issue.
 - Prefer repo-native Bazel commands such as `bazel test`, `bazel build`, `bazel run`, or documented wrappers.
 - If the affected app or test flow needs local database services, invoke `docker-compose-launch` when the repository expects it, or call the bundled `vigilante-local-service-dependencies` skill before inventing ad hoc setup.
 
-5. Validate incrementally
+6. Validate incrementally
 - Start with the smallest relevant Bazel target, package pattern, or documented wrapper command for the touched area.
 - Expand to closely related targets only when the first target scope is insufficient or shared code requires it.
 - If validation fails, first inspect the per-issue session log with `vigilante logs --repo <owner/name> --issue <n>` to determine whether the problem is in the code, target selection, test setup, or environment before retrying.
 
-6. Commit, push, and open a pull request
+7. Commit, push, and open a pull request
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Commit only issue-relevant changes in the assigned branch.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.
 - Push the assigned branch to the remote.
-- Open a pull request targeting the repository default branch unless repository instructions say otherwise.
+- Open a pull request targeting the repository default branch unless the issue specified a stacked base branch in step 4 or other repository instructions say otherwise.
+- When a stacked base branch was specified, pass `--base <base>` to `vigilante gh pr create` and state in the PR body and the PR-opened issue comment that the PR is stacked on `<base>`.
 
-7. Report progress and failures clearly
+8. Report progress and failures clearly
 - Use `vigilante gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
 - If execution is blocked, validation fails, or a resumed session is unclear, inspect `vigilante logs --repo <owner/name> --issue <n>` before retrying or reporting the blocker.
+- A `Base branch:` directive that points at a branch missing from the remote is a blocker: comment a failure on the issue and stop instead of falling back to the default branch.
 - Keep comments concise, factual, and tied to real progress.

--- a/skills/vigilante-issue-implementation-on-bazel/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-bazel/SKILL.md
@@ -11,7 +11,7 @@ description: Implement a GitHub issue end-to-end when Vigilante dispatches work 
 - If local services are required, call `vigilante-local-service-dependencies` first and then use the shared `docker-compose-launch` contract instead of writing ad hoc Compose logic.
 
 ## Workflow
-- Follow the base `vigilante-issue-implementation-on-monorepo` workflow for issue comments, validation, push, and PR creation.
+- Follow the base `vigilante-issue-implementation-on-monorepo` workflow for issue comments, validation, push, and PR creation, including stacked base-branch detection (`Base branch:` directive in the issue body).
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.

--- a/skills/vigilante-issue-implementation-on-docker/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-docker/SKILL.md
@@ -40,7 +40,7 @@ description: Implement a GitHub issue end-to-end when Vigilante dispatches work 
 - When an issue touches both Dockerfiles and application code, validate each side with its respective toolchain rather than validating only one side.
 
 ## Workflow
-- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation.
+- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation, including stacked base-branch detection (`Base branch:` directive in the issue body).
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.

--- a/skills/vigilante-issue-implementation-on-dotnet/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-dotnet/SKILL.md
@@ -36,7 +36,7 @@ description: Implement a GitHub issue end-to-end when Vigilante dispatches work 
 - Do not assume a .NET repository is C#-only; use the prompt's detected tech stacks and process hints.
 
 ## Workflow
-- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation.
+- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation, including stacked base-branch detection (`Base branch:` directive in the issue body).
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.

--- a/skills/vigilante-issue-implementation-on-github-actions/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-github-actions/SKILL.md
@@ -52,7 +52,7 @@ description: Implement a GitHub issue end-to-end when Vigilante dispatches work 
 - Check the prompt for additional detected tech stacks and follow their respective guidance for non-workflow changes.
 
 ## Workflow
-- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation.
+- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation, including stacked base-branch detection (`Base branch:` directive in the issue body).
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.

--- a/skills/vigilante-issue-implementation-on-go/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-go/SKILL.md
@@ -40,7 +40,7 @@ description: Implement a GitHub issue end-to-end when Vigilante dispatches work 
 - Do not assume a Go repository is Go-only. Read process hints and workspace signals in the prompt to understand the full repository structure.
 
 ## Workflow
-- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation.
+- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation, including stacked base-branch detection (`Base branch:` directive in the issue body).
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.

--- a/skills/vigilante-issue-implementation-on-gradle-multi-project/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-gradle-multi-project/SKILL.md
@@ -32,7 +32,17 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - After inspecting the issue and repository constraints, post a concise implementation plan to the issue using `vigilante gh issue comment`.
 - The plan comment should describe the Gradle subproject scope and validation approach before substantial coding work begins.
 
-4. Implement inside the assigned worktree only
+4. Detect a stacked base branch
+- Scan the issue body for an explicit, single-line directive of the form `Base branch: <branch-name>` (label is case-insensitive; `<branch-name>` is trimmed and may be surrounded by backticks).
+- Only honor the directive when it appears as its own top-level line in the issue body. Do not infer a stacked base from prose or sub-issue links.
+- If no directive is present, branch from and target the watch target's base branch as today.
+- When the directive is present:
+  - Run `git fetch origin <base>` inside the assigned worktree before code changes.
+  - If the fetch fails because the branch does not exist on the remote, stop work, post a failure comment on the issue, and do not silently fall back to the default branch.
+  - Re-root the work branch onto `origin/<base>` with `git reset --hard origin/<base>` (no commits yet) or `git rebase origin/<base>` (commits present).
+  - Use `<base>` as the PR target later and mention it in the implementation-plan comment.
+
+5. Implement inside the assigned worktree only
 - Use only the provided worktree path.
 - Never edit the root checkout when a worktree was assigned.
 - Keep changes scoped to the issue.
@@ -40,20 +50,22 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - When local databases or other service-backed dependencies are required, call the bundled `vigilante-local-service-dependencies` skill before inventing ad hoc setup.
 - If the repository expects `docker-compose-launch` for service-backed development or tests, use that repo-defined flow instead of replacing it with generic compose commands.
 
-5. Validate incrementally
+6. Validate incrementally
 - Run the most relevant Gradle tasks for the affected subproject(s) first, such as repo-defined `test`, `check`, `build`, or narrower module tasks.
 - Log the selected subproject(s) and Gradle task scope in issue progress updates when validation starts or changes.
 - If validation fails, first inspect the per-issue session log with `vigilante logs --repo <owner/name> --issue <n>` to determine whether the problem is in the code, Gradle task selection, test setup, or environment before retrying.
 
-6. Commit, push, and open a pull request
+7. Commit, push, and open a pull request
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Commit only issue-relevant changes in the assigned branch.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.
 - Push the assigned branch to the remote.
-- Open a pull request targeting the repository default branch unless repository instructions say otherwise.
+- Open a pull request targeting the repository default branch unless the issue specified a stacked base branch in step 4 or other repository instructions say otherwise.
+- When a stacked base branch was specified, pass `--base <base>` to `vigilante gh pr create` and state in the PR body and the PR-opened issue comment that the PR is stacked on `<base>`.
 
-7. Report progress and failures clearly
+8. Report progress and failures clearly
 - Use `vigilante gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
 - If execution is blocked, validation fails, or a resumed session is unclear, inspect `vigilante logs --repo <owner/name> --issue <n>` before retrying or reporting the blocker.
+- A `Base branch:` directive that points at a branch missing from the remote is a blocker: comment a failure on the issue and stop instead of falling back to the default branch.
 - Keep comments concise, factual, and tied to real progress.

--- a/skills/vigilante-issue-implementation-on-gradle/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-gradle/SKILL.md
@@ -11,7 +11,7 @@ description: Implement a GitHub issue end-to-end when Vigilante dispatches work 
 - If local services are required, call `vigilante-local-service-dependencies` first and then use the shared `docker-compose-launch` contract instead of writing ad hoc Compose logic.
 
 ## Workflow
-- Follow the base `vigilante-issue-implementation-on-monorepo` workflow for issue comments, validation, push, and PR creation.
+- Follow the base `vigilante-issue-implementation-on-monorepo` workflow for issue comments, validation, push, and PR creation, including stacked base-branch detection (`Base branch:` directive in the issue body).
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.

--- a/skills/vigilante-issue-implementation-on-java-kotlin/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-java-kotlin/SKILL.md
@@ -34,7 +34,7 @@ description: Implement a GitHub issue end-to-end when Vigilante dispatches work 
 - When an issue touches both JVM code and another stack, validate each side with its native tooling instead of treating the JVM toolchain as universal.
 
 ## Workflow
-- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation.
+- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation, including stacked base-branch detection (`Base branch:` directive in the issue body).
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.

--- a/skills/vigilante-issue-implementation-on-kubernetes/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-kubernetes/SKILL.md
@@ -54,7 +54,7 @@ description: Implement a GitHub issue end-to-end when Vigilante dispatches work 
 - When an issue touches both application code and Kubernetes manifests, validate each side with its appropriate toolchain.
 
 ## Workflow
-- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation.
+- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation, including stacked base-branch detection (`Base branch:` directive in the issue body).
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.

--- a/skills/vigilante-issue-implementation-on-monorepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-monorepo/SKILL.md
@@ -32,7 +32,17 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - After inspecting the issue and repository constraints, post a concise implementation plan to the issue using `vigilante gh issue comment`.
 - The plan comment should describe the intended development steps before substantial coding work begins.
 
-4. Implement inside the assigned worktree only
+4. Detect a stacked base branch
+- Scan the issue body for an explicit, single-line directive of the form `Base branch: <branch-name>` (label is case-insensitive; `<branch-name>` is trimmed and may be surrounded by backticks).
+- Only honor the directive when it appears as its own top-level line in the issue body. Do not infer a stacked base from prose, linked issue numbers, native sub-issue relationships, or branch names mentioned elsewhere in the issue.
+- If no directive is present, branch from and target the watch target's base branch as today.
+- When the directive is present:
+  - Run `git fetch origin <base>` inside the assigned worktree before code changes.
+  - If the fetch fails because the branch does not exist on the remote, stop work, post a failure comment on the issue, and do not silently fall back to the default branch.
+  - Re-root the work branch onto `origin/<base>` with `git reset --hard origin/<base>` (no commits yet) or `git rebase origin/<base>` (commits present).
+  - Use `<base>` as the PR target later in the workflow and mention the stacked base branch in the implementation-plan comment.
+
+5. Implement inside the assigned worktree only
 - Use only the provided worktree path.
 - Never edit the root checkout when a worktree was assigned.
 - Keep changes scoped to the issue.
@@ -40,19 +50,21 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - If the affected workspace needs local services, call the bundled `vigilante-local-service-dependencies` skill and reuse its structured output before creating workspace-specific ad hoc service setup.
 - When containerized local services are still needed after that analysis, use the shared `docker-compose-launch` contract from the prompt so service startup remains scoped to the assigned worktree.
 
-5. Validate incrementally
+6. Validate incrementally
 - Run the most relevant package/app/workspace checks first, then expand only if needed.
 - If validation fails, first inspect the per-issue session log with `vigilante logs --repo <owner/name> --issue <n>` to determine whether the problem is in the code, test setup, or environment before retrying.
 
-6. Commit, push, and open a pull request
+7. Commit, push, and open a pull request
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Commit only issue-relevant changes in the assigned branch.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.
 - Push the assigned branch to the remote.
-- Open a pull request targeting the repository default branch unless repository instructions say otherwise.
+- Open a pull request targeting the repository default branch unless the issue specified a stacked base branch in step 4 or other repository instructions say otherwise.
+- When a stacked base branch was specified, pass `--base <base>` to `vigilante gh pr create` and state in the PR body and the PR-opened issue comment that the PR is stacked on `<base>`.
 
-7. Report progress and failures clearly
+8. Report progress and failures clearly
 - Use `vigilante gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
 - If execution is blocked, validation fails, or a resumed session is unclear, inspect `vigilante logs --repo <owner/name> --issue <n>` before retrying or reporting the blocker.
+- A `Base branch:` directive that points at a branch missing from the remote is a blocker: comment a failure on the issue and stop instead of falling back to the default branch.
 - Keep comments concise, factual, and tied to real progress.

--- a/skills/vigilante-issue-implementation-on-nx/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-nx/SKILL.md
@@ -11,7 +11,7 @@ description: Implement a GitHub issue end-to-end when Vigilante dispatches work 
 - If local services are required, call `vigilante-local-service-dependencies` first and then use the shared `docker-compose-launch` contract instead of writing ad hoc Compose logic.
 
 ## Workflow
-- Follow the base `vigilante-issue-implementation-on-monorepo` workflow for issue comments, validation, push, and PR creation.
+- Follow the base `vigilante-issue-implementation-on-monorepo` workflow for issue comments, validation, push, and PR creation, including stacked base-branch detection (`Base branch:` directive in the issue body).
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.

--- a/skills/vigilante-issue-implementation-on-php/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-php/SKILL.md
@@ -34,7 +34,7 @@ description: Implement a GitHub issue end-to-end when Vigilante dispatches work 
 - Do not assume a PHP repository is PHP-only. Read process hints and workspace signals in the prompt to understand the full repository structure.
 
 ## Workflow
-- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation.
+- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation, including stacked base-branch detection (`Base branch:` directive in the issue body).
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.

--- a/skills/vigilante-issue-implementation-on-python/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-python/SKILL.md
@@ -32,7 +32,7 @@ description: Implement a GitHub issue end-to-end when Vigilante dispatches work 
 - Do not store secrets, tokens, or credentials in source files.
 
 ## Workflow
-- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation.
+- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation, including stacked base-branch detection (`Base branch:` directive in the issue body).
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.

--- a/skills/vigilante-issue-implementation-on-ruby/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-ruby/SKILL.md
@@ -29,7 +29,7 @@ description: Implement a GitHub issue end-to-end when Vigilante dispatches work 
 - Scope Ruby validation to Ruby files and repo-defined Ruby commands for Ruby-scoped changes. When the issue also touches frontend or other language code, validate each side with its respective toolchain.
 
 ## Workflow
-- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation.
+- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation, including stacked base-branch detection (`Base branch:` directive in the issue body).
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.

--- a/skills/vigilante-issue-implementation-on-rush-monorepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-rush-monorepo/SKILL.md
@@ -32,27 +32,39 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - After inspecting the issue and repository constraints, post a concise implementation plan to the issue using `vigilante gh issue comment`.
 - The plan comment should name the likely Rush package or app scope when it is already clear, or state that scope detection is the next step.
 
-4. Implement inside the assigned worktree only
+4. Detect a stacked base branch
+- Scan the issue body for an explicit, single-line directive of the form `Base branch: <branch-name>` (label is case-insensitive; `<branch-name>` is trimmed and may be surrounded by backticks).
+- Only honor the directive when it appears as its own top-level line in the issue body. Do not infer a stacked base from prose or sub-issue links.
+- If no directive is present, branch from and target the watch target's base branch as today.
+- When the directive is present:
+  - Run `git fetch origin <base>` inside the assigned worktree before code changes.
+  - If the fetch fails because the branch does not exist on the remote, stop work, post a failure comment on the issue, and do not silently fall back to the default branch.
+  - Re-root the work branch onto `origin/<base>` with `git reset --hard origin/<base>` (no commits yet) or `git rebase origin/<base>` (commits present).
+  - Use `<base>` as the PR target later and mention it in the implementation-plan comment.
+
+5. Implement inside the assigned worktree only
 - Use only the provided worktree path.
 - Never edit the root checkout when a worktree was assigned.
 - Keep changes scoped to the issue.
 - Prefer native repository tooling and avoid unnecessary new dependencies.
 - When multiple Rush projects exist, determine the relevant package or app before making broad edits.
 
-5. Validate incrementally with Rush-compatible commands
+6. Validate incrementally with Rush-compatible commands
 - Prefer targeted Rush validation for the affected package or app, such as repo-defined `rush test`, `rush build`, `rushx`, phased commands, or package-level scripts invoked through Rush-compatible flows.
 - Avoid full-repo validation unless the repository workflow requires it or targeted validation is unavailable.
 - If validation fails, first inspect the per-issue session log with `vigilante logs --repo <owner/name> --issue <n>` to determine whether the problem is in the code, test setup, or environment before retrying.
 
-6. Commit, push, and open a pull request
+7. Commit, push, and open a pull request
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Commit only issue-relevant changes in the assigned branch.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.
 - Push the assigned branch to the remote.
-- Open a pull request targeting the repository default branch unless repository instructions say otherwise.
+- Open a pull request targeting the repository default branch unless the issue specified a stacked base branch in step 4 or other repository instructions say otherwise.
+- When a stacked base branch was specified, pass `--base <base>` to `vigilante gh pr create` and state in the PR body and the PR-opened issue comment that the PR is stacked on `<base>`.
 
-7. Report progress and failures clearly
+8. Report progress and failures clearly
 - Use `vigilante gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
 - If execution is blocked, validation fails, or a resumed session is unclear, inspect `vigilante logs --repo <owner/name> --issue <n>` before retrying or reporting the blocker.
+- A `Base branch:` directive that points at a branch missing from the remote is a blocker: comment a failure on the issue and stop instead of falling back to the default branch.
 - Keep comments concise, factual, and tied to real progress.

--- a/skills/vigilante-issue-implementation-on-rush/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-rush/SKILL.md
@@ -11,7 +11,7 @@ description: Implement a GitHub issue end-to-end when Vigilante dispatches work 
 - If local services are required, call `vigilante-local-service-dependencies` first and then use the shared `docker-compose-launch` contract instead of writing ad hoc Compose logic.
 
 ## Workflow
-- Follow the base `vigilante-issue-implementation-on-monorepo` workflow for issue comments, validation, push, and PR creation.
+- Follow the base `vigilante-issue-implementation-on-monorepo` workflow for issue comments, validation, push, and PR creation, including stacked base-branch detection (`Base branch:` directive in the issue body).
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.

--- a/skills/vigilante-issue-implementation-on-rust/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-rust/SKILL.md
@@ -29,7 +29,7 @@ description: Implement a GitHub issue end-to-end when Vigilante dispatches work 
 - When the repository also contains other stacks such as Node.js or Go, scope Cargo commands to Rust crates only and validate the other side with its own toolchain only when the issue actually touches it.
 
 ## Workflow
-- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation.
+- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation, including stacked base-branch detection (`Base branch:` directive in the issue body).
 - If validation, tool setup, or push/PR execution fails, inspect `vigilante logs --repo <owner/name> --issue <n>` before retrying or reporting the blocker so the session transcript guides the next safe step.
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.

--- a/skills/vigilante-issue-implementation-on-terraform/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-terraform/SKILL.md
@@ -46,7 +46,7 @@ description: Implement a GitHub issue end-to-end when Vigilante dispatches work 
 - When an issue touches both Terraform and application code, validate each side with its own toolchain.
 
 ## Workflow
-- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation.
+- Follow the base `vigilante-issue-implementation` workflow for issue comments, validation, push, and PR creation, including stacked base-branch detection (`Base branch:` directive in the issue body).
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.

--- a/skills/vigilante-issue-implementation-on-turborepo/SKILL.md
+++ b/skills/vigilante-issue-implementation-on-turborepo/SKILL.md
@@ -38,7 +38,17 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - After inspecting the issue and repository constraints, post a concise implementation plan to the issue using `vigilante gh issue comment`.
 - Mention the initial workspace target or the short list of candidate workspaces when that scope is already known.
 
-4. Implement inside the assigned worktree only
+4. Detect a stacked base branch
+- Scan the issue body for an explicit, single-line directive of the form `Base branch: <branch-name>` (label is case-insensitive; `<branch-name>` is trimmed and may be surrounded by backticks).
+- Only honor the directive when it appears as its own top-level line in the issue body. Do not infer a stacked base from prose or sub-issue links.
+- If no directive is present, branch from and target the watch target's base branch as today.
+- When the directive is present:
+  - Run `git fetch origin <base>` inside the assigned worktree before code changes.
+  - If the fetch fails because the branch does not exist on the remote, stop work, post a failure comment on the issue, and do not silently fall back to the default branch.
+  - Re-root the work branch onto `origin/<base>` with `git reset --hard origin/<base>` (no commits yet) or `git rebase origin/<base>` (commits present).
+  - Use `<base>` as the PR target later and mention it in the implementation-plan comment.
+
+5. Implement inside the assigned worktree only
 - Use only the provided worktree path.
 - Never edit the root checkout when a worktree was assigned.
 - Keep changes scoped to the issue.
@@ -46,22 +56,24 @@ Implement one GitHub issue from Vigilante dispatch through validated code change
 - Use workspace-aware commands such as `pnpm --filter <workspace> ...`, workspace-local scripts, or `turbo run <task> --filter=<workspace>` instead of repo-wide commands when possible.
 - If the selected workspace needs local database services, call the bundled `vigilante-local-service-dependencies` skill before ad hoc setup, and use `docker-compose-launch` when the repository exposes that flow.
 
-5. Validate incrementally
+6. Validate incrementally
 - Run the smallest relevant workspace-aware checks first for install, lint, build, test, typecheck, or app verification.
 - Prefer commands already defined in `package.json`, workspace manifests, or `turbo.json`.
 - Expand validation scope only when the changed package affects shared dependencies, downstream apps, or integration behavior.
 - If validation fails, first inspect the per-issue session log with `vigilante logs --repo <owner/name> --issue <n>` to determine whether the problem is in the code, test setup, or environment before retrying.
 
-6. Commit, push, and open a pull request
+7. Commit, push, and open a pull request
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Commit only issue-relevant changes in the assigned branch.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
 - Do not add `Co-authored by:` trailers or any other agent attribution for Codex, Claude, Gemini, or similar coding-agent identities.
 - Push the assigned branch to the remote.
-- Open a pull request targeting the repository default branch unless repository instructions say otherwise.
+- Open a pull request targeting the repository default branch unless the issue specified a stacked base branch in step 4 or other repository instructions say otherwise.
+- When a stacked base branch was specified, pass `--base <base>` to `vigilante gh pr create` and state in the PR body and the PR-opened issue comment that the PR is stacked on `<base>`.
 
-7. Report progress and failures clearly
+8. Report progress and failures clearly
 - Use `vigilante gh issue comment` for progress updates, milestone updates, PR creation, and execution failures.
 - If execution is blocked, validation fails, or a resumed session is unclear, inspect `vigilante logs --repo <owner/name> --issue <n>` before retrying or reporting the blocker.
+- A `Base branch:` directive that points at a branch missing from the remote is a blocker: comment a failure on the issue and stop instead of falling back to the default branch.
 - Keep comments concise, factual, and tied to real progress.
 - Include the selected workspace scope in milestone updates when that information helps reviewers follow the implementation.

--- a/skills/vigilante-issue-implementation/SKILL.md
+++ b/skills/vigilante-issue-implementation/SKILL.md
@@ -36,7 +36,18 @@ Require these inputs from Vigilante:
 - The plan comment should describe the intended development steps before substantial code changes begin.
 - Keep the plan concrete and short so readers can understand what will happen next.
 
-4. Implement inside the assigned worktree only
+4. Detect a stacked base branch
+- Before implementing, scan the issue body for an explicit, single-line directive of the form `Base branch: <branch-name>` (label is case-insensitive; `<branch-name>` is trimmed and may be surrounded by backticks).
+- Only honor the directive when it appears as its own top-level line in the issue body. Do not infer a stacked base from prose, linked issue numbers, native sub-issue relationships, or branch names mentioned elsewhere in the issue.
+- If no such directive is present, follow the default workflow: branch from and target the watch target's base branch as today.
+- If the directive is present:
+  - Run `git fetch origin <base>` from inside the assigned worktree before any other code changes.
+  - If `git fetch origin <base>` fails because the branch does not exist on the remote, stop work, post a failure comment on the issue explaining that the specified stacked base branch is missing on the remote, and do not silently fall back to the default branch.
+  - When the fetch succeeds, re-root the work branch onto `origin/<base>` with either `git reset --hard origin/<base>` (preferred when the assigned branch has no commits yet) or `git rebase origin/<base>` (when commits already exist on the work branch).
+  - Use `<base>` instead of the repository default branch when opening the pull request later in the workflow.
+  - Mention the stacked base branch in the implementation-plan comment so reviewers see it before code changes start.
+
+5. Implement inside the assigned worktree only
 - Use only the provided worktree path.
 - Never edit the root checkout when a worktree was assigned.
 - Keep changes scoped to the issue.
@@ -47,12 +58,12 @@ Service dependencies:
 - If app startup, migrations, or tests need local services, call the bundled `vigilante-local-service-dependencies` skill before inventing ad hoc setup steps.
 - Prefer the skill's repository-native path first, and use its structured output to decide which env vars, commands, or cleanup steps the rest of the implementation should use.
 
-5. Validate incrementally
+6. Validate incrementally
 - Run relevant tests, builds, or linters for the changed area before concluding work.
 - Prefer targeted validation first, then broader validation when necessary.
 - If a command fails, first inspect the per-issue session log with `vigilante logs --repo <owner/name> --issue <n>` to determine whether the problem is in the code, test setup, or environment before retrying.
 
-6. Commit and push the branch
+7. Commit and push the branch
 - Use `vigilante commit` for all commit-producing operations. Do not use `git commit` or GitHub CLI commit flows directly.
 - Commit only issue-relevant changes in the assigned branch.
 - Any commit or amend must preserve the user's existing git author, committer, and signing configuration. Commit on behalf of the user and do not overwrite `git config` with a coding-agent identity.
@@ -60,28 +71,31 @@ Service dependencies:
 - Push the assigned branch to the remote with `vigilante git push`.
 - Do not leave completed implementation work only in the local worktree.
 
-7. Open a pull request
+8. Open a pull request
 - Always create a pull request for the completed change set.
-- Target the repository default branch unless repository instructions say otherwise.
+- Target the repository default branch unless the issue specified a stacked base branch in step 4 or other repository instructions say otherwise.
+- When a stacked base branch was specified, pass `--base <base>` to `vigilante gh pr create` and state in the PR body that the PR is stacked on `<base>` instead of the repository default branch.
 - Include `Closes #<issue-number>` in the PR body as a required invariant.
 - Include concise validation notes in the PR description.
 
-8. Post progress comments at meaningful milestones
+9. Post progress comments at meaningful milestones
 - Use `vigilante gh issue comment` for progress updates.
 - Comment when investigation is complete and implementation starts.
 - Comment when major milestones are reached, such as a core fix landing or tests passing.
 - Comment when the branch has been pushed and the PR has been opened.
+- When the PR is opened on a stacked base branch, the PR-opened comment must state which branch the PR is stacked on.
 - Keep comments concise and factual.
 - Do not spam the issue with low-signal updates.
 
-9. Handle failures and blockers explicitly
+10. Handle failures and blockers explicitly
 - If tool setup fails, validation fails, the provider stops unexpectedly, a resumed session still looks unclear, or the issue is otherwise blocked, first inspect the per-issue session log with `vigilante logs --repo <owner/name> --issue <n>`.
 - After checking the log, comment on the issue with the concrete problem using `vigilante gh issue comment`.
 - Use `vigilante logs` for targeted local triage only when work is blocked or failing; do not turn it into routine log scraping on successful runs.
 - Include enough detail for a human maintainer to understand the current state and next step.
 - If work cannot proceed safely, stop and report the blocker instead of guessing.
+- A `Base branch:` directive that points at a branch missing from the remote is one of these blockers: comment a failure on the issue and stop instead of falling back to the default branch.
 
-10. Finish with a clear terminal state
+11. Finish with a clear terminal state
 - Leave the worktree in a coherent state.
 - Ensure any executed validations are accurately reported.
 - If the task completed successfully, summarize what changed, what was validated, and which PR was opened.


### PR DESCRIPTION
## Summary

Adds a `Base branch: <branch-name>` directive that issue authors can place on a single top-level line of an issue body to ask Vigilante to implement that issue on top of an in-flight branch (a stacked PR) instead of the watch target's default branch.

When the directive is present, the implementation skills now:

- fetch `origin/<branch-name>` and re-root the work branch onto it before changing code
- target the resulting pull request at `<branch-name>` instead of the repository default branch (`vigilante gh pr create --base <name>`)
- state in the PR body and the PR-opened issue comment that the PR is stacked on `<branch-name>`
- fail the session with a comment on the issue when `<branch-name>` is missing from the remote, rather than silently falling back to the default branch

When the directive is absent, behavior is unchanged: branch from and target the watch target's base branch as today.

## Scope

- Prompt-level only. The base skill `vigilante-issue-implementation/SKILL.md` and the monorepo base `vigilante-issue-implementation-on-monorepo/SKILL.md` carry the full workflow step. Each delegating variant (`-on-go`, `-on-bazel`, `-on-rush`, `-on-nx`, …) gets an explicit "including stacked base-branch detection" pointer on its `Follow the base ... workflow` line. The four variants that duplicate the workflow (`-on-turborepo`, `-on-rush-monorepo`, `-on-bazel-monorepo`, `-on-gradle-multi-project`) get the full step inline.
- `vigilante-create-issue/SKILL.md` and `DOCS.md` document the convention so authors know how to express it.
- Detection is explicit only: prose mentions of other branches, linked issue numbers, and native sub-issue relationships are ignored.
- No code changes in `internal/app/app.go` — the existing `pullRequestBaseBranch` / `effectiveSessionBaseBranch` and PR-maintenance loop already track whatever base the PR is opened against.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./internal/skill/... -count=1` (embedded-skill assets still load)
- [x] `go test ./... -count=1`
- [ ] Manual: run an issue with `Base branch: feature/foo` against a remote feature branch and confirm the PR base + branch ancestry.
- [ ] Manual: run a control issue without the directive and confirm unchanged default-branch behavior.
- [ ] Manual: run an issue with `Base branch: does-not-exist` and confirm a failure comment, not a silent fallback.

Closes #468