### PR TITLE
fix: install the binary atomically instead of overwriting in place

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -18,9 +18,11 @@ tasks:
   install:
     desc: Install the built binary into ~/.local/bin
     deps: [build]
+    # Atomic write-and-rename, not `cp`. Overwriting the destination in place
+    # corrupts the binary for every later exec when a daemon is running from it.
+    # See scripts/install-binary.sh.
     cmds:
-      - mkdir -p "{{.LOCAL_BIN_DIR}}"
-      - cp ./vigilante "{{.INSTALL_PATH}}"
+      - ./scripts/install-binary.sh ./vigilante "{{.INSTALL_PATH}}"
 
   setup:
     desc: Run setup with the repo-local binary

--- a/scripts/install-binary.sh
+++ b/scripts/install-binary.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# install-binary.sh — atomically install a built binary to a destination path.
+#
+# Why this is not just `cp`: `cp` truncates the destination and writes into the
+# EXISTING inode. Overwriting a Mach-O that a live process has mapped poisons the
+# kernel's page cache for that inode — it holds pages from the old binary,
+# validated against the old cdhash, mixed with the new file's contents. Every
+# subsequent exec then fails the code-signature page hashes and AMFI SIGKILLs the
+# process (exit 137), even though the bytes on disk are correct and
+# `codesign --verify` passes. Since the vigilante daemon normally runs from the
+# install path, `task install` hit this on every reinstall.
+#
+# Writing a temp file next to the destination and renaming over it gives the
+# destination a NEW inode. Any process still executing the old binary keeps its
+# own (now unlinked) inode and is unaffected. This is the same write-and-rename
+# that `codesign` itself performs, which is why self-signing never had the bug.
+#
+# The temp file MUST live in the destination directory: `mv` is only an atomic
+# rename(2) within a single filesystem. Across filesystems it degrades to a
+# copy, which reintroduces the in-place write this script exists to avoid.
+#
+# Usage: install-binary.sh <source-binary> <destination-path>
+set -euo pipefail
+
+SRC="${1:?usage: install-binary.sh <source-binary> <destination-path>}"
+DEST="${2:?usage: install-binary.sh <source-binary> <destination-path>}"
+
+[ -f "$SRC" ] || { echo "ERROR: source binary $SRC does not exist" >&2; exit 1; }
+
+DEST_DIR="$(dirname "$DEST")"
+mkdir -p "$DEST_DIR"
+
+TMP="$(mktemp "$DEST.XXXXXX")"
+trap 'rm -f "$TMP"' EXIT
+
+# `cat` rather than `cp` so the temp file keeps the mode mktemp created it with
+# (0600) instead of inheriting the source's, closing the window where a
+# world-readable partial binary is visible in the destination directory.
+cat "$SRC" > "$TMP"
+chmod 0755 "$TMP"
+mv -f "$TMP" "$DEST"
+trap - EXIT
+
+echo "installed $SRC -> $DEST"

--- a/scripts/install_binary_test.go
+++ b/scripts/install_binary_test.go
@@ -1,0 +1,242 @@
+package scripts
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// The regression guard for this script's whole reason to exist: `cp` reuses the
+// destination inode, which poisons the kernel's page cache for any binary a live
+// process has mapped and makes every later exec fail with SIGKILL. A rename gives
+// the destination a new inode instead.
+func TestInstallBinaryReplacesDestinationInode(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	f.writeSource(t, "first")
+	if result := f.run(t); result.exitCode != 0 {
+		t.Fatalf("first install failed: exit %d\n%s", result.exitCode, result.output)
+	}
+	firstInode := f.destInode(t)
+
+	f.writeSource(t, "second")
+	if result := f.run(t); result.exitCode != 0 {
+		t.Fatalf("reinstall failed: exit %d\n%s", result.exitCode, result.output)
+	}
+	secondInode := f.destInode(t)
+
+	if firstInode == secondInode {
+		t.Fatalf("destination kept inode %d across a reinstall; the install is not atomic", firstInode)
+	}
+	if got := f.destContents(t); got != "second" {
+		t.Fatalf("destination content = %q, want %q", got, "second")
+	}
+}
+
+// A process holding the previous binary must keep running: the rename unlinks the
+// old inode but does not disturb anyone who already has it open.
+func TestInstallBinaryLeavesPreviousInodeIntactForOpenHandles(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	f.writeSource(t, "original")
+	if result := f.run(t); result.exitCode != 0 {
+		t.Fatalf("install failed: exit %d\n%s", result.exitCode, result.output)
+	}
+
+	handle, err := os.Open(f.dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer handle.Close()
+
+	f.writeSource(t, "replacement")
+	if result := f.run(t); result.exitCode != 0 {
+		t.Fatalf("reinstall failed: exit %d\n%s", result.exitCode, result.output)
+	}
+
+	// Reading through the pre-existing handle reaches the old, now-unlinked
+	// inode. `cp` would have rewritten that inode in place and this would come
+	// back as "replacement".
+	if _, err := handle.Seek(0, 0); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 64)
+	n, err := handle.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(buf[:n])); got != "original" {
+		t.Fatalf("open handle saw %q, want the original inode's content", got)
+	}
+}
+
+func TestInstallBinaryCreatesMissingDestinationDirectory(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	f.dest = filepath.Join(f.tempDir, "nested", "deeper", "vigilante")
+	f.writeSource(t, "payload")
+
+	if result := f.run(t); result.exitCode != 0 {
+		t.Fatalf("install failed: exit %d\n%s", result.exitCode, result.output)
+	}
+	if got := f.destContents(t); got != "payload" {
+		t.Fatalf("destination content = %q, want %q", got, "payload")
+	}
+}
+
+func TestInstallBinaryResultIsExecutable(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	f.writeSource(t, "payload")
+	if result := f.run(t); result.exitCode != 0 {
+		t.Fatalf("install failed: exit %d\n%s", result.exitCode, result.output)
+	}
+
+	info, err := os.Stat(f.dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Fatalf("destination mode %v is not executable", info.Mode().Perm())
+	}
+}
+
+// A half-written binary must never be observable at the destination, and the
+// temp file must not survive the run.
+func TestInstallBinaryLeavesNoTemporaryFiles(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	f.writeSource(t, "payload")
+	if result := f.run(t); result.exitCode != 0 {
+		t.Fatalf("install failed: exit %d\n%s", result.exitCode, result.output)
+	}
+
+	entries, err := os.ReadDir(filepath.Dir(f.dest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != filepath.Base(f.dest) {
+			t.Fatalf("unexpected leftover %q in the destination directory", entry.Name())
+		}
+	}
+}
+
+func TestInstallBinaryFailsWhenSourceIsMissing(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	// No source written.
+	result := f.run(t)
+
+	if result.exitCode == 0 {
+		t.Fatalf("expected failure for a missing source, got exit 0\n%s", result.output)
+	}
+	if !strings.Contains(result.output, "does not exist") {
+		t.Fatalf("expected a missing-source error, got:\n%s", result.output)
+	}
+	if _, err := os.Stat(f.dest); !os.IsNotExist(err) {
+		t.Fatalf("destination must not be created when the source is missing")
+	}
+}
+
+func TestInstallBinaryRequiresBothArguments(t *testing.T) {
+	t.Parallel()
+
+	f := newInstallFixture(t)
+	f.writeSource(t, "payload")
+
+	cmd := exec.Command("/bin/bash", "./scripts/install-binary.sh", f.source)
+	cmd.Dir = repoRoot(t)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected failure when the destination is omitted, got success:\n%s", output)
+	}
+	if !strings.Contains(string(output), "usage:") {
+		t.Fatalf("expected a usage message, got:\n%s", output)
+	}
+}
+
+type installFixture struct {
+	tempDir string
+	source  string
+	dest    string
+}
+
+func newInstallFixture(t *testing.T) *installFixture {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	destDir := filepath.Join(tempDir, "bin")
+	if err := os.Mkdir(destDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return &installFixture{
+		tempDir: tempDir,
+		source:  filepath.Join(tempDir, "vigilante"),
+		dest:    filepath.Join(destDir, "vigilante"),
+	}
+}
+
+func (f *installFixture) writeSource(t *testing.T, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(f.source, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (f *installFixture) run(t *testing.T) installResult {
+	t.Helper()
+
+	cmd := exec.Command("/bin/bash", "./scripts/install-binary.sh", f.source, f.dest)
+	cmd.Dir = repoRoot(t)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return installResult{output: string(output)}
+	}
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("run install script: %v\n%s", err, output)
+	}
+	return installResult{exitCode: exitErr.ExitCode(), output: string(output)}
+}
+
+func (f *installFixture) destInode(t *testing.T) uint64 {
+	t.Helper()
+
+	info, err := os.Stat(f.dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Skip("inode information is unavailable on this platform")
+	}
+	return uint64(stat.Ino)
+}
+
+func (f *installFixture) destContents(t *testing.T) string {
+	t.Helper()
+
+	body, err := os.ReadFile(f.dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.TrimSpace(string(body))
+}
+
+type installResult struct {
+	exitCode int
+	output   string
+}


### PR DESCRIPTION
Closes #477

`task install` used `cp`, which truncates the destination and writes into the **existing inode**. Overwriting a Mach-O that a live process has mapped poisons the kernel's page cache for that inode, and every later `exec` is SIGKILLed by AMFI. Because the daemon normally runs from the install path, any reinstall on a developer machine left `~/.local/bin/vigilante` unrunnable:

```console
$ task install-setup
task: Failed to run task "install-setup": exit status 137
$ ~/.local/bin/vigilante --help ; echo $?
137
```

## The fix

Write a temp file next to the destination and `mv` it into place. The destination gets a **new inode**; the old one stays intact for whoever is still executing it, so the running daemon is undisturbed. This is the same write-and-rename `codesign` performs — which is why `vigilante setup` self-signing its own running binary never hit this bug while `cp` did.

Two details that matter:

- **The temp file must live in the destination directory.** `mv` is only an atomic `rename(2)` within a single filesystem; across filesystems it degrades to a copy, reintroducing the in-place write.
- **`cat` into a `mktemp` file rather than `cp`**, so the temp keeps mktemp's `0600` instead of inheriting the source mode — no window where a half-written world-readable binary is visible at a predictable path.

Logic lives in `scripts/` with a Go test, matching the existing convention (`setup-daemon.sh`, `verify-nightly-release.sh`, …), rather than inline in the Taskfile where it could not be covered.

## Why this was hard to diagnose

Nothing is wrong with the file. The bytes match the source, and `codesign --verify --strict` **passes** on the broken binary. Proof — same bytes, same directory, differing only by inode:

| Path | SHA-256 | `--help` |
|---|---|---|
| `./vigilante` | `50a7d8ed…` | exit 0 |
| `~/.local/bin/vigilante-probe` (fresh inode) | `50a7d8ed…` | exit 0 |
| `~/.local/bin/vigilante` (overwritten inode) | `50a7d8ed…` | **exit 137** |

The corruption is severe enough that `cmp` is itself SIGKILLed while reading the destination, which initially produced a bogus "files differ" result. It presents as a code-signing problem when it is a page-cache problem.

## Validation

**The tests are real regression guards.** I reverted the script to the old `cp` implementation and confirmed both load-bearing tests fail:

```
--- FAIL: TestInstallBinaryReplacesDestinationInode
    destination kept inode 7552324 across a reinstall; the install is not atomic
--- FAIL: TestInstallBinaryLeavesPreviousInodeIntactForOpenHandles
    open handle saw "replacement", want the original inode's content
```

Then restored the fix and confirmed all 7 pass.

**End-to-end, in the exact failing scenario** — a daemon running from the target path (`pid 3783`):

| Criterion | Result |
|---|---|
| `task install-setup` completes | ✅ `setup complete` (was exit 137) |
| Destination inode changes | ✅ `7551006 → 7555265` |
| Installed binary runs | ✅ `--help` exit 0 |
| Executable bit preserved | ✅ `-rwxr-xr-x` |
| No temp leftovers in `~/.local/bin` | ✅ none |
| Daemon survives the install | ✅ `state: running` |

`gofmt -l .`, `go vet ./...`, `go test ./...` all clean. The script is bash 3.2 compatible (`/bin/bash -n`), which matters since macOS ships 3.2.

## Note for anyone already affected

The poisoned inode persists until it is unlinked. Recovery, which does not require stopping the daemon:

```bash
rm -f ~/.local/bin/vigilante && cp ./vigilante ~/.local/bin/vigilante
```