### PR TITLE
feat: sign and notarize macOS release binaries

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,10 @@
 name: Nightly Release
 
+# Rolling prerelease from `main`, published as the `vigilante-nightly` Homebrew
+# cask. Like the tagged release, it runs on macOS so the macOS binaries can be
+# signed and notarized — the nightly cask is a real user install path, and an
+# unsigned artifact there means Gatekeeper blocks it. See docs/releasing.md.
+
 on:
   push:
     branches:
@@ -10,7 +15,7 @@ permissions:
 
 jobs:
   prerelease:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     # Only gate production secrets behind the protected `main` environment on main pushes;
     # verification runs on other branches build without access to publish credentials.
     environment: ${{ github.ref == 'refs/heads/main' && 'main' || '' }}
@@ -59,13 +64,39 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: homebrew-spaceship
 
+      # Only main pushes have access to the signing certificate. Other refs fall
+      # through to ad-hoc signing, which still exercises the execution gate.
+      - name: Import Apple Developer ID certificate
+        if: github.ref == 'refs/heads/main'
+        env:
+          APPLE_DEVELOPER_ID_CERT_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERT_P12_BASE64 }}
+          APPLE_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASSWORD }}
+        run: bash ./scripts/import-signing-certificate.sh
+
       - name: Build nightly snapshot artifacts
         env:
           NIGHTLY_VERSION: ${{ env.NIGHTLY_VERSION }}
           OTEL_ENDPOINT: ${{ secrets.OTEL_ENDPOINT }}
           OTEL_TOKEN: ${{ secrets.OTEL_TOKEN }}
           OTEL_URL_PATH: ${{ secrets.OTEL_URL_PATH }}
-        run: goreleaser release --snapshot --clean
+          APPLE_DEVELOPER_ID_IDENTITY: ${{ vars.APPLE_DEVELOPER_ID_IDENTITY }}
+          APPLE_NOTARY_API_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_API_KEY_P8_BASE64 }}
+          APPLE_NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
+          APPLE_NOTARY_API_ISSUER_ID: ${{ secrets.APPLE_NOTARY_API_ISSUER_ID }}
+          # Escape hatch: set this repository variable to 1 to keep nightlies
+          # flowing when Apple's notary service is degraded. Signing and the
+          # execution gate still run; only the notary submission is skipped.
+          VIGILANTE_SKIP_NOTARIZE: ${{ vars.VIGILANTE_SKIP_NOTARIZE }}
+        run: |
+          set -euo pipefail
+          if [ -n "${APPLE_NOTARY_API_KEY_P8_BASE64:-}" ]; then
+            printf '%s' "$APPLE_NOTARY_API_KEY_P8_BASE64" | base64 --decode > "$RUNNER_TEMP/notary.p8"
+            trap 'rm -f "$RUNNER_TEMP/notary.p8"' EXIT
+            export APPLE_NOTARY_KEY_P8="$RUNNER_TEMP/notary.p8"
+            export APPLE_NOTARY_KEY_ID="$APPLE_NOTARY_API_KEY_ID"
+            export APPLE_NOTARY_ISSUER_ID="$APPLE_NOTARY_API_ISSUER_ID"
+          fi
+          goreleaser release --snapshot --clean
 
       - name: Publish rolling prerelease
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -1,0 +1,114 @@
+name: Release Smoke Test
+
+# Exercises the real macOS signing path on pull requests that touch the release
+# machinery, without any secrets.
+#
+# This is the check whose absence let our sibling `lander` project ship two
+# releases whose binaries could not run at all: nothing in CI ever verified a
+# signature or executed an artifact, so a bad designated requirement reached
+# users twice. `goreleaser check` alone does not build, and the Linux CI job
+# cannot execute a darwin binary.
+#
+# With no Developer ID available the signing script falls back to ad-hoc signing
+# so the execution gate still runs. That is enough to catch a broken hook, a
+# malformed codesign invocation, or a binary that will not start.
+
+on:
+  pull_request:
+    paths:
+      - '.goreleaser.yml'
+      - 'scripts/sign-macos-binary.sh'
+      - 'scripts/import-signing-certificate.sh'
+      - '.github/workflows/release.yml'
+      - '.github/workflows/nightly.yml'
+      - '.github/workflows/release-smoke.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  snapshot:
+    name: Snapshot build with signing gate
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up GoReleaser
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
+        with:
+          install-only: true
+
+      - name: Validate GoReleaser config
+        run: goreleaser check
+
+      # The build hook ad-hoc signs each macOS artifact, verifies the signature
+      # and its designated requirement, then runs the binary. A nonzero exit
+      # from any of those fails this job.
+      #
+      # The OTEL_* values are empty on purpose: they only exist because the
+      # ldflags template requires the keys to be present, and a PR has no access
+      # to the real telemetry secrets.
+      - name: Snapshot build (ad-hoc sign + execution gate)
+        env:
+          NIGHTLY_VERSION: 0.0.0-pr.${{ github.event.pull_request.number }}
+          OTEL_ENDPOINT: ''
+          OTEL_TOKEN: ''
+          OTEL_URL_PATH: ''
+          HOMEBREW_GITHUB_API_TOKEN: ''
+        run: goreleaser release --snapshot --clean
+
+      # Guard the wiring itself. Without this, deleting the hook from
+      # .goreleaser.yml would leave the job green while silently disabling
+      # signing for every future release.
+      - name: Confirm the hook signed the macOS artifacts
+        run: |
+          set -euo pipefail
+          gate_status=0
+
+          # Capture command output instead of piping into `grep -q`: under
+          # `pipefail`, grep exiting early on its first match SIGPIPEs the
+          # producer and turns a successful check into a spurious failure.
+          for binary in dist/vigilante_darwin_*/vigilante; do
+            echo "==> $binary"
+            if ! codesign --verify --strict --verbose=2 "$binary"; then
+              echo "::error::$binary failed codesign --verify --strict"
+              gate_status=1
+              continue
+            fi
+            summary="$(codesign -d --verbose=2 "$binary" 2>&1 || true)"
+            case "$summary" in
+              *"Identifier=vigilante"*) ;;
+              *)
+                echo "::error::$binary is not signed with the expected 'vigilante' identifier;" \
+                     "the .goreleaser.yml build hook probably did not run"
+                echo "$summary"
+                gate_status=1
+                ;;
+            esac
+          done
+
+          # The linux artifacts must come through untouched.
+          for binary in dist/vigilante_linux_*/vigilante dist/gh-sandbox_linux_*/gh-sandbox; do
+            case "$(file "$binary")" in
+              *Mach-O*)
+                echo "::error::$binary is a Mach-O binary; the build matrix is wrong"
+                gate_status=1
+                ;;
+            esac
+          done
+
+          exit "$gate_status"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,16 @@
 name: Release
 
+# Builds, signs, and notarizes the macOS binaries with GoReleaser, then publishes
+# the GitHub release and the Homebrew cask.
+#
+# Runs on macOS because signing needs Apple's native codesign/notarytool. The
+# Linux artifacts cross-compile from the same runner (everything is
+# CGO_ENABLED=0); GoReleaser OSS cannot split a release across runners.
+#
+# Signing happens in a `builds` post hook (scripts/sign-macos-binary.sh), which
+# signs, verifies, EXECUTES, and notarizes each macOS artifact before the archive
+# is built and before anything is published. See docs/releasing.md.
+
 on:
   push:
     tags:
@@ -10,7 +21,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     environment: main
     steps:
       - name: Check out repository
@@ -57,6 +68,17 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: homebrew-spaceship
 
+      # Import the Developer ID Application certificate into a throwaway keychain
+      # before GoReleaser runs. `codesign` needs a real keychain identity; the
+      # keychain is scoped to this runner and discarded with it.
+      - name: Import Apple Developer ID certificate
+        env:
+          APPLE_DEVELOPER_ID_CERT_P12_BASE64: ${{ secrets.APPLE_DEVELOPER_ID_CERT_P12_BASE64 }}
+          APPLE_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_CERT_PASSWORD }}
+        run: bash ./scripts/import-signing-certificate.sh
+
+      # The build post hook signs, verifies, executes, and notarizes each macOS
+      # artifact. A binary that cannot run aborts the release before publish.
       - name: Build and publish GitHub release
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -64,4 +86,19 @@ jobs:
           OTEL_ENDPOINT: ${{ secrets.OTEL_ENDPOINT }}
           OTEL_TOKEN: ${{ secrets.OTEL_TOKEN }}
           OTEL_URL_PATH: ${{ secrets.OTEL_URL_PATH }}
-        run: goreleaser release --clean
+          APPLE_DEVELOPER_ID_IDENTITY: ${{ vars.APPLE_DEVELOPER_ID_IDENTITY }}
+          APPLE_NOTARY_API_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_API_KEY_P8_BASE64 }}
+          APPLE_NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
+          APPLE_NOTARY_API_ISSUER_ID: ${{ secrets.APPLE_NOTARY_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          if [ -n "${APPLE_NOTARY_API_KEY_P8_BASE64:-}" ]; then
+            printf '%s' "$APPLE_NOTARY_API_KEY_P8_BASE64" | base64 --decode > "$RUNNER_TEMP/notary.p8"
+            trap 'rm -f "$RUNNER_TEMP/notary.p8"' EXIT
+            export APPLE_NOTARY_KEY_P8="$RUNNER_TEMP/notary.p8"
+            export APPLE_NOTARY_KEY_ID="$APPLE_NOTARY_API_KEY_ID"
+            export APPLE_NOTARY_ISSUER_ID="$APPLE_NOTARY_API_ISSUER_ID"
+          else
+            echo "::warning::Apple notary credentials are not configured; the release will be signed but NOT notarized."
+          fi
+          goreleaser release --clean

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /vigilante
 .claude/
 .worktrees/
+# GoReleaser build output. docs/releasing.md documents running local snapshot
+# builds, which produce signed binaries and archives here.
+/dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,21 @@ builds:
     ignore:
       - goos: linux
         goarch: arm64
+    hooks:
+      # Sign -> verify -> EXECUTE -> notarize each macOS artifact. This is a
+      # build post hook, so it runs after the binary is linked but BEFORE the
+      # archive is built and before anything is published: a nonzero exit aborts
+      # the release instead of shipping a binary the kernel would refuse.
+      #
+      # The hook fires for every target in the matrix. The script skips itself
+      # for non-darwin targets, on non-macOS runners, and for non-Mach-O inputs,
+      # and degrades to ad-hoc signing when no Developer ID is available (fork
+      # PRs, local snapshots) so the execution gate can still run.
+      #
+      # We deliberately do not use GoReleaser's OSS `notarize.macos` pipe
+      # (anchore/quill) — see docs/releasing.md for why.
+      post:
+        - bash scripts/sign-macos-binary.sh "{{ .Path }}" "{{ .Os }}"
 
   - id: gh-sandbox
     main: ./cmd/gh-sandbox

--- a/README.md
+++ b/README.md
@@ -149,3 +149,7 @@ The full reference lives in [DOCS.md](DOCS.md), including:
 - package hardening behavior and config
 - GitHub integration, worktree strategy, and service behavior
 - CI, releases, and implementation notes
+
+Maintainers cutting a release should start with
+[docs/releasing.md](docs/releasing.md), which covers macOS code signing and
+notarization, the required secrets, and how to verify a published binary.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,317 @@
+# Releasing Vigilante
+
+Vigilante's macOS binaries are built, **signed**, and **notarized** by GitHub
+Actions using [GoReleaser](https://goreleaser.com). This document covers the
+one-time Apple setup, wiring the secrets from 1Password into GitHub, the
+day-to-day release flow, and how to verify a published artifact.
+
+- Config: [`.goreleaser.yml`](../.goreleaser.yml)
+- Signing script: [`scripts/sign-macos-binary.sh`](../scripts/sign-macos-binary.sh)
+- Keychain import: [`scripts/import-signing-certificate.sh`](../scripts/import-signing-certificate.sh)
+- Workflows: [`release.yml`](../.github/workflows/release.yml),
+  [`nightly.yml`](../.github/workflows/nightly.yml),
+  [`release-smoke.yml`](../.github/workflows/release-smoke.yml)
+
+## What the pipeline produces
+
+| Artifact | Notes |
+|---|---|
+| `vigilante_<version>_macOS_arm64.tar.gz` | signed + notarized |
+| `vigilante_<version>_macOS_amd64.tar.gz` | signed + notarized |
+| `vigilante_<version>_Linux_amd64.tar.gz` | unsigned, unchanged |
+| `gh-sandbox_<version>_Linux_{amd64,arm64}.tar.gz` | unsigned, unchanged |
+| `checksums.txt` | covers all of the above |
+
+macOS binaries are signed with our **Apple Developer ID Application**
+certificate under the hardened runtime and notarized by Apple's notary service,
+so `brew install --cask vigilante` works without a Gatekeeper prompt.
+
+Both macOS architectures ship as **separate per-arch binaries**, not a universal
+binary, because the Homebrew casks select on `on_intel` / `on_arm`.
+
+> **A bare CLI binary cannot have a notarization ticket stapled** — stapling
+> targets `.app`, `.dmg`, and `.pkg`. The ticket is registered with Apple against
+> the binary's cdhash and Gatekeeper checks it online. A machine that has never
+> been online will not see the notarization. We ship no `.pkg`, so there is no
+> offline-verifiable artifact today.
+
+## Triggers
+
+| Trigger | Environment | Result |
+|---|---|---|
+| Push a `vX.Y.Z` tag | `main` | Signed + notarized GitHub release, Homebrew cask updated |
+| Push to `main` | `main` | Signed + notarized rolling `main-nightly` prerelease, `vigilante-nightly` cask updated |
+| PR touching the release machinery | — | `macos-latest` snapshot build, **ad-hoc** signed, execution gate runs, no secrets |
+| Any other PR | — | `goreleaser check` only, on Linux (`ci.yml`) |
+
+### Why signing runs in a GoReleaser build hook
+
+`scripts/sign-macos-binary.sh` is a `builds` **post hook**
+(`.goreleaser.yml`), so it runs once per built target, after the binary is
+linked but **before the archive is built and before anything is published**. A
+nonzero exit aborts the release rather than shipping a broken artifact.
+
+The hook fires for every target in the matrix. The script skips itself for
+non-darwin targets, on non-macOS runners, and for non-Mach-O inputs, so the
+Linux artifacts and the `gh-sandbox` build pass through untouched.
+
+### The release-blocking execution gate
+
+Signature inspection is not enough. A binary can carry a signature that every
+`codesign -d` field reports as healthy and still be refused by the kernel, so the
+script **runs what it built** and fails on a nonzero exit:
+
+| Check | Covers |
+|---|---|
+| `codesign --verify --strict` | signature integrity **and** the designated requirement |
+| `<binary> --help` (under `DO_NOT_TRACK=1`) | that AMFI actually loads and runs the artifact |
+| re-run of the above after notarization | that the final shipped form still runs |
+
+`--help` is the gate command because Vigilante has no `version` subcommand.
+`DO_NOT_TRACK=1` keeps CI gate runs out of telemetry
+(`internal/telemetry/telemetry.go`).
+
+**Coverage limit:** `macos-latest` is arm64, so the `amd64` artifact is executed
+only when Rosetta is present on the runner. When it is not, the script signs and
+verifies that artifact and reports plainly that it was **NOT COVERED** rather
+than implying the gate ran.
+
+### Why native codesign, not GoReleaser's `notarize.macos`
+
+**Do not switch this to GoReleaser's OSS `notarize.macos` pipe (anchore/quill).**
+
+Our sibling project `lander` (in `aliengiraffe/env-manager`) shipped **two
+releases whose binaries could not run at all** — SIGKILLed by the kernel at exec
+before printing a byte. The cause was quill embedding an unsatisfiable
+designated requirement:
+
+```text
+# what quill wrote — cannot ever be satisfied
+identifier X and anchor apple generic and
+  certificate root[field.1.2.840.113635.100.6.2.6] and certificate leaf[subject.OU] = "TEAMID"
+
+# what Apple's codesign writes
+identifier X and anchor apple generic and
+  certificate 1[field.1.2.840.113635.100.6.2.6] and
+  certificate leaf[field.1.2.840.113635.100.6.1.13] and certificate leaf[subject.OU] = "TEAMID"
+```
+
+The `1.2.840.113635.100.6.2.6` marker is carried by the **"Developer ID
+Certification Authority" intermediate**, never by Apple Root CA, so
+`certificate root[...]` is false for every Developer ID chain that exists. A
+non-ad-hoc signature whose designated requirement fails validation is refused by
+AMFI at exec.
+
+Two things let it survive two releases, and both are guarded against here:
+
+- **Ad-hoc signing hides it.** An ad-hoc designated requirement is a `cdhash`
+  literal, which is trivially satisfiable — which is why `codesign -s -` "fixes"
+  a broken binary without fixing anything.
+- **CI never asked Apple's tooling anything.** Nothing ran `codesign --verify`,
+  and nothing ran the binary. Note that `codesign -dv` prints a completely
+  healthy-looking summary for the broken binary, because it never evaluates the
+  designated requirement.
+
+## Secrets and variables
+
+All live in the **`main`** GitHub environment of `aliengiraffe/vigilante`.
+
+| Name | Kind | Purpose |
+|---|---|---|
+| `APPLE_DEVELOPER_ID_CERT_P12_BASE64` | secret | base64 of the Developer ID **Application** `.p12` |
+| `APPLE_DEVELOPER_ID_CERT_PASSWORD` | secret | the `.p12` export password |
+| `APPLE_NOTARY_API_KEY_P8_BASE64` | secret | base64 of the App Store Connect `.p8` notary key |
+| `APPLE_NOTARY_API_KEY_ID` | secret | notary Key ID |
+| `APPLE_NOTARY_API_ISSUER_ID` | secret | notary Issuer ID |
+| `APPLE_DEVELOPER_ID_IDENTITY` | variable | `Developer ID Application: <Name> (TEAMID)` |
+| `VIGILANTE_SKIP_NOTARIZE` | variable | optional; set to `1` to skip notary submission while keeping signing and the gate |
+
+`APPLE_DEVELOPER_ID_IDENTITY` is passed to `codesign --sign`. When it is unset,
+the signing script discovers the identity from the throwaway keychain instead, so
+both paths work.
+
+**Degradation is deliberate.** When the certificate secret is absent the workflows
+do not fail: `import-signing-certificate.sh` warns and exits 0, and the signing
+script falls back to ad-hoc signing with notarization skipped. Releases stay
+unsigned instead of the pipeline breaking.
+
+No **Developer ID Installer** certificate is needed — Vigilante ships no `.pkg`.
+
+### Pulling the secrets from 1Password
+
+The Developer ID certificate and notary key are **team-wide**, not per-product —
+these are the same items `lander` uses. They live in the **`Engineering`** vault:
+
+| 1Password item | Category |
+|---|---|
+| `Apple Developer ID — Lander (.p12)` | Document — Developer ID **Application** certificate |
+| `Apple Notary API Key — Lander (.p8)` | Document — App Store Connect notary key |
+| `Apple Developer ID — Lander Code Signing` | Secure Note — `p12 password`, `notary key id`, `notary issuer id`, `team id`, `identity`, `developer portal cert expiry` |
+
+> The `— Lander` naming predates Vigilante using the same certificate. Renaming
+> the items to something product-neutral would mean updating this document and
+> `env-manager/lander/docs/releasing.md` together.
+
+Run signed in to the `aliengiraffe` 1Password account with `gh` authenticated
+against this repository. `base64 | tr -d '\n'` produces the single-line encoding
+the workflows decode, and nothing touches disk:
+
+```bash
+REPO=aliengiraffe/vigilante
+VAULT=Engineering
+NOTE="op://$VAULT/Apple Developer ID — Lander Code Signing"
+
+# --- secrets ---
+op document get "Apple Developer ID — Lander (.p12)" --vault "$VAULT" \
+  | base64 | tr -d '\n' \
+  | gh secret set APPLE_DEVELOPER_ID_CERT_P12_BASE64 --env main --repo "$REPO"
+
+op read "$NOTE/p12 password" \
+  | gh secret set APPLE_DEVELOPER_ID_CERT_PASSWORD --env main --repo "$REPO"
+
+op document get "Apple Notary API Key — Lander (.p8)" --vault "$VAULT" \
+  | base64 | tr -d '\n' \
+  | gh secret set APPLE_NOTARY_API_KEY_P8_BASE64 --env main --repo "$REPO"
+
+op read "$NOTE/notary key id" \
+  | gh secret set APPLE_NOTARY_API_KEY_ID --env main --repo "$REPO"
+
+op read "$NOTE/notary issuer id" \
+  | gh secret set APPLE_NOTARY_API_ISSUER_ID --env main --repo "$REPO"
+
+# --- non-secret variable ---
+op read "$NOTE/identity" \
+  | gh variable set APPLE_DEVELOPER_ID_IDENTITY --env main --repo "$REPO"
+```
+
+Verify:
+
+```bash
+gh secret   list --env main --repo aliengiraffe/vigilante
+gh variable list --env main --repo aliengiraffe/vigilante
+```
+
+### Creating the Apple assets from scratch
+
+Only needed if the team-wide certificate or notary key does not already exist.
+Both steps require the account holder's Apple ID and MFA and cannot be automated.
+
+1. **Developer ID Application certificate.** Keychain Access → *Certificate
+   Assistant* → *Request a Certificate from a Certificate Authority* → **Saved to
+   disk**. Upload the CSR at
+   <https://developer.apple.com/account/resources/certificates/list> → **+** →
+   **Developer ID Application** → download the `.cer` → double-click to import →
+   select **both** the certificate and its private key → **Export 2 items…** as a
+   `.p12` with a strong password.
+2. **App Store Connect API key.**
+   <https://appstoreconnect.apple.com/access/integrations/api> → **Keys** →
+   generate a key with a role allowed to notarize → download the `.p8`
+   (**one-time download**) → record the Key ID and the Issuer ID.
+
+Back both up in 1Password as documents, with the passwords and IDs on the Secure
+Note, then delete the local copies.
+
+## Cutting a release
+
+```bash
+git switch main && git pull
+git tag v1.2.0            # must be vX.Y.Z and already merged into main
+git push origin v1.2.0
+```
+
+The `Release` workflow runs on `macos-latest`, signs and notarizes, publishes the
+GitHub release, and updates the `vigilante` Homebrew cask.
+
+Nightlies need no action: every push to `main` republishes the rolling
+`main-nightly` prerelease and the `vigilante-nightly` cask.
+
+## Local validation
+
+Signing degrades gracefully without secrets: with no Developer ID identity
+available the script signs **ad-hoc** so the execution gate can still run. (An
+unsigned arm64 Mach-O cannot exec on Apple Silicon at all, so "unsigned" is not a
+testable state — the gate would fail for the wrong reason.)
+
+```bash
+goreleaser check
+
+# Full snapshot: ad-hoc signs each macOS artifact and runs the execution gate.
+# The OTEL_* keys must exist because the ldflags template reads them.
+NIGHTLY_VERSION=0.0.0-local OTEL_ENDPOINT= OTEL_TOKEN= OTEL_URL_PATH= \
+  goreleaser release --snapshot --clean
+
+# Or run the gate by hand against one binary:
+bash scripts/sign-macos-binary.sh dist/vigilante_darwin_arm64_v8.0/vigilante darwin
+```
+
+Ad-hoc-signed local artifacts are **not shippable**; the script says so in its
+output. The shell scripts are covered by Go tests:
+
+```bash
+go test ./scripts/...
+```
+
+## Verifying a published binary
+
+**Run it first.** Only execution is conclusive — every other check below passed on
+`lander`'s broken releases except `codesign --verify`.
+
+```bash
+tar -xf vigilante_<version>_macOS_arm64.tar.gz
+
+./vigilante --help                                     # (1) MUST exit 0
+echo "exit=$?"                                         #     exit 137 = SIGKILL = broken
+
+codesign --verify --deep --strict --verbose=2 vigilante # (2) MUST exit 0
+codesign -d --requirements - vigilante                  # (3) expect `certificate 1[...6.2.6]`,
+                                                        #     NOT `certificate root[...]`
+spctl -a -vvv -t exec vigilante                         # (4) accepted, source=Notarized Developer ID
+```
+
+Do **not** treat `codesign -dv` output as verification — it prints a healthy
+summary for a binary the kernel will kill, because it never evaluates the
+designated requirement.
+
+If `./vigilante --help` ever exits 137, capture the kernel's reason (needs `sudo`;
+unprivileged `log show` returns nothing for AMFI):
+
+```bash
+sudo log show --last 5m --predicate \
+  'sender == "AppleMobileFileIntegrity" OR eventMessage CONTAINS "code signature"' \
+  --info --debug
+```
+
+Useful counter-check when triaging: re-signing ad-hoc makes *any* of these
+binaries run, because an ad-hoc designated requirement is a `cdhash` literal. So
+"it works after `codesign -s -`" tells you the Mach-O is fine and the **signature
+policy** was what got rejected — it is not a fix.
+
+## Known gap: `vigilante setup` re-signs the installed binary
+
+`prepareMacOSDaemonBinary` (`internal/service/service.go`) currently strips
+Gatekeeper xattrs and runs `codesign --force --sign -` on the installed binary
+before loading the LaunchAgent. On a signed release that **replaces the Developer
+ID signature with an ad-hoc one and voids notarization**.
+
+The same applies to the `postflight` block that
+[`scripts/update-nightly-cask.sh`](../scripts/update-nightly-cask.sh) writes into
+the nightly cask.
+
+Both were correct when every release was unsigned. Now that releases are signed,
+they should become conditional — skip the repair entirely when
+`codesign --verify --strict` and `spctl --assess` both pass. That work is tracked
+separately from the signing pipeline itself, deliberately gated on one verified
+signed release. A clean `brew install --cask` is already improved without it; what
+is lost is the signature persisting after `vigilante setup` runs.
+
+## Rotating the certificate or notary key
+
+1. Create the replacement on developer.apple.com.
+2. Update the 1Password `Engineering` items.
+3. Re-run the `gh secret set` / `gh variable set` commands above.
+4. Revoke the old certificate or API key once a release has succeeded with the new
+   one.
+
+Developer ID certificates are valid for several years — the Secure Note carries a
+`developer portal cert expiry` field, so set a calendar reminder ahead of it.
+Notary API keys do not expire but can be revoked at any time.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -153,34 +153,55 @@ these are the same items `lander` uses. They live in the **`Engineering`** vault
 > `env-manager/lander/docs/releasing.md` together.
 
 Run signed in to the `aliengiraffe` 1Password account with `gh` authenticated
-against this repository. `base64 | tr -d '\n'` produces the single-line encoding
-the workflows decode, and nothing touches disk:
+against this repository.
+
+Two `op` quirks make the obvious one-liners fail, so the script below works around
+both:
+
+- **`op://` secret references cannot contain an em dash**, and every item title
+  here has one. Address the Secure Note by its **item UUID** instead of its title
+  (`op item list --vault Engineering` prints the IDs).
+- **`op document get` refuses to write a binary document to a pipe** — it errors
+  with *"the queried document contains unprintable characters"*. The `.p12` is
+  binary, so it needs `--out-file`. (The `.p8` is PEM text and would pipe fine;
+  it uses a file here for symmetry.)
 
 ```bash
+set -euo pipefail
 REPO=aliengiraffe/vigilante
 VAULT=Engineering
-NOTE="op://$VAULT/Apple Developer ID — Lander Code Signing"
+# UUID of "Apple Developer ID — Lander Code Signing"; confirm with `op item list`.
+NOTE_ID=stfwdaukd5mtodowuejck2obsu
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+umask 077
+
+op document get "Apple Developer ID — Lander (.p12)" --vault "$VAULT" --out-file "$WORK/cert.p12"
+op document get "Apple Notary API Key — Lander (.p8)" --vault "$VAULT" --out-file "$WORK/notary.p8"
 
 # --- secrets ---
-op document get "Apple Developer ID — Lander (.p12)" --vault "$VAULT" \
-  | base64 | tr -d '\n' \
+# `tr -d '\n'` gives the single-line encoding the workflows decode.
+base64 < "$WORK/cert.p12" | tr -d '\n' \
   | gh secret set APPLE_DEVELOPER_ID_CERT_P12_BASE64 --env main --repo "$REPO"
 
-op read "$NOTE/p12 password" \
-  | gh secret set APPLE_DEVELOPER_ID_CERT_PASSWORD --env main --repo "$REPO"
-
-op document get "Apple Notary API Key — Lander (.p8)" --vault "$VAULT" \
-  | base64 | tr -d '\n' \
+base64 < "$WORK/notary.p8" | tr -d '\n' \
   | gh secret set APPLE_NOTARY_API_KEY_P8_BASE64 --env main --repo "$REPO"
 
-op read "$NOTE/notary key id" \
+# `printf '%s' "$(...)"` guarantees no trailing newline reaches the secret value,
+# independently of how gh handles stdin. A stray newline in the .p12 password
+# fails the keychain import in CI with a misleading error.
+printf '%s' "$(op read "op://$VAULT/$NOTE_ID/p12 password")" \
+  | gh secret set APPLE_DEVELOPER_ID_CERT_PASSWORD --env main --repo "$REPO"
+
+printf '%s' "$(op read "op://$VAULT/$NOTE_ID/notary key id")" \
   | gh secret set APPLE_NOTARY_API_KEY_ID --env main --repo "$REPO"
 
-op read "$NOTE/notary issuer id" \
+printf '%s' "$(op read "op://$VAULT/$NOTE_ID/notary issuer id")" \
   | gh secret set APPLE_NOTARY_API_ISSUER_ID --env main --repo "$REPO"
 
 # --- non-secret variable ---
-op read "$NOTE/identity" \
+printf '%s' "$(op read "op://$VAULT/$NOTE_ID/identity")" \
   | gh variable set APPLE_DEVELOPER_ID_IDENTITY --env main --repo "$REPO"
 ```
 
@@ -190,6 +211,40 @@ Verify:
 gh secret   list --env main --repo aliengiraffe/vigilante
 gh variable list --env main --repo aliengiraffe/vigilante
 ```
+
+### Checking the certificate before you push it
+
+Worth doing after a rotation — a bad `.p12`/password pair fails in CI with an
+unhelpful error. Note that macOS ships **LibreSSL**, whose `openssl pkcs12` has no
+`-legacy` flag and whose `openssl x509` cannot read the `Bag Attributes` preamble
+directly, hence the `sed`:
+
+```bash
+op document get "Apple Developer ID — Lander (.p12)" --vault Engineering --out-file /tmp/c.p12
+export P12PW="$(op read "op://Engineering/$NOTE_ID/p12 password")"
+
+openssl pkcs12 -in /tmp/c.p12 -passin env:P12PW -nokeys -clcerts 2>/dev/null \
+  | sed -n '/BEGIN CERTIFICATE/,/END CERTIFICATE/p' > /tmp/c.crt
+
+openssl x509 -in /tmp/c.crt -noout -subject -enddate -issuer
+openssl x509 -in /tmp/c.crt -noout -checkend 7776000   # nonzero => expires within 90 days
+
+# Must report at least one private key; codesign cannot sign without it.
+openssl pkcs12 -in /tmp/c.p12 -passin env:P12PW -nocerts -nodes 2>/dev/null | grep -c "PRIVATE KEY"
+
+unset P12PW; rm -f /tmp/c.p12 /tmp/c.crt
+```
+
+Expect the issuer to be **`Developer ID Certification Authority`** — that
+intermediate is what carries the `1.2.840.113635.100.6.2.6` marker the designated
+requirement checks for.
+
+> **Do not validate by importing into your login keychain.** If you want to
+> rehearse the CI path locally, import into a throwaway keychain and remember that
+> `security list-keychains -d user -s <kc>` **replaces** your search list. Save it
+> first (`security list-keychains -d user`) and restore it afterwards — calling
+> `-s` with no arguments empties the list and breaks login-keychain lookups until
+> it is put back.
 
 ### Creating the Apple assets from scratch
 

--- a/scripts/import-signing-certificate.sh
+++ b/scripts/import-signing-certificate.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# import-signing-certificate.sh — import the Apple Developer ID Application
+# certificate into a throwaway keychain on a macOS CI runner.
+#
+# `codesign` needs a real keychain identity, so the certificate cannot simply be
+# handed over as base64. The keychain created here is scoped to the runner and
+# discarded with it; its password is random and never leaves the process.
+#
+# The keychain path is exported to the job via GITHUB_ENV as
+# VIGILANTE_SIGN_KEYCHAIN, which scripts/sign-macos-binary.sh reads.
+#
+# Inputs (env):
+#   APPLE_DEVELOPER_ID_CERT_P12_BASE64  base64 of the Developer ID Application
+#                                       .p12 (certificate + private key)
+#   APPLE_DEVELOPER_ID_CERT_PASSWORD    the .p12 export password
+#   RUNNER_TEMP                         GitHub Actions temp dir (falls back to
+#                                       a mktemp dir for local runs)
+#   GITHUB_ENV                          GitHub Actions env file (optional)
+#
+# When the certificate secret is absent this exits 0 without creating anything.
+# That is the fork-PR and unconfigured-repo path: sign-macos-binary.sh then falls
+# back to ad-hoc signing so the execution gate still runs, and notarization is
+# skipped. Releases stay unsigned rather than failing the build.
+set -euo pipefail
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "==> $(uname -s) runner: no keychain to import into. Skipping."
+  exit 0
+fi
+
+if [ -z "${APPLE_DEVELOPER_ID_CERT_P12_BASE64:-}" ]; then
+  echo "::warning::APPLE_DEVELOPER_ID_CERT_P12_BASE64 is not set;" \
+       "macOS artifacts will be ad-hoc signed and NOT notarized." \
+       "See docs/releasing.md to configure signing."
+  exit 0
+fi
+
+RUNNER_TEMP="${RUNNER_TEMP:-$(mktemp -d)}"
+KEYCHAIN="$RUNNER_TEMP/vigilante-signing.keychain-db"
+P12_PATH="$RUNNER_TEMP/application.p12"
+KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+
+cleanup() {
+  rm -f "$P12_PATH"
+}
+trap cleanup EXIT
+
+security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+# Keep it unlocked for the length of a release (6h) rather than the 5m default.
+security set-keychain-settings -lut 21600 "$KEYCHAIN"
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+
+printf '%s' "$APPLE_DEVELOPER_ID_CERT_P12_BASE64" | base64 --decode > "$P12_PATH"
+security import "$P12_PATH" -k "$KEYCHAIN" \
+  -P "${APPLE_DEVELOPER_ID_CERT_PASSWORD:-}" -T /usr/bin/codesign
+rm -f "$P12_PATH"
+
+# Let codesign use the private key without an interactive prompt.
+security set-key-partition-list \
+  -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" >/dev/null
+# Make the throwaway keychain searchable so codesign resolves the identity.
+security list-keychains -d user -s "$KEYCHAIN" login.keychain-db
+
+if [ -n "${GITHUB_ENV:-}" ]; then
+  echo "VIGILANTE_SIGN_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
+fi
+
+echo "==> imported Developer ID certificate into $KEYCHAIN"
+echo "Available signing identities:"
+security find-identity -v -p codesigning "$KEYCHAIN"

--- a/scripts/sign-macos-binary.sh
+++ b/scripts/sign-macos-binary.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+#
+# sign-macos-binary.sh — sign a macOS binary with Apple's native `codesign`,
+# verify it, EXECUTE it, and (optionally) notarize it.
+#
+# Called from .goreleaser.yml as a `builds` post hook, so it runs once per built
+# target, after the binary is linked and BEFORE the archive is built and before
+# anything is published — a nonzero exit here aborts the release.
+#
+# The execution step is the point of this script, not a bonus. Signature
+# *verification* is exactly what fails to catch a bad designated requirement:
+# `codesign --verify` re-hashes the file using the CodeDirectory's own
+# parameters and never asks the kernel whether it would load the thing. Running
+# the binary is the only check that exercises AMFI.
+#
+# We deliberately do NOT use GoReleaser's OSS `notarize.macos` pipe
+# (anchore/quill). It embeds an unsatisfiable designated requirement
+# (`certificate root[field.1.2.840.113635.100.6.2.6]`, where the marker actually
+# lives on the Developer ID intermediate, so Apple writes `certificate 1[...]`).
+# AMFI SIGKILLs such a binary at exec while `codesign -dv` still prints a
+# healthy-looking summary. That is how our sibling `lander` project shipped two
+# releases whose binaries could not run at all. See docs/releasing.md.
+#
+# Usage: sign-macos-binary.sh <path-to-binary> [goos]
+#
+# Inputs (env, all optional — the script degrades to what is available):
+#   APPLE_DEVELOPER_ID_IDENTITY   "Developer ID Application: … (TEAMID)". When
+#                                 unset, the identity is discovered from
+#                                 VIGILANTE_SIGN_KEYCHAIN.
+#   VIGILANTE_SIGN_KEYCHAIN       keychain holding the Developer ID Application
+#                                 identity (the throwaway keychain CI creates).
+#   APPLE_NOTARY_KEY_P8           App Store Connect .p8 path  ┐ notarization runs
+#   APPLE_NOTARY_KEY_ID           notary key id               ├ only when all
+#   APPLE_NOTARY_ISSUER_ID        notary issuer id            ┘ three are set.
+#   VIGILANTE_SKIP_NOTARIZE       set to 1/true to sign and gate but skip the
+#                                 notary submission (escape hatch for when
+#                                 Apple's notary service is degraded).
+#
+# With no identity available (fork PRs, local snapshot builds, no secrets) the
+# binary is signed AD-HOC so the execution gate can still run: on Apple Silicon
+# an unsigned arm64 Mach-O is itself SIGKILLed by the kernel, so "unsigned" is
+# not a testable state. Ad-hoc artifacts are not shippable and the script says
+# so loudly.
+set -euo pipefail
+
+BIN="${1:?usage: sign-macos-binary.sh <path-to-binary> [goos]}"
+GOOS_HINT="${2:-}"
+
+# ------------------------------------------------------------------- skips ----
+# This hook fires for every target in the build matrix, including linux/amd64,
+# and on the Linux runners used by PR validation. Skip loudly rather than fail.
+if [ -n "$GOOS_HINT" ] && [ "$GOOS_HINT" != "darwin" ]; then
+  echo "==> $BIN targets $GOOS_HINT, not darwin. Skipping the sign + execute gate."
+  exit 0
+fi
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "==> $(uname -s) runner: no codesign, and darwin binaries are not executable here."
+  echo "    Skipping the sign + execute gate for $BIN."
+  echo "    NOTE: the exec gate only runs on the macOS jobs (release, nightly, PR smoke test)."
+  exit 0
+fi
+
+[ -f "$BIN" ] || { echo "ERROR: $BIN does not exist" >&2; exit 1; }
+
+# Belt and braces for the case where GoReleaser gives us no GOOS: a non-Mach-O
+# file (the linux artifact) has no architectures to report.
+if ! ARCHS=$(lipo -archs "$BIN" 2>/dev/null) || [ -z "$ARCHS" ]; then
+  echo "==> $BIN is not a Mach-O binary. Skipping the sign + execute gate."
+  exit 0
+fi
+
+# macos-latest ships bash 3.2, where expanding an empty array under `set -u` is
+# an error — hence the `${arr[@]+"${arr[@]}"}` guard at the use site below.
+KEYCHAIN_ARGS=()
+[ -n "${VIGILANTE_SIGN_KEYCHAIN:-}" ] && KEYCHAIN_ARGS=(--keychain "$VIGILANTE_SIGN_KEYCHAIN")
+
+# ---------------------------------------------------------------- identity ----
+IDENTITY="${APPLE_DEVELOPER_ID_IDENTITY:-}"
+if [ -z "$IDENTITY" ] && [ -n "${VIGILANTE_SIGN_KEYCHAIN:-}" ]; then
+  # Prefer the identity's SHA-1 hash over its display name: it is unambiguous
+  # even when several Developer ID certificates are present.
+  IDENTITY=$(security find-identity -v -p codesigning "$VIGILANTE_SIGN_KEYCHAIN" 2>/dev/null \
+    | awk '/Developer ID Application:/ { print $2; exit }')
+  [ -n "$IDENTITY" ] && echo "==> discovered Developer ID Application identity $IDENTITY in $VIGILANTE_SIGN_KEYCHAIN"
+fi
+
+# -------------------------------------------------------------------- sign ----
+if [ -n "$IDENTITY" ]; then
+  echo "==> codesign (Developer ID, hardened runtime, secure timestamp): $BIN [$ARCHS]"
+  # --options runtime  : hardened runtime, required for notarization
+  # --timestamp        : secure timestamp from Apple's TSA, also required
+  # --identifier       : pin it instead of letting codesign derive it from the
+  #                      filename, so the signing identity is deterministic
+  codesign \
+    --force \
+    --sign "$IDENTITY" \
+    --identifier vigilante \
+    --options runtime \
+    --timestamp \
+    ${KEYCHAIN_ARGS[@]+"${KEYCHAIN_ARGS[@]}"} \
+    --verbose=2 \
+    "$BIN"
+  SIGNED_FOR_RELEASE=yes
+else
+  echo "==> no Developer ID identity available — signing AD-HOC."
+  echo "    This artifact is NOT shippable; it exists so the execution gate below"
+  echo "    can run (an unsigned arm64 Mach-O cannot exec on Apple Silicon)."
+  codesign --force --sign - --identifier vigilante --options runtime "$BIN"
+  SIGNED_FOR_RELEASE=no
+fi
+
+# ------------------------------------------------------------------ verify ----
+# `codesign --verify` evaluates the signature AND the code's own designated
+# requirement. That second part is what quill gets wrong, and it is the check
+# that catches the failure mode described at the top of this file.
+verify_failed=0
+echo "==> codesign --verify --strict (signature + designated requirement)"
+if ! codesign --verify --strict --verbose=2 "$BIN"; then
+  verify_failed=1
+  echo "::error::codesign --verify --strict rejected $BIN" >&2
+  echo "  If this says 'does not satisfy its designated Requirement', the signer" >&2
+  echo "  wrote a bad DR. Compare against Apple's canonical Developer ID form:" >&2
+  echo "    identifier X and anchor apple generic and \\" >&2
+  echo "    certificate 1[field.1.2.840.113635.100.6.2.6] and \\" >&2
+  echo "    certificate leaf[field.1.2.840.113635.100.6.1.13] and \\" >&2
+  echo "    certificate leaf[subject.OU] = TEAMID" >&2
+  echo "  Actual DR embedded in this binary:" >&2
+  codesign --display --requirements - "$BIN" 2>&1 | tail -3 >&2 || true
+fi
+
+echo "==> signature summary"
+codesign --display --verbose=4 "$BIN" 2>&1 | grep -vE '^ *-?[0-9]+=' || true
+
+# ------------------------------------------------- THE GATE: execute it -------
+# A binary with a bad designated requirement reaches its entry point and is
+# killed with SIGKILL (137) before printing a byte. Anything other than a clean
+# exit 0 fails the release.
+#
+# `--help` is the cheapest subcommand that exits 0 (vigilante has no `version`
+# command). DO_NOT_TRACK keeps CI gate runs out of telemetry — see
+# internal/telemetry/telemetry.go.
+run_gate() {
+  local label="$1" path="$2" out rc
+  set +e
+  out=$(DO_NOT_TRACK=1 "$path" --help 2>&1)
+  rc=$?
+  set -e
+  if [ "$rc" -ne 0 ]; then
+    echo "::error::EXECUTION GATE FAILED ($label): '$path --help' exited $rc" >&2
+    if [ "$rc" -eq 137 ]; then
+      echo "  exit 137 = SIGKILL. The kernel (AMFI) refused to load this binary." >&2
+      echo "  Userland verification passing does NOT mean the kernel accepts it." >&2
+      echo "  Capture the kernel's reason on a Mac with:" >&2
+      echo "    sudo log show --last 5m --predicate 'sender == \"AppleMobileFileIntegrity\" OR eventMessage CONTAINS \"code signature\"'" >&2
+    fi
+    echo "  output: ${out:-<none>}" >&2
+    codesign --display --verbose=4 "$path" 2>&1 | grep -vE '^ *-?[0-9]+=' >&2 || true
+    return 1
+  fi
+  echo "    OK ($label): exit 0"
+  return 0
+}
+
+gate_failed=0
+gate_ran=no
+
+# Each artifact is single-arch, so the gate can only run when the artifact's
+# architecture matches the runner's (macos-latest is arm64; the amd64 artifact
+# needs Rosetta). Report honestly when it cannot run rather than implying the
+# artifact was covered.
+if [ "$ARCHS" = "$(uname -m)" ]; then
+  echo "==> EXECUTION GATE: running the signed binary"
+  run_gate "$ARCHS binary" "$BIN" || gate_failed=1
+  gate_ran=yes
+elif [ "$ARCHS" = "x86_64" ] && arch -x86_64 /usr/bin/true >/dev/null 2>&1; then
+  echo "==> EXECUTION GATE: running the signed binary under Rosetta"
+  run_gate "$ARCHS binary (rosetta)" "$BIN" || gate_failed=1
+  gate_ran=yes
+else
+  echo "==> NOT COVERED: the $ARCHS binary was signed and verified but not executed"
+  echo "                 (runner is $(uname -m) and Rosetta is unavailable). Its"
+  echo "                 signature is structurally identical to the native one's."
+fi
+
+# Report both signals before bailing out — a DR problem and a failed exec are the
+# same defect seen from two sides, and seeing both makes triage obvious.
+if [ "$verify_failed" -ne 0 ] || [ "$gate_failed" -ne 0 ]; then
+  echo "::error::signing gate failed for $BIN (verify=$verify_failed exec=$gate_failed) — refusing to continue" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------- notarize ----
+skip_notarize=no
+case "$(printf '%s' "${VIGILANTE_SKIP_NOTARIZE:-}" | tr '[:upper:]' '[:lower:]')" in
+  1 | true | yes) skip_notarize=yes ;;
+esac
+
+if [ "$SIGNED_FOR_RELEASE" = yes ] \
+  && [ "$skip_notarize" = no ] \
+  && [ -n "${APPLE_NOTARY_KEY_P8:-}" ] \
+  && [ -n "${APPLE_NOTARY_KEY_ID:-}" ] \
+  && [ -n "${APPLE_NOTARY_ISSUER_ID:-}" ]; then
+  echo "==> notarize (notarytool --wait)"
+  # notarytool only accepts .zip/.pkg/.dmg, so submit the binary in a zip. A bare
+  # Mach-O cannot have a ticket stapled — the ticket lives with Apple, keyed by
+  # cdhash, and Gatekeeper checks it online.
+  zip_dir=$(mktemp -d)
+  trap 'rm -rf "$zip_dir"' EXIT
+  zip_path="$zip_dir/vigilante-notarize.zip"
+  ditto -c -k --keepParent "$BIN" "$zip_path"
+  xcrun notarytool submit "$zip_path" \
+    --key "$APPLE_NOTARY_KEY_P8" \
+    --key-id "$APPLE_NOTARY_KEY_ID" \
+    --issuer "$APPLE_NOTARY_ISSUER_ID" \
+    --wait \
+    --timeout 30m
+
+  # Notarization does not modify the binary, but re-run the gate so a release can
+  # never publish a binary that was not executed in its final shipped form.
+  if [ "$gate_ran" = yes ]; then
+    echo "==> EXECUTION GATE (post-notarization re-check)"
+    run_gate "notarized $ARCHS binary" "$BIN"
+  fi
+elif [ "$SIGNED_FOR_RELEASE" = yes ]; then
+  if [ "$skip_notarize" = yes ]; then
+    echo "==> VIGILANTE_SKIP_NOTARIZE is set — skipping notarization (signing-only run)"
+  else
+    echo "==> notary credentials not set — skipping notarization (signing-only run)"
+  fi
+fi
+
+if [ "$gate_ran" = yes ]; then
+  echo "==> $BIN signed, verified, and PROVEN TO EXECUTE"
+else
+  echo "==> $BIN signed and verified (execution not covered on this runner)"
+fi

--- a/scripts/sign_macos_binary_test.go
+++ b/scripts/sign_macos_binary_test.go
@@ -1,0 +1,537 @@
+package scripts
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestSignMacOSBinarySkipsNonDarwinTarget(t *testing.T) {
+	t.Parallel()
+
+	f := newSignFixture(t)
+	result := f.run(t, "linux")
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected success, got exit %d\noutput:\n%s", result.exitCode, result.output)
+	}
+	if !strings.Contains(result.output, "targets linux, not darwin") {
+		t.Fatalf("expected the linux skip notice, got:\n%s", result.output)
+	}
+	if log := f.readLogMaybe(t, "codesign.log"); log != "" {
+		t.Fatalf("codesign must not run for a linux target, got:\n%s", log)
+	}
+}
+
+func TestSignMacOSBinarySkipsNonDarwinRunner(t *testing.T) {
+	t.Parallel()
+
+	f := newSignFixture(t)
+	f.unameSystem = "Linux"
+	result := f.run(t, "")
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected success, got exit %d\noutput:\n%s", result.exitCode, result.output)
+	}
+	if !strings.Contains(result.output, "Skipping the sign + execute gate") {
+		t.Fatalf("expected the runner skip notice, got:\n%s", result.output)
+	}
+	if log := f.readLogMaybe(t, "codesign.log"); log != "" {
+		t.Fatalf("codesign must not run on a Linux runner, got:\n%s", log)
+	}
+}
+
+// The build hook also fires for the linux artifact, which GoReleaser may hand
+// over without a usable GOOS. Detecting a non-Mach-O file is the backstop.
+func TestSignMacOSBinarySkipsNonMachOInput(t *testing.T) {
+	t.Parallel()
+
+	f := newSignFixture(t)
+	f.lipoArchs = ""
+	f.lipoExitCode = 1
+	result := f.run(t, "")
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected success, got exit %d\noutput:\n%s", result.exitCode, result.output)
+	}
+	if !strings.Contains(result.output, "is not a Mach-O binary") {
+		t.Fatalf("expected the Mach-O skip notice, got:\n%s", result.output)
+	}
+	if log := f.readLogMaybe(t, "codesign.log"); log != "" {
+		t.Fatalf("codesign must not run for a non-Mach-O input, got:\n%s", log)
+	}
+}
+
+func TestSignMacOSBinaryFailsWhenBinaryIsMissing(t *testing.T) {
+	t.Parallel()
+
+	f := newSignFixture(t)
+	f.binaryPath = filepath.Join(f.tempDir, "absent")
+	f.skipBinary = true
+	result := f.run(t, "darwin")
+
+	if result.exitCode == 0 {
+		t.Fatalf("expected failure for a missing binary, got exit 0\noutput:\n%s", result.output)
+	}
+	if !strings.Contains(result.output, "does not exist") {
+		t.Fatalf("expected a missing-binary error, got:\n%s", result.output)
+	}
+}
+
+func TestSignMacOSBinaryAdHocSignsWithoutIdentityAndSkipsNotarization(t *testing.T) {
+	t.Parallel()
+
+	f := newSignFixture(t)
+	// Notary credentials are present, but an ad-hoc artifact must never be
+	// submitted to Apple.
+	f.notaryEnv = true
+	result := f.run(t, "darwin")
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected success, got exit %d\noutput:\n%s", result.exitCode, result.output)
+	}
+	if !strings.Contains(result.output, "signing AD-HOC") {
+		t.Fatalf("expected the ad-hoc notice, got:\n%s", result.output)
+	}
+
+	codesignLog := f.readLog(t, "codesign.log")
+	if !strings.Contains(codesignLog, "--force --sign - --identifier vigilante --options runtime") {
+		t.Fatalf("expected an ad-hoc codesign invocation, got:\n%s", codesignLog)
+	}
+	if log := f.readLogMaybe(t, "xcrun.log"); log != "" {
+		t.Fatalf("an ad-hoc binary must not be notarized, got:\n%s", log)
+	}
+}
+
+func TestSignMacOSBinarySignsWithDeveloperIDAndHardenedRuntime(t *testing.T) {
+	t.Parallel()
+
+	f := newSignFixture(t)
+	f.identity = "Developer ID Application: Example (TEAMID)"
+	result := f.run(t, "darwin")
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected success, got exit %d\noutput:\n%s", result.exitCode, result.output)
+	}
+
+	codesignLog := f.readLog(t, "codesign.log")
+	for _, want := range []string{
+		"--sign Developer ID Application: Example (TEAMID)",
+		"--identifier vigilante",
+		"--options runtime",
+		"--timestamp",
+		"--verify --strict",
+	} {
+		if !strings.Contains(codesignLog, want) {
+			t.Fatalf("missing %q in codesign invocations:\n%s", want, codesignLog)
+		}
+	}
+	if strings.Contains(codesignLog, "--sign -") {
+		t.Fatalf("must not fall back to ad-hoc signing when an identity is set:\n%s", codesignLog)
+	}
+}
+
+func TestSignMacOSBinaryDiscoversIdentityFromKeychain(t *testing.T) {
+	t.Parallel()
+
+	f := newSignFixture(t)
+	f.keychain = filepath.Join(f.tempDir, "signing.keychain-db")
+	f.keychainIdentity = "ABC123DEF456"
+	result := f.run(t, "darwin")
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected success, got exit %d\noutput:\n%s", result.exitCode, result.output)
+	}
+	if !strings.Contains(result.output, "discovered Developer ID Application identity ABC123DEF456") {
+		t.Fatalf("expected keychain identity discovery, got:\n%s", result.output)
+	}
+
+	codesignLog := f.readLog(t, "codesign.log")
+	if !strings.Contains(codesignLog, "--sign ABC123DEF456") {
+		t.Fatalf("expected the discovered identity to be used:\n%s", codesignLog)
+	}
+	if !strings.Contains(codesignLog, "--keychain "+f.keychain) {
+		t.Fatalf("expected the throwaway keychain to be passed to codesign:\n%s", codesignLog)
+	}
+}
+
+// The execution gate is the whole point of the script: a binary can carry a
+// signature that every `codesign -d` field reports as healthy and still be
+// refused by the kernel.
+func TestSignMacOSBinaryFailsWhenExecutionGateFails(t *testing.T) {
+	t.Parallel()
+
+	f := newSignFixture(t)
+	f.binaryExitCode = 137
+	f.notaryEnv = true
+	f.identity = "Developer ID Application: Example (TEAMID)"
+	result := f.run(t, "darwin")
+
+	if result.exitCode == 0 {
+		t.Fatalf("expected failure when the binary cannot run, got exit 0\noutput:\n%s", result.output)
+	}
+	if !strings.Contains(result.output, "EXECUTION GATE FAILED") {
+		t.Fatalf("expected an execution gate error, got:\n%s", result.output)
+	}
+	if !strings.Contains(result.output, "exit 137 = SIGKILL") {
+		t.Fatalf("expected SIGKILL triage guidance, got:\n%s", result.output)
+	}
+	if log := f.readLogMaybe(t, "xcrun.log"); log != "" {
+		t.Fatalf("a binary that failed the gate must not be notarized, got:\n%s", log)
+	}
+}
+
+func TestSignMacOSBinaryFailsWhenVerificationFails(t *testing.T) {
+	t.Parallel()
+
+	f := newSignFixture(t)
+	f.identity = "Developer ID Application: Example (TEAMID)"
+	f.verifyExitCode = 3
+	result := f.run(t, "darwin")
+
+	if result.exitCode == 0 {
+		t.Fatalf("expected failure when verification fails, got exit 0\noutput:\n%s", result.output)
+	}
+	if !strings.Contains(result.output, "codesign --verify --strict rejected") {
+		t.Fatalf("expected a verification error, got:\n%s", result.output)
+	}
+	if !strings.Contains(result.output, "certificate 1[field.1.2.840.113635.100.6.2.6]") {
+		t.Fatalf("expected the canonical designated requirement hint, got:\n%s", result.output)
+	}
+}
+
+func TestSignMacOSBinaryRunsTheGateWithoutTelemetry(t *testing.T) {
+	t.Parallel()
+
+	f := newSignFixture(t)
+	result := f.run(t, "darwin")
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected success, got exit %d\noutput:\n%s", result.exitCode, result.output)
+	}
+
+	binaryLog := f.readLog(t, "binary.log")
+	if !strings.Contains(binaryLog, "args=--help") {
+		t.Fatalf("expected the gate to invoke --help, got:\n%s", binaryLog)
+	}
+	if !strings.Contains(binaryLog, "do_not_track=1") {
+		t.Fatalf("expected the gate to suppress telemetry, got:\n%s", binaryLog)
+	}
+}
+
+func TestSignMacOSBinaryNotarizesWhenCredentialsArePresent(t *testing.T) {
+	t.Parallel()
+
+	f := newSignFixture(t)
+	f.identity = "Developer ID Application: Example (TEAMID)"
+	f.notaryEnv = true
+	result := f.run(t, "darwin")
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected success, got exit %d\noutput:\n%s", result.exitCode, result.output)
+	}
+
+	xcrunLog := f.readLog(t, "xcrun.log")
+	for _, want := range []string{
+		"notarytool submit",
+		"--key " + filepath.Join(f.tempDir, "notary.p8"),
+		"--key-id NOTARYKEYID",
+		"--issuer NOTARYISSUERID",
+		"--wait",
+		"--timeout 30m",
+	} {
+		if !strings.Contains(xcrunLog, want) {
+			t.Fatalf("missing %q in notarytool invocation:\n%s", want, xcrunLog)
+		}
+	}
+	if !strings.Contains(f.readLog(t, "ditto.log"), "-c -k --keepParent") {
+		t.Fatalf("expected the binary to be zipped for notarytool:\n%s", f.readLog(t, "ditto.log"))
+	}
+
+	// The gate must run again on the final shipped artifact.
+	if !strings.Contains(result.output, "post-notarization re-check") {
+		t.Fatalf("expected a post-notarization gate re-check, got:\n%s", result.output)
+	}
+	if got := strings.Count(f.readLog(t, "binary.log"), "args=--help"); got != 2 {
+		t.Fatalf("expected the gate to run twice (pre and post notarization), ran %d times", got)
+	}
+}
+
+func TestSignMacOSBinarySkipsNotarizationWhenOptedOut(t *testing.T) {
+	t.Parallel()
+
+	f := newSignFixture(t)
+	f.identity = "Developer ID Application: Example (TEAMID)"
+	f.notaryEnv = true
+	f.skipNotarize = "true"
+	result := f.run(t, "darwin")
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected success, got exit %d\noutput:\n%s", result.exitCode, result.output)
+	}
+	if !strings.Contains(result.output, "VIGILANTE_SKIP_NOTARIZE is set") {
+		t.Fatalf("expected the opt-out notice, got:\n%s", result.output)
+	}
+	if log := f.readLogMaybe(t, "xcrun.log"); log != "" {
+		t.Fatalf("notarization must be skipped when opted out, got:\n%s", log)
+	}
+}
+
+// macos-latest is arm64. The amd64 artifact still gets signed and verified, but
+// the script must say plainly that it was not executed instead of implying the
+// gate covered it.
+func TestSignMacOSBinaryReportsUncoveredExecutionForForeignArch(t *testing.T) {
+	t.Parallel()
+
+	f := newSignFixture(t)
+	f.lipoArchs = "x86_64"
+	f.unameMachine = "arm64"
+	f.rosettaAvailable = false
+	result := f.run(t, "darwin")
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected success, got exit %d\noutput:\n%s", result.exitCode, result.output)
+	}
+	if !strings.Contains(result.output, "NOT COVERED") {
+		t.Fatalf("expected an uncovered-execution notice, got:\n%s", result.output)
+	}
+	if !strings.Contains(result.output, "execution not covered on this runner") {
+		t.Fatalf("expected the summary to admit the gate did not run, got:\n%s", result.output)
+	}
+	if log := f.readLogMaybe(t, "binary.log"); log != "" {
+		t.Fatalf("the foreign-arch binary must not be executed, got:\n%s", log)
+	}
+	if !strings.Contains(f.readLog(t, "codesign.log"), "--verify --strict") {
+		t.Fatalf("the foreign-arch binary must still be verified:\n%s", f.readLog(t, "codesign.log"))
+	}
+}
+
+func TestSignMacOSBinaryRunsForeignArchUnderRosetta(t *testing.T) {
+	t.Parallel()
+
+	f := newSignFixture(t)
+	f.lipoArchs = "x86_64"
+	f.unameMachine = "arm64"
+	f.rosettaAvailable = true
+	result := f.run(t, "darwin")
+
+	if result.exitCode != 0 {
+		t.Fatalf("expected success, got exit %d\noutput:\n%s", result.exitCode, result.output)
+	}
+	if !strings.Contains(result.output, "under Rosetta") {
+		t.Fatalf("expected the Rosetta gate to run, got:\n%s", result.output)
+	}
+	if !strings.Contains(f.readLog(t, "binary.log"), "args=--help") {
+		t.Fatalf("expected the binary to be executed under Rosetta:\n%s", f.readLog(t, "binary.log"))
+	}
+}
+
+type signFixture struct {
+	tempDir          string
+	binDir           string
+	binaryPath       string
+	binaryExitCode   int
+	identity         string
+	keychain         string
+	keychainIdentity string
+	lipoArchs        string
+	lipoExitCode     int
+	verifyExitCode   int
+	unameSystem      string
+	unameMachine     string
+	rosettaAvailable bool
+	notaryEnv        bool
+	skipNotarize     string
+	skipBinary       bool
+}
+
+func newSignFixture(t *testing.T) *signFixture {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	binDir := filepath.Join(tempDir, "bin")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	f := &signFixture{
+		tempDir:      tempDir,
+		binDir:       binDir,
+		binaryPath:   filepath.Join(tempDir, "vigilante"),
+		lipoArchs:    "arm64",
+		unameSystem:  "Darwin",
+		unameMachine: "arm64",
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "notary.p8"), []byte("notary-key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func (f *signFixture) writeTool(t *testing.T, name string, body string) {
+	t.Helper()
+
+	path := filepath.Join(f.binDir, name)
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeStubs installs the macOS toolchain the script depends on. Stubbing
+// `uname` too keeps these tests runnable on the Linux CI runner.
+func (f *signFixture) writeStubs(t *testing.T) {
+	t.Helper()
+
+	f.writeTool(t, "uname", `#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  -m) printf '%s\n' "$STUB_UNAME_MACHINE" ;;
+  *) printf '%s\n' "$STUB_UNAME_SYSTEM" ;;
+esac
+`)
+
+	f.writeTool(t, "lipo", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_TMPDIR/lipo.log"
+if [ "$STUB_LIPO_EXIT" -ne 0 ]; then
+  exit "$STUB_LIPO_EXIT"
+fi
+printf '%s\n' "$STUB_LIPO_ARCHS"
+`)
+
+	f.writeTool(t, "codesign", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_TMPDIR/codesign.log"
+case "$*" in
+  *--verify*) exit "$STUB_VERIFY_EXIT" ;;
+  *--display*) printf 'Identifier=vigilante\n' ;;
+esac
+`)
+
+	f.writeTool(t, "security", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_TMPDIR/security.log"
+if [ -n "$STUB_KEYCHAIN_IDENTITY" ]; then
+  printf '  1) %s "Developer ID Application: Example (TEAMID)"\n' "$STUB_KEYCHAIN_IDENTITY"
+fi
+`)
+
+	f.writeTool(t, "xcrun", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_TMPDIR/xcrun.log"
+`)
+
+	f.writeTool(t, "ditto", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_TMPDIR/ditto.log"
+: > "${!#}"
+`)
+
+	f.writeTool(t, "arch", `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_TMPDIR/arch.log"
+exit "$STUB_ROSETTA_EXIT"
+`)
+}
+
+// writeBinary installs the artifact under test: a stub that records how the
+// execution gate invoked it, including whether telemetry was suppressed.
+func (f *signFixture) writeBinary(t *testing.T) {
+	t.Helper()
+
+	body := `#!/usr/bin/env bash
+set -euo pipefail
+printf 'args=%s do_not_track=%s\n' "$*" "${DO_NOT_TRACK:-unset}" >> "$TEST_TMPDIR/binary.log"
+exit ` + strconv.Itoa(f.binaryExitCode) + `
+`
+	if err := os.WriteFile(f.binaryPath, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (f *signFixture) run(t *testing.T, goos string) signResult {
+	t.Helper()
+
+	f.writeStubs(t)
+	// The missing-binary test deliberately leaves the artifact uncreated.
+	if !f.skipBinary {
+		f.writeBinary(t)
+	}
+
+	args := []string{"./scripts/sign-macos-binary.sh", f.binaryPath}
+	if goos != "" {
+		args = append(args, goos)
+	}
+
+	rosettaExit := "1"
+	if f.rosettaAvailable {
+		rosettaExit = "0"
+	}
+
+	cmd := exec.Command("/bin/bash", args...)
+	cmd.Dir = repoRoot(t)
+	cmd.Env = append(os.Environ(),
+		"TEST_TMPDIR="+f.tempDir,
+		"PATH="+f.binDir+":"+os.Getenv("PATH"),
+		"STUB_UNAME_SYSTEM="+f.unameSystem,
+		"STUB_UNAME_MACHINE="+f.unameMachine,
+		"STUB_LIPO_ARCHS="+f.lipoArchs,
+		"STUB_LIPO_EXIT="+strconv.Itoa(f.lipoExitCode),
+		"STUB_VERIFY_EXIT="+strconv.Itoa(f.verifyExitCode),
+		"STUB_KEYCHAIN_IDENTITY="+f.keychainIdentity,
+		"STUB_ROSETTA_EXIT="+rosettaExit,
+		"APPLE_DEVELOPER_ID_IDENTITY="+f.identity,
+		"VIGILANTE_SIGN_KEYCHAIN="+f.keychain,
+		"VIGILANTE_SKIP_NOTARIZE="+f.skipNotarize,
+	)
+	if f.notaryEnv {
+		cmd.Env = append(cmd.Env,
+			"APPLE_NOTARY_KEY_P8="+filepath.Join(f.tempDir, "notary.p8"),
+			"APPLE_NOTARY_KEY_ID=NOTARYKEYID",
+			"APPLE_NOTARY_ISSUER_ID=NOTARYISSUERID",
+		)
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return signResult{output: string(output)}
+	}
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("run sign script: %v\n%s", err, output)
+	}
+	return signResult{exitCode: exitErr.ExitCode(), output: string(output)}
+}
+
+func (f *signFixture) readLog(t *testing.T, name string) string {
+	t.Helper()
+
+	body, err := os.ReadFile(filepath.Join(f.tempDir, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(body)
+}
+
+func (f *signFixture) readLogMaybe(t *testing.T, name string) string {
+	t.Helper()
+
+	body, err := os.ReadFile(filepath.Join(f.tempDir, name))
+	if os.IsNotExist(err) {
+		return ""
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(body)
+}
+
+type signResult struct {
+	exitCode int
+	output   string
+}


### PR DESCRIPTION
Closes #475

Ships **Phase 1** of the signing work: macOS release binaries are now signed with our Apple Developer ID Application certificate under the hardened runtime and notarized by Apple's notary service, in both the tagged-release and nightly pipelines.

Phase 2 (retiring the runtime Gatekeeper workarounds) is **deliberately not here** — the issue gates it on a verified signed release. See [Known gap](#known-gap) below.

## What changed

| File | Change |
|---|---|
| `scripts/sign-macos-binary.sh` | **new** — codesign → verify → **execute** → notarize |
| `scripts/import-signing-certificate.sh` | **new** — throwaway-keychain cert import, shared by both workflows |
| `scripts/sign_macos_binary_test.go` | **new** — 13 tests over the signing script |
| `.goreleaser.yml` | `builds[vigilante].hooks.post` invoking the signing script |
| `.github/workflows/release.yml` | `macos-latest`, cert import, notary credentials |
| `.github/workflows/nightly.yml` | same, gated on `refs/heads/main` |
| `.github/workflows/release-smoke.yml` | **new** — PR-time macOS snapshot + signing assertions |
| `docs/releasing.md` | **new** — setup, secrets, 1Password bootstrap, verification, rotation |
| `.gitignore` | ignore `/dist/` (the docs now tell contributors to build snapshots locally) |

## Design notes

**The execution gate is the point, not a bonus.** `codesign --verify` re-hashes the file using the CodeDirectory's own parameters and never asks the kernel whether it would load it. `lander` shipped two releases of binaries that were SIGKILLed at exec while `codesign -dv` printed a healthy summary. So the script runs `<binary> --help` and fails the release on a nonzero exit. Same reasoning for using Apple's native `codesign`/`notarytool` instead of GoReleaser's OSS `notarize.macos` (quill) pipe — the rationale is written up in `docs/releasing.md`.

**Adapted, not copy-pasted, from `lander`:**
- The hook hangs off `builds`, not `universal_binaries` — the casks select per-arch tarballs, so there is no universal binary here.
- It skips non-darwin targets, non-macOS runners, and non-Mach-O inputs, so the Linux and `gh-sandbox` artifacts pass through untouched.
- No per-slice `lipo -thin` loop; artifacts are already single-arch. Instead the gate skips when the artifact arch ≠ runner arch and reports **NOT COVERED** rather than implying it ran.
- No Developer ID **Installer** cert, no `.pkg`, no mirror repo — this repo is public and ships a cask.

**Degradation is deliberate.** With no certificate configured, `import-signing-certificate.sh` warns and exits 0, and signing falls back to ad-hoc with notarization skipped. Releases stay unsigned rather than the pipeline breaking. This also covers fork PRs, which never see secrets.

**Exec gate command.** Vigilante has no `version` subcommand — `vigilante --version` and `vigilante version` both exit 1 today. The gate uses `--help` (exits 0) under `DO_NOT_TRACK=1` so CI runs do not emit telemetry. I did not add a `version` command here (optional item 6 in the issue); it is a product change and cleanly separable.

**PR smoke test.** Without it, deleting the hook from `.goreleaser.yml` would leave CI green while silently disabling signing forever. The job asserts the artifacts are actually signed with the `vigilante` identifier, and that the Linux artifacts are not Mach-O.

## Two bugs caught while writing the tests

1. **bash 3.2 empty-array expansion.** `"${KEYCHAIN_ARGS[@]}"` under `set -u` aborts on macOS's bash 3.2 whenever an identity is set but no keychain is — my first manual smoke test missed it because it took the ad-hoc branch. Now guarded with `${arr[@]+"${arr[@]}"}`.
2. **`grep -q` under `pipefail`.** In the smoke-test assertion, `grep -q` exits on first match, SIGPIPEs `codesign`, and `pipefail` turns a passing check into a failure. Rewritten to capture output and `case`-match.

## Validation

All run locally on macOS (arm64, bash 3.2):

- `gofmt -l .` — clean
- `go vet ./...` — clean
- `go test ./...` — pass; `go test -race ./scripts/...` — pass
- `goreleaser check` — pass
- `actionlint` — 0 errors across all 5 workflows
- `goreleaser release --snapshot --clean` — both macOS artifacts signed (`Identifier=vigilante`, hardened runtime), gate executed both (Rosetta present locally), Linux artifacts still ELF, archive names unchanged
- Extracted `vigilante_*_macOS_arm64.tar.gz` and confirmed the **archived** binary carries the signature and runs — i.e. the hook lands before archiving
- Verified the smoke-test guard actually fails on an unsigned binary (`codesign --remove-signature`), so it is not decoration

`govulncheck` reports 3 pre-existing vulnerabilities (`grpc`, `otel/sdk`, `otlploghttp`). `go.mod`/`go.sum` are untouched by this branch, so they are unrelated and out of scope — worth a separate dependency bump.

## Before the first signed release

The `APPLE_*` secrets must be pushed from 1Password into the `main` environment. Commands are in `docs/releasing.md`; the certificate and notary key are team-wide and already backed up in the `Engineering` vault. Until they are set, both workflows keep working and produce unsigned artifacts exactly as today.

## Known gap

`prepareMacOSDaemonBinary` (`internal/service/service.go`) still runs `codesign --force --sign -` on the installed binary at `vigilante setup`, which **strips the Developer ID signature and voids notarization**. The nightly cask `postflight` does the same. Both were correct when every release was unsigned.

A clean `brew install --cask` is already improved without touching them; what is lost is the signature persisting after `setup` runs. Making them conditional on `codesign --verify` + `spctl --assess` passing is Phase 2 in #475, and the issue is explicit that it should not ship in this PR.