### PR TITLE
Rotate local logs and cap ~/.vigilante/logs/ at a configurable 500MB total

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -336,10 +336,17 @@ Inspect local log files under `~/.vigilante/logs/`.
 
 Expected behavior:
 
-- `vigilante logs` lists the available daemon, access, and per-issue session logs so an operator can see which local evidence exists before choosing a recovery action
+- `vigilante logs` lists the available daemon, access, and per-issue session logs so an operator can see which local evidence exists before choosing a recovery action, including rotated backups such as `vigilante.log.1`
 - `vigilante logs --access` prints the structured access log at `~/.vigilante/logs/access.jsonl`, where each JSON line records one subprocess execution with timing, execution context, repo or issue metadata when available, sanitized argv, and exit status
 - `vigilante logs --repo <owner/name> --issue <n>` prints the log for one issue session so an operator can inspect the latest local execution details directly
+- all read paths always show the current log file; rotated backups carry a numeric suffix and are listed but not concatenated into the current output
+- both follow modes (`vigilante logs -f` and `vigilante logs --access -w`) reopen the log path on every poll, so following continues across a rotation — expect a visible seam where the current file restarts, not an error
 - logs complement `vigilante list`, `vigilante status`, and GitHub issue comments; they do not replace session state or the remote audit trail
+
+Log files are size-bounded. Every log write path rotates its file once it exceeds
+`log_max_file_size`, and the total size of `~/.vigilante/logs/` is capped at
+`log_max_total_size` (default 500MB). See
+[Log Rotation and Disk Budget](#log-rotation-and-disk-budget).
 
 ### `vigilante service restart`
 
@@ -579,13 +586,16 @@ Initial files:
 - `config.json`: service-level daemon configuration
 - `watchlist.json`: configured repositories being monitored
 - `sessions.json`: active or recent issue execution sessions
-- `logs/`: daemon and run logs
+- `logs/`: daemon and run logs, plus their rotated backups, size-capped at `log_max_total_size` (default 500MB) in total
 
 Suggested `config.json` shape:
 
 ```json
 {
-  "blocked_session_inactivity_timeout": "20m"
+  "blocked_session_inactivity_timeout": "20m",
+  "log_max_total_size": "500MB",
+  "log_max_file_size": "50MB",
+  "log_max_backups": 3
 }
 ```
 
@@ -593,10 +603,53 @@ Notes:
 
 - `blocked_session_inactivity_timeout` is a service-level setting shared across all watched repositories.
 - The default is `20m`.
+- `log_max_total_size`, `log_max_file_size`, and `log_max_backups` bound local log growth; see [Log Rotation and Disk Budget](#log-rotation-and-disk-budget). All three are optional and default to `500MB`, `50MB`, and `3`.
 - A blocked session is eligible for automatic local cleanup only after there have been no qualifying user comments on the issue, no session updates, and no worktree updates for longer than the configured timeout.
 - This inactivity cleanup is conservative: it clears local blocked-session artifacts so the issue can be redispatched later, but it does not delete remote pull requests or remote branches automatically.
 - Stale running implementation sessions use a separate recovery path: after Vigilante first confirms the run is stale, it waits 20 minutes before attempting an automatic fresh restart, persists the restart attempt count in session state, and stops after 3 automatic restarts until a human intervenes.
 - When an issue looks blocked or the daemon appears unhealthy, inspect `vigilante logs` alongside `sessions.json`, `vigilante list`, `vigilante status`, and GitHub issue comments so recovery decisions use both local state and remote context.
+- Local log evidence is size-bounded, so it does not persist indefinitely. When investigating an older failure, collect the relevant logs before continued daemon activity pushes the directory over budget and evicts them.
+
+### Log Rotation and Disk Budget
+
+Vigilante bounds the disk it uses for local logs so a long-running daemon cannot
+fill the operator's disk. Two limits work together:
+
+- **Per-file rotation.** Each log file rotates once a write would push it past
+  `log_max_file_size` (default `50MB`). The current file is renamed to
+  `<name>.1`, existing backups shift up (`<name>.1` becomes `<name>.2`, and so
+  on), and the writer immediately reopens the original path. `log_max_backups`
+  (default `3`) retained backups are kept per file; older generations are
+  deleted. Backups are uncompressed, so they stay readable with ordinary tools.
+- **Directory budget.** The total size of `~/.vigilante/logs/` is capped at
+  `log_max_total_size` (default `500MB`). A sweep runs after every rotation, at
+  daemon start, and on each scan tick. It evicts rotated backups first (oldest
+  generation first), then logs for completed sessions by least recent
+  modification.
+
+The sweep never deletes the current `vigilante.log`, the current `access.jsonl`,
+or the session log of a session that is still running, blocked, or resuming. If
+the live files alone exceed the budget, the sweep stops rather than deleting a
+log an active writer owns.
+
+Rotations and evictions are recorded in the daemon log, including the reclaimed
+bytes, so a missing log can be distinguished from a rotated one.
+
+Notes:
+
+- All three settings live in `~/.vigilante/config.json` and are optional.
+  Existing config files without them keep working and are not rewritten.
+- Sizes accept human-readable values (`"500MB"`, `"1GB"`, `"512KB"`) or a plain
+  byte count. Suffixes are powers of 1024.
+- An unparseable or invalid value falls back to that setting's default rather
+  than disabling rotation — logging never prevents the daemon from starting.
+- Enforcement covers every write path: the daemon log, the access log, and
+  per-issue session logs, including the streaming provider output that dominates
+  log volume.
+- Upgrading with an already-oversized logs directory needs no manual step: the
+  first daemon start sweeps it back within budget and logs the eviction.
+- This is a size-driven policy only. There is no time-based retention, and
+  `vigilante cleanup` semantics are unchanged — it does not delete logs.
 
 ### Operator Log Triage
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -174,6 +174,7 @@ func (f *stringListFlag) Set(value string) error {
 
 func New() *App {
 	store := state.NewStore()
+	configureLogRotation(store)
 	logger, err := logging.NewDaemonLogger(store.DaemonLogPath())
 	if err != nil {
 		logger = logging.Discard()
@@ -1994,6 +1995,10 @@ func (a *App) DaemonRun(ctx context.Context, interval time.Duration, once bool) 
 		})
 	}()
 
+	// Bring an already-oversized logs directory back within budget before doing
+	// any work, so upgrading operators do not need a manual cleanup step.
+	a.sweepLogsDir()
+
 	// Initialize sandbox manager if sandbox mode is enabled.
 	if err := a.initSandboxIfEnabled(ctx); err != nil {
 		a.logger.Warn("sandbox initialization skipped", "err", err)
@@ -2016,6 +2021,8 @@ func (a *App) DaemonRun(ctx context.Context, interval time.Duration, once bool) 
 			a.logger.Error("scan error", "err", err)
 			fmt.Fprintln(a.stderr, "scan error:", err)
 		}
+
+		a.sweepLogsDir()
 
 		select {
 		case <-ctx.Done():

--- a/internal/app/logrotation_test.go
+++ b/internal/app/logrotation_test.go
@@ -1,0 +1,351 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nicobistolfi/vigilante/internal/environment"
+	"github.com/nicobistolfi/vigilante/internal/logging"
+	"github.com/nicobistolfi/vigilante/internal/state"
+	"github.com/nicobistolfi/vigilante/internal/testutil"
+)
+
+// newRotationTestApp points the app at an isolated VIGILANTE_HOME with a tiny
+// rotation size, so tests exercise rotation without writing 500MB.
+func newRotationTestApp(t *testing.T, limits logging.Limits) *App {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	app := New()
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	logging.Configure(limits, app.state.LiveLogPaths, nil)
+	t.Cleanup(func() {
+		_ = logging.OpenWriter(app.state.DaemonLogPath()).Close()
+		_ = logging.OpenWriter(app.state.AccessLogPath()).Close()
+		logging.Configure(logging.DefaultLimits(), nil, nil)
+	})
+	app.stderr = testutil.IODiscard{}
+	return app
+}
+
+func TestConfigureLogRotationUsesConfiguredLimits(t *testing.T) {
+	home := t.TempDir()
+	root := filepath.Join(home, ".vigilante")
+	t.Setenv("HOME", home)
+	t.Setenv("VIGILANTE_HOME", root)
+
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	backups := 1
+	if err := store.SaveServiceConfig(state.ServiceConfig{
+		LogMaxTotalSize: "4MB",
+		LogMaxFileSize:  "1MB",
+		LogMaxBackups:   &backups,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { logging.Configure(logging.DefaultLimits(), nil, nil) })
+
+	limits := configureLogRotation(store)
+	if limits.MaxTotalSize != 4*1024*1024 || limits.MaxFileSize != 1024*1024 || limits.MaxBackups != 1 {
+		t.Fatalf("unexpected limits: %+v", limits)
+	}
+	if got := logging.CurrentLimits(); got != limits {
+		t.Fatalf("CurrentLimits() = %+v, want %+v", got, limits)
+	}
+}
+
+// A malformed size must not stop the daemon from starting or from logging.
+func TestConfigureLogRotationFallsBackAndKeepsLogging(t *testing.T) {
+	home := t.TempDir()
+	root := filepath.Join(home, ".vigilante")
+	t.Setenv("HOME", home)
+	t.Setenv("VIGILANTE_HOME", root)
+
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	malformed := `{"log_max_total_size": "definitely not a size", "log_max_file_size": "-7"}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "config.json"), []byte(malformed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { logging.Configure(logging.DefaultLimits(), nil, nil) })
+
+	app := New()
+	if got := logging.CurrentLimits(); got != logging.DefaultLimits() {
+		t.Fatalf("CurrentLimits() = %+v, want defaults %+v", got, logging.DefaultLimits())
+	}
+
+	app.logger.Info("daemon still logging")
+	data, err := os.ReadFile(app.state.DaemonLogPath())
+	if err != nil {
+		t.Fatalf("read daemon log: %v", err)
+	}
+	if !strings.Contains(string(data), "daemon still logging") {
+		t.Fatalf("daemon log missing line: %q", data)
+	}
+}
+
+// The daemon logger is created once for the process lifetime; it must keep
+// writing to the current file after a rotation instead of the renamed inode.
+func TestDaemonLoggerKeepsLoggingAcrossRotation(t *testing.T) {
+	app := newRotationTestApp(t, logging.Limits{MaxFileSize: 400, MaxBackups: 3, MaxTotalSize: 1 << 20})
+
+	for i := range 25 {
+		app.logger.Info("scan tick", "iteration", i, "padding", strings.Repeat("q", 20))
+	}
+	app.logger.Info("line after rotation")
+
+	if _, err := os.Stat(app.state.DaemonLogPath() + ".1"); err != nil {
+		t.Fatalf("expected a rotated daemon log: %v", err)
+	}
+	current, err := os.ReadFile(app.state.DaemonLogPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(current), "line after rotation") {
+		t.Fatalf("daemon stopped logging into the current file: %q", current)
+	}
+}
+
+func TestLogsListingIncludesRotatedFiles(t *testing.T) {
+	app := newRotationTestApp(t, logging.Limits{MaxFileSize: 300, MaxBackups: 3, MaxTotalSize: 1 << 20})
+
+	for i := range 20 {
+		app.state.AppendDaemonLog("daemon line %d with padding to force a rotation", i)
+	}
+
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	if code := app.Run(context.Background(), []string{"logs"}); code != 0 {
+		t.Fatalf("logs exited with %d", code)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "vigilante.log\n") && !strings.Contains(output, "vigilante.log ") {
+		t.Fatalf("listing missing current log: %q", output)
+	}
+	if !strings.Contains(output, "vigilante.log.1") {
+		t.Fatalf("listing missing rotated log: %q", output)
+	}
+}
+
+func TestLogsAccessReadsCurrentFileAfterRotation(t *testing.T) {
+	app := newRotationTestApp(t, logging.Limits{MaxFileSize: 300, MaxBackups: 3, MaxTotalSize: 1 << 20})
+
+	for i := range 20 {
+		app.state.AppendAccessLogEntry(newTestAccessLogEntry(i))
+	}
+	if _, err := os.Stat(app.state.AccessLogPath() + ".1"); err != nil {
+		t.Fatalf("expected the access log to have rotated: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	if code := app.Run(context.Background(), []string{"logs", "--access"}); code != 0 {
+		t.Fatalf("logs --access exited with %d: %q", code, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "git status") {
+		t.Fatalf("expected rendered access entries, got %q", stdout.String())
+	}
+}
+
+func TestLogsRepoIssueReadsCurrentFileAfterRotation(t *testing.T) {
+	app := newRotationTestApp(t, logging.Limits{MaxFileSize: 200, MaxBackups: 3, MaxTotalSize: 1 << 20})
+
+	path := app.state.SessionLogPath("owner/repo", 472)
+	writer := logging.OpenWriter(path)
+	t.Cleanup(func() { _ = writer.Close() })
+	for i := range 20 {
+		if _, err := fmt.Fprintf(writer, "session line %d with padding\n", i); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Fatalf("expected the session log to have rotated: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	if code := app.Run(context.Background(), []string{"logs", "--repo", "owner/repo", "--issue", "472"}); code != 0 {
+		t.Fatalf("logs --repo/--issue exited with %d: %q", code, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "session line 19") {
+		t.Fatalf("expected the current session log contents, got %q", stdout.String())
+	}
+}
+
+// Following a session log must survive a rotation: watchPlaintextLog resets its
+// byte offset when the file shrinks, so new lines keep arriving.
+func TestWatchSessionLogSurvivesRotation(t *testing.T) {
+	app := newRotationTestApp(t, logging.Limits{MaxFileSize: 120, MaxBackups: 3, MaxTotalSize: 1 << 20})
+
+	path := app.state.SessionLogPath("owner/repo", 8)
+	writer := logging.OpenWriter(path)
+	t.Cleanup(func() { _ = writer.Close() })
+	if _, err := writer.Write([]byte("before rotation\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// The follow runs in a goroutine while the test reads what it printed, so the
+	// sink has to be safe for concurrent use.
+	stdout := &syncBuffer{}
+	app.stdout = stdout
+
+	done := make(chan error, 1)
+	go func() { done <- app.watchSessionLog(ctx, path) }()
+
+	time.Sleep(150 * time.Millisecond)
+
+	// Force a rotation, then write past it.
+	if _, err := writer.Write([]byte(strings.Repeat("f", 130) + "\n")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Fatalf("expected a rotation while following: %v", err)
+	}
+	if _, err := writer.Write([]byte("after rotation\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(stdout.String(), "after rotation") {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	cancel()
+	if err := <-done; err != nil && !strings.Contains(err.Error(), context.Canceled.Error()) {
+		t.Fatalf("watchSessionLog returned %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "before rotation") {
+		t.Fatalf("expected pre-rotation content, got %q", output)
+	}
+	if !strings.Contains(output, "after rotation") {
+		t.Fatalf("follow stopped emitting after rotation, got %q", output)
+	}
+}
+
+func TestSweepLogsDirEnforcesBudget(t *testing.T) {
+	app := newRotationTestApp(t, logging.Limits{MaxFileSize: 1 << 20, MaxBackups: 3, MaxTotalSize: 900})
+
+	daemonLog := app.state.DaemonLogPath()
+	blob := strings.Repeat("x", 400)
+	for _, path := range []string{
+		daemonLog,
+		daemonLog + ".1",
+		daemonLog + ".2",
+		app.state.AccessLogPath(),
+		app.state.SessionLogPath("owner/repo", 1),
+	} {
+		if err := os.WriteFile(path, []byte(blob), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	before := logsDirSize(t, app.state.LogsDir())
+	daemonBefore := fileSize(t, daemonLog)
+
+	app.sweepLogsDir()
+
+	// The sweep records its own audit line in the daemon log, so discount that
+	// growth when checking convergence.
+	after := logsDirSize(t, app.state.LogsDir()) - (fileSize(t, daemonLog) - daemonBefore)
+	if before <= 900 {
+		t.Fatalf("test setup did not exceed the budget: %d", before)
+	}
+	if after > 900 {
+		t.Fatalf("logs directory size after sweep = %d, want <= 900", after)
+	}
+	for _, path := range []string{daemonLog, app.state.AccessLogPath()} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("live log %s was evicted: %v", path, err)
+		}
+	}
+}
+
+func logsDirSize(t *testing.T, dir string) int64 {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var total int64
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		total += info.Size()
+	}
+	return total
+}
+
+func fileSize(t *testing.T, path string) int64 {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return info.Size()
+}
+
+// A sweep failure must be logged and swallowed, never returned up the daemon loop.
+func TestSweepLogsDirIsNonFatalWhenLogsDirIsMissing(t *testing.T) {
+	app := newRotationTestApp(t, logging.Limits{MaxFileSize: 1 << 20, MaxBackups: 3, MaxTotalSize: 100})
+
+	if err := os.RemoveAll(app.state.LogsDir()); err != nil {
+		t.Fatal(err)
+	}
+	app.sweepLogsDir()
+}
+
+func newTestAccessLogEntry(i int) environment.AccessLogEntry {
+	return environment.AccessLogEntry{
+		Timestamp:        "2026-07-30T12:00:00Z",
+		ExecutionContext: "scan",
+		Tool:             "git",
+		Argv:             []string{"git", "status"},
+		ExitCode:         0,
+		DurationMs:       int64(i),
+		Success:          true,
+	}
+}
+
+// syncBuffer is a bytes.Buffer that is safe to write from a follow goroutine
+// while the test reads it.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}

--- a/internal/app/logs.go
+++ b/internal/app/logs.go
@@ -12,7 +12,53 @@ import (
 	"time"
 
 	"github.com/nicobistolfi/vigilante/internal/environment"
+	"github.com/nicobistolfi/vigilante/internal/logging"
+	"github.com/nicobistolfi/vigilante/internal/state"
 )
+
+// configureLogRotation applies the operator's configured rotation limits to
+// every log write path in the process and records rotations and evictions in the
+// daemon log, so operators can tell rotated logs apart from missing ones.
+// Unreadable or malformed configuration falls back to the built-in defaults.
+func configureLogRotation(store *state.Store) logging.Limits {
+	config, err := store.LoadServiceConfig()
+	if err != nil {
+		config = state.ServiceConfig{}
+	}
+	limits := config.LogRotationLimits()
+	logging.Configure(limits, store.LiveLogPaths, func(ev logging.Event) {
+		switch ev.Kind {
+		case logging.EventEvict:
+			store.AppendDaemonLog("log budget enforced: evicted %d file(s), reclaimed %s from %s",
+				len(ev.Removed), logging.FormatSize(ev.ReclaimedByte), ev.Path)
+		default:
+			store.AppendDaemonLog("rotated log file %s (max_file_size=%s)",
+				ev.Path, logging.FormatSize(limits.MaxFileSize))
+		}
+	})
+	return limits
+}
+
+// sweepLogsDir brings the logs directory back within the configured total
+// budget. It is best-effort: a failed sweep is logged and otherwise ignored.
+func (a *App) sweepLogsDir() {
+	limits := logging.CurrentLimits()
+	result, err := a.state.SweepLogs(limits)
+	if err != nil {
+		a.logger.Warn("log sweep failed", "err", err)
+		return
+	}
+	if len(result.Removed) == 0 {
+		return
+	}
+	a.logger.Info("log sweep evicted files",
+		"files", len(result.Removed),
+		"reclaimed_bytes", result.Reclaimed,
+		"total_before_bytes", result.TotalBefore,
+		"total_after_bytes", result.TotalAfter,
+		"max_total_size", logging.FormatSize(limits.MaxTotalSize),
+	)
+}
 
 func formatAccessLogEntry(e environment.AccessLogEntry) string {
 	var b strings.Builder
@@ -107,76 +153,28 @@ func (a *App) waitForFile(ctx context.Context, path string) error {
 // data until the context is canceled. If the file does not yet exist, it waits
 // for the file to appear before tailing.
 func (a *App) watchSessionLog(ctx context.Context, path string) error {
-	f, err := os.Open(path)
-	if err != nil {
+	if _, err := os.Stat(path); err != nil {
 		if waitErr := a.waitForFile(ctx, path); waitErr != nil {
 			return waitErr
 		}
-		f, err = os.Open(path)
-		if err != nil {
+		if _, err := os.Stat(path); err != nil {
 			return fmt.Errorf("no session log found for follow mode")
 		}
 	}
-	defer f.Close()
-
-	// Print existing content.
-	if _, err := io.Copy(a.stdout, f); err != nil {
-		return err
-	}
-
-	ticker := time.NewTicker(250 * time.Millisecond)
-	defer ticker.Stop()
-
-	buf := make([]byte, 4096)
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-ticker.C:
-			for {
-				n, err := f.Read(buf)
-				if n > 0 {
-					if _, wErr := a.stdout.Write(buf[:n]); wErr != nil {
-						return wErr
-					}
-				}
-				if err != nil {
-					break
-				}
-			}
-		}
-	}
+	return watchPlaintextLog(ctx, a.stdout, path, false)
 }
 
 func (a *App) watchAccessLog(ctx context.Context, path string) error {
-	f, err := os.Open(path)
-	if err != nil {
+	if _, err := os.Stat(path); err != nil {
 		return fmt.Errorf("no access log found")
 	}
-	defer f.Close()
-
-	// Print existing entries first.
-	if err := renderAccessLogStream(a.stdout, f); err != nil {
-		return err
-	}
-
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-ticker.C:
-			if err := renderAccessLogStream(a.stdout, f); err != nil {
-				return err
-			}
-		}
-	}
+	return followFile(ctx, path, false, 500*time.Millisecond, func(r io.Reader) error {
+		return renderAccessLogStream(a.stdout, r)
+	})
 }
 
-func renderAccessLogStream(w io.Writer, f *os.File) error {
-	scanner := bufio.NewScanner(f)
+func renderAccessLogStream(w io.Writer, r io.Reader) error {
+	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" {
@@ -193,6 +191,18 @@ func renderAccessLogStream(w io.Writer, f *os.File) error {
 }
 
 func watchPlaintextLog(ctx context.Context, w io.Writer, path string, startAtEnd bool) error {
+	return followFile(ctx, path, startAtEnd, 250*time.Millisecond, func(r io.Reader) error {
+		_, err := io.Copy(w, r)
+		return err
+	})
+}
+
+// followFile polls path and hands every newly appended chunk to emit until the
+// context is canceled. The file is reopened on each tick rather than held open,
+// and the byte offset resets whenever the file shrinks, so a rename-based log
+// rotation is survivable: the follow picks up the fresh current file instead of
+// tailing the rotated-away inode. Expect a visible seam at the rotation.
+func followFile(ctx context.Context, path string, startAtEnd bool, interval time.Duration, emit func(io.Reader) error) error {
 	var offset int64
 	if startAtEnd {
 		if info, err := os.Stat(path); err == nil {
@@ -200,7 +210,7 @@ func watchPlaintextLog(ctx context.Context, w io.Writer, path string, startAtEnd
 		}
 	}
 
-	ticker := time.NewTicker(250 * time.Millisecond)
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	readDelta := func() error {
@@ -226,7 +236,7 @@ func watchPlaintextLog(ctx context.Context, w io.Writer, path string, startAtEnd
 		if _, err := f.Seek(offset, io.SeekStart); err != nil {
 			return err
 		}
-		if _, err := io.Copy(w, f); err != nil {
+		if err := emit(io.LimitReader(f, info.Size()-offset)); err != nil {
 			return err
 		}
 		offset = info.Size()

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -9,18 +9,17 @@ import (
 )
 
 // NewDaemonLogger creates a *slog.Logger that writes human-readable text
-// to the daemon log file at path. The file is opened in append mode and
-// timestamps use the local timezone in RFC3339 format to match the
-// previous operator-facing log format.
+// to the daemon log file at path. Writes go through the shared rotation-aware
+// Writer for that path, so the logger keeps writing to the current file across
+// rotations instead of holding a handle on a renamed inode. Timestamps use the
+// local timezone in RFC3339 format to match the previous operator-facing log
+// format.
 func NewDaemonLogger(path string) (*slog.Logger, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, err
 	}
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
-	if err != nil {
-		return nil, err
-	}
-	handler := slog.NewTextHandler(f, &slog.HandlerOptions{
+	w := OpenWriter(path)
+	handler := slog.NewTextHandler(w, &slog.HandlerOptions{
 		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
 			if a.Key == slog.TimeKey {
 				a.Value = slog.StringValue(a.Value.Time().In(time.Local).Format(time.RFC3339))

--- a/internal/logging/rotate.go
+++ b/internal/logging/rotate.go
@@ -1,0 +1,514 @@
+package logging
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// Default rotation limits applied when configuration is absent or unparseable.
+const (
+	DefaultMaxFileSize  int64 = 50 * 1024 * 1024
+	DefaultMaxTotalSize int64 = 500 * 1024 * 1024
+	DefaultMaxBackups   int   = 3
+)
+
+// Limits describes the on-disk budget for the logs directory.
+//
+// MaxFileSize bounds a single log file before it is rotated, MaxBackups is the
+// number of rotated copies retained per file, and MaxTotalSize bounds the sum of
+// every file in the logs directory. A non-positive value disables that
+// particular limit.
+type Limits struct {
+	MaxFileSize  int64
+	MaxBackups   int
+	MaxTotalSize int64
+}
+
+// DefaultLimits returns the built-in rotation limits.
+func DefaultLimits() Limits {
+	return Limits{
+		MaxFileSize:  DefaultMaxFileSize,
+		MaxBackups:   DefaultMaxBackups,
+		MaxTotalSize: DefaultMaxTotalSize,
+	}
+}
+
+// Event kinds reported through the Configure callback.
+const (
+	EventRotate = "rotate"
+	EventEvict  = "evict"
+)
+
+// Event describes a rotation or eviction that the writer performed. It is
+// reported through the callback registered with Configure so operators can tell
+// rotated logs apart from missing ones.
+type Event struct {
+	Kind          string // EventRotate or EventEvict
+	Path          string
+	ReclaimedByte int64
+	Removed       []string
+}
+
+// ParseSize converts a human-readable size such as "500MB", "1 GiB", or a plain
+// byte count such as "1048576" into bytes. Decimal suffixes (KB, MB, GB, TB) and
+// binary suffixes (KiB, MiB, GiB, TiB) are both treated as powers of 1024, which
+// matches how operators read the existing sandbox_memory_limit values.
+func ParseSize(raw string) (int64, error) {
+	text := strings.TrimSpace(raw)
+	if text == "" {
+		return 0, errors.New("empty size")
+	}
+	unit := int64(1)
+	lower := strings.ToLower(text)
+	for _, candidate := range []struct {
+		suffix string
+		unit   int64
+	}{
+		{"tib", 1 << 40}, {"gib", 1 << 30}, {"mib", 1 << 20}, {"kib", 1 << 10},
+		{"tb", 1 << 40}, {"gb", 1 << 30}, {"mb", 1 << 20}, {"kb", 1 << 10},
+		{"t", 1 << 40}, {"g", 1 << 30}, {"m", 1 << 20}, {"k", 1 << 10},
+		{"b", 1},
+	} {
+		if strings.HasSuffix(lower, candidate.suffix) {
+			unit = candidate.unit
+			text = strings.TrimSpace(text[:len(text)-len(candidate.suffix)])
+			break
+		}
+	}
+	if text == "" {
+		return 0, fmt.Errorf("missing size value in %q", raw)
+	}
+	value, err := strconv.ParseFloat(text, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid size %q", raw)
+	}
+	// ParseFloat accepts "NaN" and "Inf"; neither is a usable byte count.
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, fmt.Errorf("invalid size %q", raw)
+	}
+	if value < 0 {
+		return 0, fmt.Errorf("negative size %q", raw)
+	}
+	scaled := value * float64(unit)
+	if scaled > float64(1<<62) {
+		return 0, fmt.Errorf("size %q out of range", raw)
+	}
+	return int64(scaled), nil
+}
+
+// FormatSize renders bytes using the same human-readable style ParseSize accepts.
+func FormatSize(bytes int64) string {
+	units := []struct {
+		suffix string
+		unit   int64
+	}{
+		{"TB", 1 << 40}, {"GB", 1 << 30}, {"MB", 1 << 20}, {"KB", 1 << 10},
+	}
+	for _, u := range units {
+		if bytes >= u.unit && bytes%u.unit == 0 {
+			return fmt.Sprintf("%d%s", bytes/u.unit, u.suffix)
+		}
+	}
+	return fmt.Sprintf("%dB", bytes)
+}
+
+var (
+	configMu    sync.RWMutex
+	activeLimit = DefaultLimits()
+	liveFunc    func() []string
+	notifyFunc  func(Event)
+
+	registryMu sync.Mutex
+	registry   = map[string]*Writer{}
+
+	notifying atomic.Bool
+)
+
+// Configure sets the process-wide rotation limits, the callback that reports the
+// log files a sweep must never evict, and an optional event sink used to log
+// rotations and evictions. It also retunes writers that were created earlier,
+// so the daemon logger opened before configuration is loaded picks up the
+// configured limits.
+func Configure(limits Limits, live func() []string, notify func(Event)) {
+	configMu.Lock()
+	activeLimit = limits
+	liveFunc = live
+	notifyFunc = notify
+	configMu.Unlock()
+
+	registryMu.Lock()
+	writers := make([]*Writer, 0, len(registry))
+	for _, w := range registry {
+		writers = append(writers, w)
+	}
+	registryMu.Unlock()
+
+	for _, w := range writers {
+		w.SetLimits(limits)
+	}
+}
+
+// CurrentLimits returns the process-wide rotation limits.
+func CurrentLimits() Limits {
+	configMu.RLock()
+	defer configMu.RUnlock()
+	return activeLimit
+}
+
+func livePaths() []string {
+	configMu.RLock()
+	fn := liveFunc
+	configMu.RUnlock()
+	if fn == nil {
+		return nil
+	}
+	return fn()
+}
+
+// notify reports an event, guarding against re-entry: the sink typically writes
+// a daemon log line, which can itself rotate and emit another event.
+func notify(ev Event) {
+	configMu.RLock()
+	fn := notifyFunc
+	configMu.RUnlock()
+	if fn == nil {
+		return
+	}
+	if !notifying.CompareAndSwap(false, true) {
+		return
+	}
+	defer notifying.Store(false)
+	fn(ev)
+}
+
+// Writer is a rotation-aware io.WriteCloser for a single log file. It renames
+// the current file aside once it exceeds the configured size and reopens the
+// original path, so callers holding a long-lived Writer never keep appending to
+// a rotated-away inode. Write and Close are safe for concurrent use.
+type Writer struct {
+	path string
+
+	mu     sync.Mutex
+	limits Limits
+	file   *os.File
+	size   int64
+}
+
+// OpenWriter returns the shared Writer for path, creating it on first use. All
+// callers writing to the same file get the same Writer, so a rotation triggered
+// by one of them is immediately visible to the others.
+func OpenWriter(path string) *Writer {
+	key := writerKey(path)
+
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if w, ok := registry[key]; ok {
+		return w
+	}
+	w := NewWriter(path, CurrentLimits())
+	registry[key] = w
+	return w
+}
+
+// NewWriter returns a standalone Writer for path with the given limits. It is
+// not shared through the process registry; prefer OpenWriter for real log files.
+func NewWriter(path string, limits Limits) *Writer {
+	return &Writer{path: path, limits: limits}
+}
+
+func writerKey(path string) string {
+	if abs, err := filepath.Abs(path); err == nil {
+		return abs
+	}
+	return path
+}
+
+// Path returns the current log file path.
+func (w *Writer) Path() string { return w.path }
+
+// SetLimits replaces the writer's rotation limits.
+func (w *Writer) SetLimits(limits Limits) {
+	w.mu.Lock()
+	w.limits = limits
+	w.mu.Unlock()
+}
+
+// Append writes p through the shared writer for path and then releases the file
+// handle. One-shot callers use it so they do not hold a descriptor open for every
+// log file the process ever touched, while still sharing rotation state — and the
+// rotation lock — with any long-lived writer on the same path.
+func Append(path string, p []byte) (int, error) {
+	return OpenWriter(path).Append(p)
+}
+
+// Write appends p to the log file, rotating first when the write would push the
+// file past the configured size limit. The file handle stays open for subsequent
+// writes; callers holding a Writer for a bounded lifetime should Close it.
+func (w *Writer) Write(p []byte) (int, error) {
+	return w.write(p, true)
+}
+
+// Append writes p and then closes the file handle. A long-lived writer sharing
+// this path simply reopens the current file on its next write.
+func (w *Writer) Append(p []byte) (int, error) {
+	return w.write(p, false)
+}
+
+func (w *Writer) write(p []byte, keepOpen bool) (int, error) {
+	w.mu.Lock()
+	events, err := w.prepare(len(p))
+	if err != nil {
+		w.mu.Unlock()
+		return 0, err
+	}
+	n, writeErr := w.file.Write(p)
+	w.size += int64(n)
+	if !keepOpen {
+		_ = w.file.Close()
+		w.file = nil
+		w.size = 0
+	}
+	w.mu.Unlock()
+
+	for _, ev := range events {
+		notify(ev)
+	}
+	return n, writeErr
+}
+
+// prepare ensures the file handle is open and rotates when needed. It must be
+// called with w.mu held and returns the events to report after unlocking.
+func (w *Writer) prepare(incoming int) ([]Event, error) {
+	if err := w.ensureOpen(); err != nil {
+		return nil, err
+	}
+	limit := w.limits.MaxFileSize
+	if limit <= 0 || w.size == 0 || w.size+int64(incoming) <= limit {
+		return nil, nil
+	}
+	return w.rotateLocked(), nil
+}
+
+func (w *Writer) ensureOpen() error {
+	if w.file != nil {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(w.path), 0o755); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(w.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	size := int64(0)
+	if info, statErr := f.Stat(); statErr == nil {
+		size = info.Size()
+	}
+	w.file = f
+	w.size = size
+	return nil
+}
+
+// rotateLocked renames the current file aside, prunes surplus backups, reopens
+// the original path, and sweeps the directory back within budget. Every step is
+// best-effort: logging must never be the reason a session or the daemon fails.
+func (w *Writer) rotateLocked() []Event {
+	_ = w.file.Close()
+	w.file = nil
+	w.size = 0
+
+	backups := w.limits.MaxBackups
+	if backups < 0 {
+		backups = 0
+	}
+	removed := []string{}
+	if backups == 0 {
+		if err := os.Remove(w.path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			// Keep the oversized file rather than losing the handle entirely.
+			_ = w.ensureOpen()
+			return nil
+		}
+		removed = append(removed, w.path)
+	} else {
+		_ = os.Remove(backupPath(w.path, backups))
+		for i := backups - 1; i >= 1; i-- {
+			from := backupPath(w.path, i)
+			if _, err := os.Stat(from); err != nil {
+				continue
+			}
+			_ = os.Rename(from, backupPath(w.path, i+1))
+		}
+		if err := os.Rename(w.path, backupPath(w.path, 1)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			_ = w.ensureOpen()
+			return nil
+		}
+	}
+
+	// Reopen immediately so the next write lands in the fresh file even if the
+	// caller never writes again through this writer.
+	_ = w.ensureOpen()
+
+	events := []Event{{Kind: EventRotate, Path: w.path, Removed: removed}}
+	if result, err := Sweep(filepath.Dir(w.path), w.limits, livePaths()); err == nil && len(result.Removed) > 0 {
+		events = append(events, Event{
+			Kind:          EventEvict,
+			Path:          filepath.Dir(w.path),
+			ReclaimedByte: result.Reclaimed,
+			Removed:       result.Removed,
+		})
+	}
+	return events
+}
+
+// Close releases the underlying file handle. The Writer stays usable: a later
+// Write reopens the current file, so closing a session's writer never silences
+// other callers sharing it.
+func (w *Writer) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.file == nil {
+		return nil
+	}
+	err := w.file.Close()
+	w.file = nil
+	w.size = 0
+	return err
+}
+
+// backupPath returns the name of the index-th rotated copy of path.
+func backupPath(path string, index int) string {
+	return fmt.Sprintf("%s.%d", path, index)
+}
+
+// backupIndex reports the rotation index encoded in name, or 0 when name is not
+// a rotated backup. Rotated names always carry a numeric suffix, so they can
+// never be mistaken for a live "<repo>-issue-<n>.log" session log.
+func backupIndex(name string) int {
+	dot := strings.LastIndex(name, ".")
+	if dot <= 0 || dot == len(name)-1 {
+		return 0
+	}
+	index, err := strconv.Atoi(name[dot+1:])
+	if err != nil || index <= 0 {
+		return 0
+	}
+	return index
+}
+
+// SweepResult reports what a directory sweep reclaimed.
+type SweepResult struct {
+	TotalBefore int64
+	TotalAfter  int64
+	Reclaimed   int64
+	Removed     []string
+}
+
+type sweepCandidate struct {
+	path    string
+	size    int64
+	modTime int64
+	backup  int
+}
+
+// Sweep removes log files from dir until its total size is at or below
+// limits.MaxTotalSize. Rotated backups are evicted first, oldest rotation
+// generation first, followed by the least recently modified non-live files.
+// Paths listed in live — the current daemon log, the access log, and the session
+// logs of running sessions — are never removed. A missing or empty directory is
+// a no-op.
+func Sweep(dir string, limits Limits, live []string) (SweepResult, error) {
+	var result SweepResult
+	if limits.MaxTotalSize <= 0 {
+		return result, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return result, nil
+		}
+		return result, err
+	}
+
+	protected := make(map[string]struct{}, len(live))
+	for _, path := range live {
+		if strings.TrimSpace(path) == "" {
+			continue
+		}
+		protected[writerKey(path)] = struct{}{}
+	}
+
+	candidates := make([]sweepCandidate, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		result.TotalBefore += info.Size()
+		if _, ok := protected[writerKey(path)]; ok {
+			continue
+		}
+		candidates = append(candidates, sweepCandidate{
+			path:    path,
+			size:    info.Size(),
+			modTime: info.ModTime().UnixNano(),
+			backup:  backupIndex(entry.Name()),
+		})
+	}
+	result.TotalAfter = result.TotalBefore
+	if result.TotalBefore <= limits.MaxTotalSize {
+		return result, nil
+	}
+
+	// Highest rotation generation first (oldest data), then live-name files by
+	// least recent modification. Path breaks ties so eviction is deterministic.
+	sort.Slice(candidates, func(i, j int) bool {
+		a, b := candidates[i], candidates[j]
+		if (a.backup > 0) != (b.backup > 0) {
+			return a.backup > 0
+		}
+		if a.backup != b.backup {
+			return a.backup > b.backup
+		}
+		if a.modTime != b.modTime {
+			return a.modTime < b.modTime
+		}
+		return a.path < b.path
+	})
+
+	for _, candidate := range candidates {
+		if result.TotalAfter <= limits.MaxTotalSize {
+			break
+		}
+		if err := os.Remove(candidate.path); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				result.TotalAfter -= candidate.size
+			}
+			continue
+		}
+		result.TotalAfter -= candidate.size
+		result.Reclaimed += candidate.size
+		result.Removed = append(result.Removed, candidate.path)
+	}
+	return result, nil
+}
+
+// hasOpenFile reports whether the writer currently holds a file handle. It exists
+// for tests that assert one-shot appends do not leak descriptors.
+func (w *Writer) hasOpenFile() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.file != nil
+}

--- a/internal/logging/rotate_test.go
+++ b/internal/logging/rotate_test.go
@@ -1,0 +1,497 @@
+package logging
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestParseSize(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int64
+	}{
+		{"1", 1},
+		{"1024", 1024},
+		{"512B", 512},
+		{"1KB", 1024},
+		{"1kb", 1024},
+		{"1KiB", 1024},
+		{"500MB", 500 * 1024 * 1024},
+		{" 500 MB ", 500 * 1024 * 1024},
+		{"1GB", 1024 * 1024 * 1024},
+		{"1GiB", 1024 * 1024 * 1024},
+		{"1.5MB", 1024 * 1024 * 3 / 2},
+		{"2G", 2 * 1024 * 1024 * 1024},
+	}
+	for _, tc := range cases {
+		got, err := ParseSize(tc.in)
+		if err != nil {
+			t.Fatalf("ParseSize(%q) returned error: %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Fatalf("ParseSize(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+
+	for _, bad := range []string{"", "   ", "abc", "MB", "-5MB", "12XB", "1..2MB", "NaN", "nAn", "Inf", "+Inf", "-Inf"} {
+		if got, err := ParseSize(bad); err == nil {
+			t.Fatalf("ParseSize(%q) = %d, want error", bad, got)
+		}
+	}
+}
+
+func FuzzParseSize(f *testing.F) {
+	for _, seed := range []string{"500MB", "1024", "1.5GiB", "", "-1", "MB", "999999999999999999999TB"} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, raw string) {
+		size, err := ParseSize(raw)
+		if err != nil {
+			return
+		}
+		if size < 0 {
+			t.Fatalf("ParseSize(%q) returned negative size %d", raw, size)
+		}
+	})
+}
+
+func TestFormatSize(t *testing.T) {
+	cases := map[int64]string{
+		500 * 1024 * 1024: "500MB",
+		1024:              "1KB",
+		1536:              "1536B",
+		0:                 "0B",
+	}
+	for in, want := range cases {
+		if got := FormatSize(in); got != want {
+			t.Fatalf("FormatSize(%d) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestWriterRotatesAtMaxFileSize(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vigilante.log")
+	w := NewWriter(path, Limits{MaxFileSize: 64, MaxBackups: 2})
+	t.Cleanup(func() { _ = w.Close() })
+
+	line := strings.Repeat("a", 40) + "\n"
+	for range 4 {
+		if _, err := w.Write([]byte(line)); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat current: %v", err)
+	}
+	if info.Size() > 64 {
+		t.Fatalf("current file size = %d, want <= 64", info.Size())
+	}
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Fatalf("expected rotated backup: %v", err)
+	}
+}
+
+func TestWriterEnforcesBackupCount(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vigilante.log")
+	w := NewWriter(path, Limits{MaxFileSize: 16, MaxBackups: 2})
+	t.Cleanup(func() { _ = w.Close() })
+
+	for i := range 12 {
+		if _, err := fmt.Fprintf(w, "line %02d padding\n", i); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Fatalf("expected .1 backup: %v", err)
+	}
+	if _, err := os.Stat(path + ".2"); err != nil {
+		t.Fatalf("expected .2 backup: %v", err)
+	}
+	if _, err := os.Stat(path + ".3"); !os.IsNotExist(err) {
+		t.Fatalf("expected .3 backup to be pruned, got err=%v", err)
+	}
+}
+
+func TestWriterKeepsWritingAfterRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vigilante.log")
+	w := NewWriter(path, Limits{MaxFileSize: 32, MaxBackups: 3})
+	t.Cleanup(func() { _ = w.Close() })
+
+	if _, err := w.Write([]byte(strings.Repeat("x", 40) + "\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := w.Write([]byte("after rotation\n")); err != nil {
+		t.Fatalf("write after rotation: %v", err)
+	}
+
+	current, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read current: %v", err)
+	}
+	if !strings.Contains(string(current), "after rotation") {
+		t.Fatalf("post-rotation line missing from current file, got %q", current)
+	}
+}
+
+func TestWriterStreamingWritesFollowRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.log")
+	streaming := NewWriter(path, Limits{MaxFileSize: 24, MaxBackups: 2})
+	t.Cleanup(func() { _ = streaming.Close() })
+
+	// The streaming writer holds the handle; a short-lived appender writes
+	// through the same shared writer and must land in the same current file.
+	if _, err := streaming.Write([]byte("stream line\n")); err != nil {
+		t.Fatalf("stream write: %v", err)
+	}
+	if _, err := streaming.Write([]byte("rotate me now\n")); err != nil {
+		t.Fatalf("stream write: %v", err)
+	}
+	if _, err := streaming.Write([]byte("post rotate\n")); err != nil {
+		t.Fatalf("stream write: %v", err)
+	}
+
+	current, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read current: %v", err)
+	}
+	if !strings.Contains(string(current), "post rotate") {
+		t.Fatalf("current file missing latest line: %q", current)
+	}
+}
+
+func TestWriterCloseThenWriteReopens(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.log")
+	w := NewWriter(path, DefaultLimits())
+
+	if _, err := w.Write([]byte("first\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if _, err := w.Write([]byte("second\n")); err != nil {
+		t.Fatalf("write after close: %v", err)
+	}
+	t.Cleanup(func() { _ = w.Close() })
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got := string(data); !strings.Contains(got, "first") || !strings.Contains(got, "second") {
+		t.Fatalf("expected both lines, got %q", got)
+	}
+}
+
+func TestOpenWriterSharesWriterPerPath(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "shared.log")
+
+	a := OpenWriter(path)
+	b := OpenWriter(filepath.Join(dir, ".", "shared.log"))
+	t.Cleanup(func() { _ = a.Close() })
+
+	if a != b {
+		t.Fatal("OpenWriter returned different writers for the same path")
+	}
+}
+
+func TestWriterConcurrentWritesRotateSafely(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vigilante.log")
+	w := NewWriter(path, Limits{MaxFileSize: 128, MaxBackups: 3, MaxTotalSize: 1 << 20})
+	t.Cleanup(func() { _ = w.Close() })
+
+	payload := strings.Repeat("p", 32)
+	var wg sync.WaitGroup
+	for g := range 8 {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := range 50 {
+				if _, err := fmt.Fprintf(w, "goroutine=%d line=%d payload=%s\n", g, i, payload); err != nil {
+					t.Errorf("write: %v", err)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat current: %v", err)
+	}
+	if info.Size() > 128 {
+		t.Fatalf("current file size = %d, want <= 128", info.Size())
+	}
+}
+
+func TestSweepReducesDirectoryToBudget(t *testing.T) {
+	dir := t.TempDir()
+	live := filepath.Join(dir, "vigilante.log")
+	writeSized(t, live, 100)
+	writeSized(t, live+".1", 100)
+	writeSized(t, live+".2", 100)
+	writeSized(t, filepath.Join(dir, "owner-repo-issue-1.log"), 100)
+
+	result, err := Sweep(dir, Limits{MaxTotalSize: 150}, []string{live})
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if result.TotalAfter > 150 {
+		t.Fatalf("TotalAfter = %d, want <= 150", result.TotalAfter)
+	}
+	if total := dirSize(t, dir); total > 150 {
+		t.Fatalf("directory size after sweep = %d, want <= 150", total)
+	}
+	if _, err := os.Stat(live); err != nil {
+		t.Fatalf("live log must survive sweep: %v", err)
+	}
+	if result.Reclaimed != result.TotalBefore-result.TotalAfter {
+		t.Fatalf("Reclaimed = %d, want %d", result.Reclaimed, result.TotalBefore-result.TotalAfter)
+	}
+}
+
+func TestSweepEvictsRotatedBackupsBeforeCompletedSessions(t *testing.T) {
+	dir := t.TempDir()
+	live := filepath.Join(dir, "vigilante.log")
+	completed := filepath.Join(dir, "owner-repo-issue-7.log")
+	writeSized(t, live, 100)
+	writeSized(t, live+".1", 100)
+	writeSized(t, completed, 100)
+
+	// Make the completed-session log the oldest file, so eviction order can only
+	// be explained by the rotated-backup preference.
+	old := time.Now().Add(-72 * time.Hour)
+	if err := os.Chtimes(completed, old, old); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	if _, err := Sweep(dir, Limits{MaxTotalSize: 250}, []string{live}); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if _, err := os.Stat(live + ".1"); !os.IsNotExist(err) {
+		t.Fatalf("expected rotated backup to be evicted first, got err=%v", err)
+	}
+	if _, err := os.Stat(completed); err != nil {
+		t.Fatalf("completed-session log evicted too early: %v", err)
+	}
+}
+
+func TestSweepNeverEvictsLivePaths(t *testing.T) {
+	dir := t.TempDir()
+	daemonLog := filepath.Join(dir, "vigilante.log")
+	accessLog := filepath.Join(dir, "access.jsonl")
+	running := filepath.Join(dir, "owner-repo-issue-9.log")
+	for _, path := range []string{daemonLog, accessLog, running} {
+		writeSized(t, path, 500)
+	}
+
+	// Budget far below the live total: the sweep must give up rather than delete
+	// a file an active writer owns.
+	result, err := Sweep(dir, Limits{MaxTotalSize: 10}, []string{daemonLog, accessLog, running})
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if len(result.Removed) != 0 {
+		t.Fatalf("expected no evictions, removed %v", result.Removed)
+	}
+	for _, path := range []string{daemonLog, accessLog, running} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("live log %s was evicted: %v", path, err)
+		}
+	}
+}
+
+func TestSweepEvictsOldestRotatedGenerationFirst(t *testing.T) {
+	dir := t.TempDir()
+	live := filepath.Join(dir, "vigilante.log")
+	writeSized(t, live, 10)
+	writeSized(t, live+".1", 100)
+	writeSized(t, live+".2", 100)
+
+	if _, err := Sweep(dir, Limits{MaxTotalSize: 120}, []string{live}); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if _, err := os.Stat(live + ".2"); !os.IsNotExist(err) {
+		t.Fatalf("expected the oldest generation .2 to be evicted, got err=%v", err)
+	}
+	if _, err := os.Stat(live + ".1"); err != nil {
+		t.Fatalf("newest backup .1 evicted too early: %v", err)
+	}
+}
+
+func TestSweepNoOpForMissingOrEmptyDir(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "absent")
+	result, err := Sweep(missing, DefaultLimits(), nil)
+	if err != nil {
+		t.Fatalf("sweep on missing dir: %v", err)
+	}
+	if result.TotalBefore != 0 || len(result.Removed) != 0 {
+		t.Fatalf("unexpected result for missing dir: %+v", result)
+	}
+
+	empty := t.TempDir()
+	result, err = Sweep(empty, DefaultLimits(), nil)
+	if err != nil {
+		t.Fatalf("sweep on empty dir: %v", err)
+	}
+	if result.TotalBefore != 0 || len(result.Removed) != 0 {
+		t.Fatalf("unexpected result for empty dir: %+v", result)
+	}
+}
+
+func TestSweepDisabledWhenBudgetNotPositive(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "owner-repo-issue-1.log")
+	writeSized(t, path, 100)
+
+	result, err := Sweep(dir, Limits{MaxTotalSize: 0}, nil)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if len(result.Removed) != 0 {
+		t.Fatalf("expected no evictions with an unlimited budget, removed %v", result.Removed)
+	}
+}
+
+func TestBackupIndexDoesNotMatchSessionLogNames(t *testing.T) {
+	for _, name := range []string{"vigilante.log", "access.jsonl", "owner-repo-issue-472.log", "owner-repo2-issue-3.log"} {
+		if idx := backupIndex(name); idx != 0 {
+			t.Fatalf("backupIndex(%q) = %d, want 0", name, idx)
+		}
+	}
+	for name, want := range map[string]int{
+		"vigilante.log.1":            1,
+		"access.jsonl.12":            12,
+		"owner-repo-issue-472.log.3": 3,
+	} {
+		if idx := backupIndex(name); idx != want {
+			t.Fatalf("backupIndex(%q) = %d, want %d", name, idx, want)
+		}
+	}
+}
+
+func writeSized(t *testing.T, path string, size int) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(strings.Repeat("z", size)), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func dirSize(t *testing.T, dir string) int64 {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	var total int64
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		total += info.Size()
+	}
+	return total
+}
+
+// Append must not leave a descriptor open, or a daemon that touches one session
+// log per issue would leak a file handle per issue for its whole lifetime.
+func TestAppendReleasesFileHandleButWriteKeepsIt(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "owner-repo-issue-1.log")
+	w := NewWriter(path, DefaultLimits())
+	t.Cleanup(func() { _ = w.Close() })
+
+	if _, err := w.Append([]byte("one shot\n")); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if w.hasOpenFile() {
+		t.Fatal("Append left the file handle open")
+	}
+
+	if _, err := w.Write([]byte("streamed\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if !w.hasOpenFile() {
+		t.Fatal("Write should keep the file handle open for the next write")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(data); got != "one shot\nstreamed\n" {
+		t.Fatalf("unexpected contents %q", got)
+	}
+}
+
+// The streaming writer and one-shot appenders must never disagree about which
+// file is current, no matter which of them triggers the rotation.
+func TestAppendAndWriteStayOnTheSameCurrentFileAcrossRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "owner-repo-issue-1.log")
+	limits := Limits{MaxFileSize: 64, MaxBackups: 3, MaxTotalSize: 1 << 20}
+	w := NewWriter(path, limits)
+	t.Cleanup(func() { _ = w.Close() })
+
+	for i := range 12 {
+		if _, err := fmt.Fprintf(w, "streamed %02d padding\n", i); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if _, err := w.Append([]byte(fmt.Sprintf("appended %02d padding\n", i))); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+	}
+	if _, err := fmt.Fprintf(w, "last streamed\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := w.Append([]byte("last appended\n")); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	current, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(current)
+	if !strings.Contains(got, "last streamed") {
+		t.Fatalf("streaming write went to a stale file: %q", got)
+	}
+	if !strings.Contains(got, "last appended") {
+		t.Fatalf("append went to a stale file: %q", got)
+	}
+
+	// Every event must land whole in exactly one file: a rotation may not split a
+	// line across the current file and a backup.
+	for _, name := range []string{path, path + ".1", path + ".2", path + ".3"} {
+		data, err := os.ReadFile(name)
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(strings.TrimSuffix(string(data), "\n"), "\n") {
+			if line == "" {
+				continue
+			}
+			if !strings.HasPrefix(line, "streamed ") && !strings.HasPrefix(line, "appended ") &&
+				!strings.HasPrefix(line, "last ") {
+				t.Fatalf("torn line %q in %s", line, name)
+			}
+		}
+	}
+}

--- a/internal/logging/testdata/fuzz/FuzzParseSize/f9e9adb66b0924ed
+++ b/internal/logging/testdata/fuzz/FuzzParseSize/f9e9adb66b0924ed
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("nAn")

--- a/internal/runner/session.go
+++ b/internal/runner/session.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nicobistolfi/vigilante/internal/environment"
 	forkmode "github.com/nicobistolfi/vigilante/internal/fork"
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
+	"github.com/nicobistolfi/vigilante/internal/logging"
 	"github.com/nicobistolfi/vigilante/internal/logtime"
 	"github.com/nicobistolfi/vigilante/internal/provider"
 	"github.com/nicobistolfi/vigilante/internal/sandbox/container"
@@ -613,17 +614,13 @@ func sanitizeDiagnosticText(text string, limit int) string {
 	return text
 }
 
+// appendSessionLog records one lifecycle event in the session log. It goes
+// through the same rotation-aware writer as the streaming writer from
+// openSessionLogWriter, so both agree on which file is current after a rotation,
+// and the whole event is written in one call so a rotation cannot split it.
 func appendSessionLog(path string, event string, session state.Session, details string) {
-	if err := os.MkdirAll(filepathDir(path), 0o755); err != nil {
-		return
-	}
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
-	if err != nil {
-		return
-	}
-	defer f.Close()
-
-	_, _ = fmt.Fprintf(f, "[%s] %s issue=%d provider=%s branch=%s worktree=%s status=%s\n",
+	var b strings.Builder
+	fmt.Fprintf(&b, "[%s] %s issue=%d provider=%s branch=%s worktree=%s status=%s\n",
 		logtime.FormatLocal(time.Now()),
 		event,
 		session.IssueNumber,
@@ -632,10 +629,12 @@ func appendSessionLog(path string, event string, session state.Session, details 
 		session.WorktreePath,
 		session.Status,
 	)
-	if strings.TrimSpace(details) != "" {
-		_, _ = fmt.Fprintln(f, strings.TrimSpace(details))
+	if trimmed := strings.TrimSpace(details); trimmed != "" {
+		fmt.Fprintln(&b, trimmed)
 	}
-	_, _ = fmt.Fprintln(f)
+	fmt.Fprintln(&b)
+
+	_, _ = logging.Append(path, []byte(b.String()))
 }
 
 func formatInvocationDebug(inv provider.Invocation) string {
@@ -674,13 +673,15 @@ func filepathDir(path string) string {
 	return path[:last]
 }
 
-// openSessionLogWriter opens the session log file for appending and returns it
-// as an io.WriteCloser suitable for streaming provider output.
+// openSessionLogWriter returns the rotation-aware writer for the session log,
+// suitable for streaming provider output. The writer is shared with
+// appendSessionLog and rotates the file once it exceeds the configured size, so
+// a verbose provider run cannot grow the log without bound.
 func openSessionLogWriter(path string) (io.WriteCloser, error) {
 	if err := os.MkdirAll(filepathDir(path), 0o755); err != nil {
 		return nil, err
 	}
-	return os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	return logging.OpenWriter(path), nil
 }
 
 // writeLifecycleEvent writes a [vigilante HH:MM:SS] prefixed event into the

--- a/internal/runner/sessionlog_test.go
+++ b/internal/runner/sessionlog_test.go
@@ -1,0 +1,129 @@
+package runner
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nicobistolfi/vigilante/internal/logging"
+	"github.com/nicobistolfi/vigilante/internal/state"
+)
+
+// withSessionLogLimits narrows the process-wide rotation limits for the duration
+// of a test so rotation can be exercised without writing megabytes.
+func withSessionLogLimits(t *testing.T, path string, limits logging.Limits) {
+	t.Helper()
+	logging.Configure(limits, nil, nil)
+	t.Cleanup(func() {
+		_ = logging.OpenWriter(path).Close()
+		logging.Configure(logging.DefaultLimits(), nil, nil)
+	})
+}
+
+func TestAppendSessionLogRotates(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "owner-repo-issue-472.log")
+	withSessionLogLimits(t, path, logging.Limits{MaxFileSize: 300, MaxBackups: 2, MaxTotalSize: 1 << 20})
+
+	session := state.Session{Repo: "owner/repo", IssueNumber: 472, Provider: "claude", Branch: "topic", Status: state.SessionStatusRunning}
+	for i := range 20 {
+		appendSessionLog(path, fmt.Sprintf("event %d", i), session, "")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() > 300 {
+		t.Fatalf("session log size = %d, want <= 300", info.Size())
+	}
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Fatalf("expected rotated session log: %v", err)
+	}
+	current, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(current), "event 19") {
+		t.Fatalf("latest event missing from current session log: %q", current)
+	}
+}
+
+// The streaming writer from openSessionLogWriter and the open/append/close
+// appendSessionLog path must agree on which file is current, so a rotation
+// triggered by one is immediately visible to the other.
+func TestSessionLogStreamingAndAppendStayConsistentAcrossRotation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "owner-repo-issue-472.log")
+	withSessionLogLimits(t, path, logging.Limits{MaxFileSize: 400, MaxBackups: 3, MaxTotalSize: 1 << 20})
+
+	writer, err := openSessionLogWriter(path)
+	if err != nil {
+		t.Fatalf("openSessionLogWriter: %v", err)
+	}
+	defer writer.Close()
+
+	session := state.Session{Repo: "owner/repo", IssueNumber: 472, Provider: "claude", Branch: "topic", Status: state.SessionStatusRunning}
+
+	// Interleave streamed provider output with lifecycle events until several
+	// rotations have happened.
+	for i := range 15 {
+		writeLifecycleEvent(writer, fmt.Sprintf("streamed chunk %d %s", i, strings.Repeat("o", 40)))
+		appendSessionLog(path, fmt.Sprintf("event %d", i), session, "")
+	}
+	writeLifecycleEvent(writer, "final streamed line")
+	appendSessionLog(path, "final event", session, "")
+
+	current, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(current)
+	if !strings.Contains(got, "final streamed line") {
+		t.Fatalf("streaming writer wrote to a stale file, current log = %q", got)
+	}
+	if !strings.Contains(got, "final event") {
+		t.Fatalf("appendSessionLog wrote to a stale file, current log = %q", got)
+	}
+}
+
+// Rotated session logs must not look like a session log for a different issue,
+// or `vigilante logs` would list them as a new repo/issue pair.
+func TestRotatedSessionLogNameIsNotASessionLogPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	store := state.NewStore()
+
+	path := store.SessionLogPath("owner/repo", 472)
+	rotated := path + ".1"
+	for issue := 1; issue <= 500; issue++ {
+		if store.SessionLogPath("owner/repo", issue) == rotated {
+			t.Fatalf("rotated name %q collides with session log for issue %d", rotated, issue)
+		}
+	}
+	if !strings.HasSuffix(path, ".log") {
+		t.Fatalf("unexpected session log suffix in %q", path)
+	}
+	if strings.HasSuffix(rotated, ".log") {
+		t.Fatalf("rotated name %q must not end in .log", rotated)
+	}
+}
+
+// A rotation must never abort a session: the writers swallow filesystem errors
+// the same way the original append paths did.
+func TestSessionLogWritesSurviveUnwritableDirectory(t *testing.T) {
+	dir := t.TempDir()
+	blocked := filepath.Join(dir, "blocked")
+	if err := os.WriteFile(blocked, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(blocked, "owner-repo-issue-1.log")
+	withSessionLogLimits(t, path, logging.Limits{MaxFileSize: 10, MaxBackups: 1, MaxTotalSize: 100})
+
+	session := state.Session{Repo: "owner/repo", IssueNumber: 1, Status: state.SessionStatusRunning}
+	appendSessionLog(path, "event", session, "details")
+
+	if _, err := openSessionLogWriter(path); err == nil {
+		t.Fatal("expected openSessionLogWriter to report the unusable directory")
+	}
+}

--- a/internal/state/logrotation_test.go
+++ b/internal/state/logrotation_test.go
@@ -1,0 +1,313 @@
+package state
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nicobistolfi/vigilante/internal/environment"
+	"github.com/nicobistolfi/vigilante/internal/logging"
+)
+
+func newAccessLogEntry(i int) environment.AccessLogEntry {
+	return environment.AccessLogEntry{
+		Timestamp:        "2026-07-30T12:00:00Z",
+		ExecutionContext: "scan",
+		Tool:             "git",
+		Argv:             []string{"git", "status", strings.Repeat("p", 20)},
+		ExitCode:         i % 2,
+		Success:          i%2 == 0,
+	}
+}
+
+func TestLogRotationLimitsDefaultsWhenUnset(t *testing.T) {
+	limits := ServiceConfig{}.LogRotationLimits()
+	if limits.MaxTotalSize != 500*1024*1024 {
+		t.Fatalf("MaxTotalSize = %d, want 500MB", limits.MaxTotalSize)
+	}
+	if limits.MaxFileSize != logging.DefaultMaxFileSize {
+		t.Fatalf("MaxFileSize = %d, want %d", limits.MaxFileSize, logging.DefaultMaxFileSize)
+	}
+	if limits.MaxBackups != logging.DefaultMaxBackups {
+		t.Fatalf("MaxBackups = %d, want %d", limits.MaxBackups, logging.DefaultMaxBackups)
+	}
+}
+
+func TestLogRotationLimitsFromConfig(t *testing.T) {
+	backups := 5
+	limits := ServiceConfig{
+		LogMaxTotalSize: "1GB",
+		LogMaxFileSize:  "8MB",
+		LogMaxBackups:   &backups,
+	}.LogRotationLimits()
+
+	if limits.MaxTotalSize != 1024*1024*1024 {
+		t.Fatalf("MaxTotalSize = %d, want 1GB", limits.MaxTotalSize)
+	}
+	if limits.MaxFileSize != 8*1024*1024 {
+		t.Fatalf("MaxFileSize = %d, want 8MB", limits.MaxFileSize)
+	}
+	if limits.MaxBackups != 5 {
+		t.Fatalf("MaxBackups = %d, want 5", limits.MaxBackups)
+	}
+}
+
+func TestLogRotationLimitsFallsBackOnMalformedValues(t *testing.T) {
+	negative := -3
+	limits := ServiceConfig{
+		LogMaxTotalSize: "five hundred megabytes",
+		LogMaxFileSize:  "",
+		LogMaxBackups:   &negative,
+	}.LogRotationLimits()
+
+	if limits.MaxTotalSize != logging.DefaultMaxTotalSize {
+		t.Fatalf("MaxTotalSize = %d, want default %d", limits.MaxTotalSize, logging.DefaultMaxTotalSize)
+	}
+	if limits.MaxFileSize != logging.DefaultMaxFileSize {
+		t.Fatalf("MaxFileSize = %d, want default %d", limits.MaxFileSize, logging.DefaultMaxFileSize)
+	}
+	if limits.MaxBackups != logging.DefaultMaxBackups {
+		t.Fatalf("MaxBackups = %d, want default %d", limits.MaxBackups, logging.DefaultMaxBackups)
+	}
+}
+
+func TestServiceConfigLogFieldsRoundTrip(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	store := NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	backups := 4
+	if err := store.SaveServiceConfig(ServiceConfig{
+		LogMaxTotalSize: "250MB",
+		LogMaxFileSize:  "10MB",
+		LogMaxBackups:   &backups,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := store.LoadServiceConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.LogMaxTotalSize != "250MB" || config.LogMaxFileSize != "10MB" {
+		t.Fatalf("unexpected sizes after round-trip: %+v", config)
+	}
+	if config.LogMaxBackups == nil || *config.LogMaxBackups != 4 {
+		t.Fatalf("unexpected backup count after round-trip: %+v", config.LogMaxBackups)
+	}
+	limits := config.LogRotationLimits()
+	if limits.MaxTotalSize != 250*1024*1024 {
+		t.Fatalf("MaxTotalSize = %d, want 250MB", limits.MaxTotalSize)
+	}
+}
+
+// A config file that predates this feature must keep working untouched and must
+// not have the new keys written into it just because defaults were applied.
+func TestServiceConfigWithoutLogFieldsUsesDefaults(t *testing.T) {
+	home := t.TempDir()
+	root := filepath.Join(home, ".vigilante")
+	t.Setenv("VIGILANTE_HOME", root)
+
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	legacy := `{"sandbox_enabled": true}` + "\n"
+	if err := os.WriteFile(filepath.Join(root, "config.json"), []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	store := NewStore()
+	config, err := store.LoadServiceConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.LogMaxTotalSize != "" || config.LogMaxFileSize != "" || config.LogMaxBackups != nil {
+		t.Fatalf("legacy config gained log fields: %+v", config)
+	}
+	if got := config.LogRotationLimits().MaxTotalSize; got != 500*1024*1024 {
+		t.Fatalf("MaxTotalSize = %d, want 500MB default", got)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(root, "config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "log_max_total_size") {
+		t.Fatalf("loading config rewrote the file: %s", raw)
+	}
+}
+
+func TestServiceConfigOmitsUnsetLogFields(t *testing.T) {
+	data, err := json.Marshal(ServiceConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"log_max_total_size", "log_max_file_size", "log_max_backups"} {
+		if strings.Contains(string(data), key) {
+			t.Fatalf("expected %s to be omitted, got %s", key, data)
+		}
+	}
+}
+
+func TestAppendDaemonLogRotates(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	store := NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	logging.Configure(logging.Limits{MaxFileSize: 200, MaxBackups: 2, MaxTotalSize: 1 << 20}, store.LiveLogPaths, nil)
+	t.Cleanup(func() {
+		logging.OpenWriter(store.DaemonLogPath()).Close()
+		logging.Configure(logging.DefaultLimits(), nil, nil)
+	})
+
+	for i := range 20 {
+		store.AppendDaemonLog("daemon line %d with some padding to grow the file", i)
+	}
+
+	info, err := os.Stat(store.DaemonLogPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() > 200 {
+		t.Fatalf("daemon log size = %d, want <= 200", info.Size())
+	}
+	if _, err := os.Stat(store.DaemonLogPath() + ".1"); err != nil {
+		t.Fatalf("expected rotated daemon log: %v", err)
+	}
+
+	// The most recent line must be in the current file, not the rotated one.
+	current, err := os.ReadFile(store.DaemonLogPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(current), "daemon line 19") {
+		t.Fatalf("latest line missing from current daemon log: %q", current)
+	}
+}
+
+func TestAppendAccessLogEntryRotates(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	store := NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	logging.Configure(logging.Limits{MaxFileSize: 300, MaxBackups: 2, MaxTotalSize: 1 << 20}, store.LiveLogPaths, nil)
+	t.Cleanup(func() {
+		logging.OpenWriter(store.AccessLogPath()).Close()
+		logging.Configure(logging.DefaultLimits(), nil, nil)
+	})
+
+	for i := range 20 {
+		store.AppendAccessLogEntry(newAccessLogEntry(i))
+	}
+
+	info, err := os.Stat(store.AccessLogPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Size() > 300 {
+		t.Fatalf("access log size = %d, want <= 300", info.Size())
+	}
+	if _, err := os.Stat(store.AccessLogPath() + ".1"); err != nil {
+		t.Fatalf("expected rotated access log: %v", err)
+	}
+
+	// Every retained line must still be valid JSON so `logs --access` keeps working.
+	current, err := os.ReadFile(store.AccessLogPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(current)), "\n") {
+		if line == "" {
+			continue
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal([]byte(line), &decoded); err != nil {
+			t.Fatalf("rotated access log holds a torn line %q: %v", line, err)
+		}
+	}
+}
+
+func TestLiveLogPathsProtectsActiveSessionsOnly(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	store := NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveSessions([]Session{
+		{Repo: "owner/live", IssueNumber: 1, Status: SessionStatusRunning},
+		{Repo: "owner/blocked", IssueNumber: 2, Status: SessionStatusBlocked},
+		{Repo: "owner/done", IssueNumber: 3, Status: SessionStatusSuccess},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	paths := store.LiveLogPaths()
+	want := map[string]bool{
+		store.DaemonLogPath():                    true,
+		store.AccessLogPath():                    true,
+		store.SessionLogPath("owner/live", 1):    true,
+		store.SessionLogPath("owner/blocked", 2): true,
+	}
+	if len(paths) != len(want) {
+		t.Fatalf("LiveLogPaths() = %v, want %d entries", paths, len(want))
+	}
+	for _, path := range paths {
+		if !want[path] {
+			t.Fatalf("unexpected live path %q", path)
+		}
+	}
+	for _, path := range paths {
+		if path == store.SessionLogPath("owner/done", 3) {
+			t.Fatal("completed session log must not be protected")
+		}
+	}
+}
+
+func TestSweepLogsKeepsRunningSessionLog(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	store := NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveSessions([]Session{
+		{Repo: "owner/live", IssueNumber: 1, Status: SessionStatusRunning},
+		{Repo: "owner/done", IssueNumber: 2, Status: SessionStatusSuccess},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	running := store.SessionLogPath("owner/live", 1)
+	completed := store.SessionLogPath("owner/done", 2)
+	blob := strings.Repeat("x", 400)
+	for _, path := range []string{running, completed, store.DaemonLogPath(), store.AccessLogPath()} {
+		if err := os.WriteFile(path, []byte(blob), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := store.SweepLogs(logging.Limits{MaxTotalSize: 1300})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Removed) != 1 || result.Removed[0] != completed {
+		t.Fatalf("expected only the completed session log to be evicted, got %v", result.Removed)
+	}
+	if _, err := os.Stat(running); err != nil {
+		t.Fatalf("running session log evicted: %v", err)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/nicobistolfi/vigilante/internal/backend"
 	"github.com/nicobistolfi/vigilante/internal/environment"
+	"github.com/nicobistolfi/vigilante/internal/logging"
 	"github.com/nicobistolfi/vigilante/internal/logtime"
 	"github.com/nicobistolfi/vigilante/internal/repo"
 )
@@ -130,6 +131,26 @@ type ServiceConfig struct {
 	SandboxDefaultTTL               string `json:"sandbox_default_ttl,omitempty"`
 	SandboxMemoryLimit              string `json:"sandbox_memory_limit,omitempty"`
 	SandboxCPUs                     string `json:"sandbox_cpus,omitempty"`
+	LogMaxTotalSize                 string `json:"log_max_total_size,omitempty"`
+	LogMaxFileSize                  string `json:"log_max_file_size,omitempty"`
+	LogMaxBackups                   *int   `json:"log_max_backups,omitempty"`
+}
+
+// LogRotationLimits returns the log rotation limits for the logs directory.
+// Unset or malformed values fall back to the built-in defaults — a bad config
+// value must never disable rotation or stop the daemon from logging.
+func (c ServiceConfig) LogRotationLimits() logging.Limits {
+	limits := logging.DefaultLimits()
+	if size, err := logging.ParseSize(c.LogMaxTotalSize); err == nil && size > 0 {
+		limits.MaxTotalSize = size
+	}
+	if size, err := logging.ParseSize(c.LogMaxFileSize); err == nil && size > 0 {
+		limits.MaxFileSize = size
+	}
+	if c.LogMaxBackups != nil && *c.LogMaxBackups >= 0 {
+		limits.MaxBackups = *c.LogMaxBackups
+	}
+	return limits
 }
 
 // IsSandboxEnabled returns whether sandbox mode is enabled.
@@ -161,6 +182,17 @@ const (
 	SessionStatusFailed     SessionStatus = "failed"
 	SessionStatusClosed     SessionStatus = "closed"
 )
+
+// IsActive reports whether a session is still in flight and therefore may still
+// be writing to its session log.
+func (s SessionStatus) IsActive() bool {
+	switch s {
+	case SessionStatusRunning, SessionStatusBlocked, SessionStatusResuming:
+		return true
+	default:
+		return false
+	}
+}
 
 type BlockedReason struct {
 	Kind      string `json:"kind,omitempty"`
@@ -596,32 +628,43 @@ func (s *Store) AppendAccessLogEntry(value environment.AccessLogEntry) {
 	appendJSONLine(s.AccessLogPath(), value)
 }
 
+// appendLogFile writes one rotation-aware log line. The line is written in a
+// single call so a rotation can never split it across two files.
 func appendLogFile(path string, message string) {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return
-	}
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
-	if err != nil {
-		return
-	}
-	defer f.Close()
-	_, _ = fmt.Fprintf(f, "[%s] %s\n", logtime.FormatLocal(time.Now()), strings.TrimSpace(message))
+	line := fmt.Sprintf("[%s] %s\n", logtime.FormatLocal(time.Now()), strings.TrimSpace(message))
+	_, _ = logging.Append(path, []byte(line))
 }
 
 func appendJSONLine(path string, value any) {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return
-	}
 	data, err := json.Marshal(value)
 	if err != nil {
 		return
 	}
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	_, _ = logging.Append(path, append(data, '\n'))
+}
+
+// LiveLogPaths returns the log files a directory sweep must never evict: the
+// current daemon log, the access log, and the session log of every session that
+// is not finished yet.
+func (s *Store) LiveLogPaths() []string {
+	paths := []string{s.DaemonLogPath(), s.AccessLogPath()}
+	sessions, err := s.LoadSessions()
 	if err != nil {
-		return
+		return paths
 	}
-	defer f.Close()
-	_, _ = f.Write(append(data, '\n'))
+	for _, session := range sessions {
+		if !session.Status.IsActive() {
+			continue
+		}
+		paths = append(paths, s.SessionLogPath(session.Repo, session.IssueNumber))
+	}
+	return paths
+}
+
+// SweepLogs brings the logs directory back within the configured total budget.
+// It is best-effort and reports what it reclaimed so callers can log it.
+func (s *Store) SweepLogs(limits logging.Limits) (logging.SweepResult, error) {
+	return logging.Sweep(s.LogsDir(), limits, s.LiveLogPaths())
 }
 
 func (s *Store) TryWithScanLock(fn func() error) (bool, error) {


### PR DESCRIPTION
## Summary

Every log write path opened its file with `O_APPEND` and appended unconditionally, so a long-running daemon grew `vigilante.log`, `access.jsonl`, and one session log per issue until the operator's disk filled. Session logs dominated the byte volume — they stream full raw provider stdout/stderr — and nothing ever deleted them, not even `vigilante cleanup`.

This adds per-file rotation plus a total disk budget for `~/.vigilante/logs/`, defaulting to 500MB, implemented self-contained in `internal/logging` rather than as a new dependency (the repo has a deliberately small direct-dependency set).

## How it works

**`Writer`** — a mutex-guarded, rotation-aware `io.WriteCloser`. When a write would exceed the per-file limit it renames the current file aside (`x.log` → `x.log.1` → `x.log.2`…), prunes surplus backups, and **reopens the original path**, so a long-lived handle never keeps appending to a rotated-away inode. Handles open lazily, so `Close` leaves the writer usable.

**A process-wide registry keyed by absolute path** shares one `Writer` per file. The daemon `slog` handler, the session streaming writer, and the one-shot appenders therefore share one lock and one rotation decision, and can never disagree about which file is current. One-shot callers use `Append`, which releases the descriptor — otherwise a daemon would hold a handle for every log file it ever touched — and writes each event in a single call so a rotation cannot split it across two files.

**`Sweep`** bounds the whole directory: rotated backups go first (oldest generation first), then completed-session logs by least recent modification. It never removes the current `vigilante.log`, the current `access.jsonl`, or the log of a running/blocked/resuming session; if the live files alone exceed the budget it stops rather than deleting a log an active writer owns. It runs after every rotation, at daemon start (so an already-oversized directory needs no manual step), and on each scan tick.

All four write paths from the issue now go through it: the `slog` handler, `appendLogFile`, `appendJSONLine`, and the session writer plus `appendSessionLog`.

**Config** — `ServiceConfig` gains `log_max_total_size`, `log_max_file_size`, and `log_max_backups`, all `omitempty` with accessor defaults of 500MB / 50MB / 3. Existing config files are not rewritten, and an unparseable value falls back **per field**, so logging can never be the reason the daemon fails to start.

## Two things the issue's assumptions didn't cover

- **`logs -f` and `logs --access -w` would have broken.** The issue expected both to tail via `watchPlaintextLog`, which already resets on truncation. They actually use `watchSessionLog`/`watchAccessLog`, which held a **persistent file handle** — after a rotation they would have tailed the rotated-away inode forever, silently emitting nothing. Both now share a reopen-per-tick `followFile` helper, so following survives a rotation with a visible seam instead of stalling. `watchPlaintextLog` is now a thin wrapper over the same helper.
- **The `ParseSize` fuzz test found a real bug.** `strconv.ParseFloat` happily accepts `"NaN"`, which produced a *negative* budget (`-9223372036854775808`) — a malformed config value would have made the sweep behave unpredictably instead of falling back. Non-finite values are now rejected, and the crasher is committed as a regression seed.

## Testing

`task test` passes. Added:

- `internal/logging` — size-triggered rotation, backup-count enforcement, reopen-after-rotate, `Append` releasing its descriptor while `Write` keeps it, streaming and append paths staying on the same current file with no torn lines, concurrent writers, sweep convergence, eviction order, live-path protection, missing/empty dir no-ops, and a `ParseSize` fuzz test.
- `internal/state` — config round-trip, default applied when absent, per-field fallback on malformed values, legacy config not rewritten, daemon/access log rotation, `LiveLogPaths` protecting only active sessions.
- `internal/runner` — `appendSessionLog` rotation, streaming/append consistency across rotation, rotated names not colliding with any `SessionLogPath`.
- `internal/app` — daemon logger still logging after rotation via a logger created once (the highest-risk regression), `logs` listing rotated files, `logs --access` and `logs --repo/--issue` reading fine post-rotation, `logs -f` continuing across a rotation boundary, sweep convergence and non-fatality.

Regressions from the issue's list are each covered explicitly. Tests use a low configured rotation size and a temp `VIGILANTE_HOME`, so nothing writes 500MB.

**Not run:** `-race` — this environment has no C compiler, so `CGO_ENABLED=1` cannot build the race runtime. The concurrency tests are written for it (the follow test uses a mutex-guarded buffer rather than a bare `bytes.Buffer`), so CI should exercise them. `govulncheck`, `golangci-lint`, and `staticcheck` are not installed; there is no `.golangci.yml`, so `go vet ./...` is the project standard and passes. No dependency changes.

## Docs

`DOCS.md` gains a **Log Rotation and Disk Budget** section, plus updates to the `vigilante logs` section, the `logs/` directory description, the `config.json` shape, and the troubleshooting guidance — including the note that log evidence is now size-bounded, so operators should collect logs for an old failure before the budget evicts them.

Closes #472