### PR TITLE
feat: make Claude Code the default coding agent provider instead of Codex

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -55,10 +55,10 @@ Install with Homebrew:
 brew install vigilante
 ```
 
-Prepare the local machine with your preferred coding-agent provider:
+Prepare the local machine. `--provider` defaults to `claude`, so pass the flag only when you want a different coding agent:
 
 ```sh
-vigilante setup -d --provider codex
+vigilante setup -d
 ```
 
 Register a repository after setup installs the background service:
@@ -81,7 +81,7 @@ Quickstart requirements:
 
 - `git`
 - `gh` authenticated against the GitHub account you want Vigilante to operate with
-- one supported coding-agent CLI installed locally: `codex`, `claude`, `gemini`, or `opencode`
+- one supported coding-agent CLI installed locally: `claude` (the default), or `codex`, `gemini`, or `opencode` selected with `--provider`
 
 ## Product Goal
 
@@ -254,7 +254,7 @@ Expected behavior:
 - switches an existing target back to default-branch tracking when `--track-default-branch` is supplied
 - defaults the assignee filter to `me` unless overridden
 - defaults `--max-parallel` to `0` when not configured, where `0` means unlimited
-- defaults `--provider` to `codex` unless overridden
+- defaults `--provider` to `claude` unless overridden; already-watched repositories keep the provider already recorded in `watchlist.json`
 - defaults `--issue-tracker` to `github` unless overridden
 - when `--issue-tracker linear` is selected, verifies the local `linear` CLI is installed and authenticated before saving the watch target
 - accepts an optional `--issue-tracker-stage` filter; Linear defaults to `Todo` when the flag is omitted
@@ -401,6 +401,7 @@ Prepare the machine for autonomous execution.
 
 Expected behavior:
 
+- defaults `--provider` to `claude` unless overridden
 - creates `~/.vigilante/`
 - initializes `watchlist.json`
 - verifies `git`, `gh`, and the selected coding-agent provider CLI

--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ Requirements:
 
 - `git`
 - `gh` authenticated against the GitHub account Vigilante should operate with
-- one supported coding-agent CLI installed locally: `codex`, `claude`, `gemini`, or `opencode`
+- one supported coding-agent CLI installed locally: `claude` (the default), or `codex`, `gemini`, or `opencode` selected with `--provider`
 
-Bootstrap the local machine and install the managed service:
+Bootstrap the local machine and install the managed service. `--provider` defaults to `claude`:
 
 ```sh
-vigilante setup -d --provider codex
+vigilante setup -d
 ```
 
 ## Quick Start
@@ -94,7 +94,7 @@ Typical first-run flow:
 
 ```sh
 brew install vigilante
-vigilante setup -d --provider codex
+vigilante setup -d
 vigilante watch ~/hello-world-app
 vigilante daemon run --once
 ```

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6250,13 +6250,13 @@ func (a *App) generateResumeFailureDiagnostic(ctx context.Context, session state
 
 func buildResumeFailureSummaryInvocation(selectedProvider provider.Provider, workdir string, prompt string) (provider.Invocation, error) {
 	switch selectedProvider.ID() {
-	case provider.ClaudeID:
+	case provider.CodexID:
 		return provider.Invocation{
-			Dir:  workdir,
-			Name: "claude",
+			Name: "codex",
 			Args: []string{
-				"--print",
-				"--dangerously-skip-permissions",
+				"exec",
+				"--cd", workdir,
+				"--dangerously-bypass-approvals-and-sandbox",
 				prompt,
 			},
 		}, nil
@@ -6280,15 +6280,15 @@ func buildResumeFailureSummaryInvocation(selectedProvider provider.Provider, wor
 				prompt,
 			},
 		}, nil
-	case provider.DefaultID:
+	case provider.ClaudeID:
 		fallthrough
 	default:
 		return provider.Invocation{
-			Name: "codex",
+			Dir:  workdir,
+			Name: "claude",
 			Args: []string{
-				"exec",
-				"--cd", workdir,
-				"--dangerously-bypass-approvals-and-sandbox",
+				"--print",
+				"--dangerously-skip-permissions",
 				prompt,
 			},
 		}, nil

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -19,6 +19,7 @@ import (
 	githubbackend "github.com/nicobistolfi/vigilante/internal/backend/github"
 	"github.com/nicobistolfi/vigilante/internal/environment"
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
+	"github.com/nicobistolfi/vigilante/internal/provider"
 	"github.com/nicobistolfi/vigilante/internal/repo"
 	"github.com/nicobistolfi/vigilante/internal/skill"
 	"github.com/nicobistolfi/vigilante/internal/state"
@@ -2282,26 +2283,21 @@ func TestSetupCreatesStateLayoutAndInstallsBundledSkillsForAllProviders(t *testi
 	app := New()
 	app.stdout = testutil.IODiscard{}
 	app.stderr = testutil.IODiscard{}
-	app.env.Runner = testutil.FakeRunner{
-		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
-		Outputs: map[string]string{
-			"codex --version": "codex 0.114.0",
-			"gh auth status":  "ok",
-		},
-	}
 
+	// Setup with no --provider must provision the default provider, Claude
+	// Code, so only the claude CLI is stubbed here.
 	app.env.OS = "linux"
 	app.env.Runner = testutil.FakeRunner{
-		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "codex": "/usr/bin/codex"},
+		LookPaths: map[string]string{"git": "/usr/bin/git", "gh": "/usr/bin/gh", "claude": "/usr/bin/claude"},
 		Outputs: map[string]string{
-			"codex --version":                                                 "codex 0.114.0",
-			"gh auth status":                                                  "ok",
-			"systemctl --user daemon-reload":                                  "",
-			"systemctl --user enable --now vigilante.service":                 "",
-			`/bin/sh -lc PATH="` + os.Getenv("PATH") + `" command -v 'git'`:   "/usr/bin/git\n",
-			`/bin/sh -lc PATH="` + os.Getenv("PATH") + `" command -v 'gh'`:    "/usr/bin/gh\n",
-			`/bin/sh -lc PATH="` + os.Getenv("PATH") + `" command -v 'codex'`: "/usr/bin/codex\n",
-			`/bin/sh -lc PATH="` + os.Getenv("PATH") + `" 'codex' --version`:  "codex 0.114.0\n",
+			"claude --version":                                                 "claude 2.0.0",
+			"gh auth status":                                                   "ok",
+			"systemctl --user daemon-reload":                                   "",
+			"systemctl --user enable --now vigilante.service":                  "",
+			`/bin/sh -lc PATH="` + os.Getenv("PATH") + `" command -v 'git'`:    "/usr/bin/git\n",
+			`/bin/sh -lc PATH="` + os.Getenv("PATH") + `" command -v 'gh'`:     "/usr/bin/gh\n",
+			`/bin/sh -lc PATH="` + os.Getenv("PATH") + `" command -v 'claude'`: "/usr/bin/claude\n",
+			`/bin/sh -lc PATH="` + os.Getenv("PATH") + `" 'claude' --version`:  "claude 2.0.0\n",
 		},
 	}
 
@@ -2827,7 +2823,7 @@ func TestSetupFailsWhenProviderVersionIsIncompatible(t *testing.T) {
 		},
 	}
 
-	err := app.Setup(context.Background())
+	err := app.SetupWithProvider(context.Background(), provider.CodexID)
 	if err == nil || !strings.Contains(err.Error(), "codex CLI version 2.0.0 is incompatible") {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -9718,7 +9714,7 @@ func mergeStringMaps(maps ...map[string]string) map[string]string {
 }
 
 func issuePromptCommand(worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, branch string) string {
-	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePrompt(
+	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePromptForRuntime(skill.RuntimeCodex,
 		state.WatchTarget{Path: repoPath, Repo: repo},
 		ghcli.Issue{Number: issueNumber, Title: title, URL: issueURL},
 		state.Session{WorktreePath: worktreePath, Branch: branch, Provider: "codex"},
@@ -9726,7 +9722,7 @@ func issuePromptCommand(worktreePath string, repo string, repoPath string, issue
 }
 
 func issuePromptCommandForSession(worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, session state.Session) string {
-	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePrompt(
+	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePromptForRuntime(skill.RuntimeCodex,
 		state.WatchTarget{Path: repoPath, Repo: repo},
 		ghcli.Issue{Number: issueNumber, Title: title, URL: issueURL},
 		session,
@@ -9775,7 +9771,7 @@ func resumeDiagnosticSummaryCommandForProvider(worktreePath string, providerID s
 }
 
 func ciRemediationPromptCommand(worktreePath string, repo string, repoPath string, session state.Session, pr ghcli.PullRequest, checks []ghcli.StatusCheckRoll) string {
-	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildCIRemediationPrompt(
+	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildCIRemediationPromptForRuntime(skill.RuntimeCodex,
 		state.WatchTarget{Path: repoPath, Repo: repo},
 		session,
 		pr,
@@ -9784,7 +9780,7 @@ func ciRemediationPromptCommand(worktreePath string, repo string, repoPath strin
 }
 
 func conflictResolutionPromptCommand(worktreePath string, repo string, repoPath string, session state.Session, pr ghcli.PullRequest) string {
-	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildConflictResolutionPrompt(
+	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildConflictResolutionPromptForRuntime(skill.RuntimeCodex,
 		state.WatchTarget{Path: repoPath, Repo: repo, Branch: session.BaseBranch},
 		session,
 		pr,
@@ -10227,5 +10223,130 @@ func TestWriteSandboxGitconfigWritesSanitizedFile(t *testing.T) {
 	}
 	if strings.Contains(string(data), "[gpg]") {
 		t.Errorf("expected [gpg] stripped, got: %s", string(data))
+	}
+}
+
+// TestWatchWithoutProviderPersistsClaude covers the default watch path: with no
+// --provider flag the new watch target must be pinned to Claude Code.
+func TestWatchWithoutProviderPersistsClaude(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                  "true\n",
+			testutil.Key("git", "remote", "get-url", "origin"):                         "git@github.com:nicobistolfi/vigilante.git\n",
+			testutil.Key("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"): "origin/main\n",
+		},
+	}
+
+	if err := app.Watch(context.Background(), repoPath, nil, "", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	targets, err := app.state.LoadWatchTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 || targets[0].Provider != provider.ClaudeID {
+		t.Fatalf("expected claude provider to persist: %#v", targets)
+	}
+}
+
+// TestWatchWithCodexProviderPersistsSelection keeps Codex explicitly
+// selectable now that it is no longer the default.
+func TestWatchWithCodexProviderPersistsSelection(t *testing.T) {
+	home := t.TempDir()
+	repoPath := filepath.Join(home, "repo")
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{
+		Outputs: map[string]string{
+			testutil.Key("git", "rev-parse", "--is-inside-work-tree"):                  "true\n",
+			testutil.Key("git", "remote", "get-url", "origin"):                         "git@github.com:nicobistolfi/vigilante.git\n",
+			testutil.Key("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"): "origin/main\n",
+		},
+	}
+
+	if err := app.WatchWithProvider(context.Background(), repoPath, nil, "", 0, provider.CodexID); err != nil {
+		t.Fatal(err)
+	}
+
+	targets, err := app.state.LoadWatchTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 || targets[0].Provider != provider.CodexID {
+		t.Fatalf("expected codex provider to persist: %#v", targets)
+	}
+}
+
+// TestBuildResumeFailureSummaryInvocationPerProvider asserts the default
+// dispatch path builds a claude invocation rather than falling through to
+// codex exec, while Codex keeps its own arm.
+func TestBuildResumeFailureSummaryInvocationPerProvider(t *testing.T) {
+	cases := map[string]string{
+		"":                  "claude",
+		provider.ClaudeID:   "claude",
+		provider.CodexID:    "codex",
+		provider.GeminiID:   "gemini",
+		provider.OpenCodeID: "opencode",
+	}
+
+	for id, wantName := range cases {
+		t.Run("provider="+id, func(t *testing.T) {
+			selectedProvider, err := provider.Resolve(id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			invocation, err := buildResumeFailureSummaryInvocation(selectedProvider, "/tmp/worktree", "prompt")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if invocation.Name != wantName {
+				t.Fatalf("expected %q invocation, got %q", wantName, invocation.Name)
+			}
+		})
+	}
+}
+
+// TestResolveIssueProviderPrefersLabelOverDefault keeps label routing intact
+// now that the unlabeled default is Claude.
+func TestResolveIssueProviderPrefersLabelOverDefault(t *testing.T) {
+	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
+
+	selected, err := resolveIssueProvider(target, ghcli.Issue{Number: 7})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selected != provider.ClaudeID {
+		t.Fatalf("expected unlabeled issue to default to claude, got %q", selected)
+	}
+
+	selected, err = resolveIssueProvider(target, ghcli.Issue{Number: 7, Labels: []ghcli.Label{{Name: provider.CodexID}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selected != provider.CodexID {
+		t.Fatalf("expected codex label to override the default, got %q", selected)
+	}
+
+	if _, err := resolveIssueProvider(target, ghcli.Issue{Number: 7, Labels: []ghcli.Label{{Name: provider.CodexID}, {Name: provider.GeminiID}}}); err == nil {
+		t.Fatal("expected conflicting provider labels to error")
 	}
 }

--- a/internal/app/start_test.go
+++ b/internal/app/start_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
+	"github.com/nicobistolfi/vigilante/internal/provider"
 	"github.com/nicobistolfi/vigilante/internal/skill"
 	"github.com/nicobistolfi/vigilante/internal/state"
 	"github.com/nicobistolfi/vigilante/internal/testutil"
@@ -95,7 +96,7 @@ func TestStartOneOffSessionSuccess(t *testing.T) {
 		t.Fatal("expected no watch targets")
 	}
 
-	err = app.StartOneOffSession(context.Background(), repoPath, 10, "", false)
+	err = app.StartOneOffSession(context.Background(), repoPath, 10, provider.CodexID, false)
 	// Without a tracked PR the session is incomplete, which StartOneOffSession reports as an error.
 	if err == nil {
 		t.Fatal("expected error for incomplete session without PR")
@@ -334,7 +335,7 @@ func TestStartOneOffSessionReusesExistingSessionOrchestration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := app.StartOneOffSession(context.Background(), repoPath, 7, "", false)
+	err := app.StartOneOffSession(context.Background(), repoPath, 7, provider.CodexID, false)
 	if err == nil {
 		t.Fatal("expected error for blocked session")
 	}

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -8,7 +8,7 @@ import (
 type codexProvider struct{}
 
 func (codexProvider) ID() string {
-	return DefaultID
+	return CodexID
 }
 
 func (codexProvider) DisplayName() string {
@@ -42,7 +42,7 @@ func (codexProvider) BuildIssueInvocation(task IssueTask) (Invocation, error) {
 			"exec",
 			"--cd", task.Session.WorktreePath,
 			"--dangerously-bypass-approvals-and-sandbox",
-			skill.BuildIssuePrompt(task.Target, task.Issue, task.Session),
+			skill.BuildIssuePromptForRuntime(skill.RuntimeCodex, task.Target, task.Issue, task.Session),
 		},
 	}, nil
 }
@@ -54,7 +54,7 @@ func (codexProvider) BuildConflictResolutionInvocation(task ConflictTask) (Invoc
 			"exec",
 			"--cd", task.Session.WorktreePath,
 			"--dangerously-bypass-approvals-and-sandbox",
-			skill.BuildConflictResolutionPrompt(task.Target, task.Session, task.PR),
+			skill.BuildConflictResolutionPromptForRuntime(skill.RuntimeCodex, task.Target, task.Session, task.PR),
 		},
 	}, nil
 }
@@ -66,7 +66,7 @@ func (codexProvider) BuildCIRemediationInvocation(task CIRemediationTask) (Invoc
 			"exec",
 			"--cd", task.Session.WorktreePath,
 			"--dangerously-bypass-approvals-and-sandbox",
-			skill.BuildCIRemediationPrompt(task.Target, task.Session, task.PR, task.FailingChecks),
+			skill.BuildCIRemediationPromptForRuntime(skill.RuntimeCodex, task.Target, task.Session, task.PR, task.FailingChecks),
 		},
 	}, nil
 }
@@ -78,7 +78,7 @@ func (codexProvider) BuildIssueCreateInvocation(task IssueCreateTask) (Invocatio
 			"exec",
 			"--cd", task.Target.Path,
 			"--dangerously-bypass-approvals-and-sandbox",
-			skill.BuildIssueCreatePromptDefault(task.Target, task.Prompt),
+			skill.BuildIssueCreatePrompt(skill.RuntimeCodex, task.Target, task.Prompt),
 		},
 	}, nil
 }

--- a/internal/provider/compatibility.go
+++ b/internal/provider/compatibility.go
@@ -24,7 +24,7 @@ type compatibilityContract struct {
 }
 
 var compatibilityContracts = map[string]compatibilityContract{
-	DefaultID:  {minInclusive: "0.114.0", maxExclusive: "2.0.0"},
+	CodexID:    {minInclusive: "0.114.0", maxExclusive: "2.0.0"},
 	ClaudeID:   {minInclusive: "2.0.0", maxExclusive: "3.0.0"},
 	GeminiID:   {minInclusive: "0.34.0", maxExclusive: "1.0.0"},
 	OpenCodeID: {minInclusive: "1.0.0", maxExclusive: "2.0.0"},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,10 +9,17 @@ import (
 	"github.com/nicobistolfi/vigilante/internal/state"
 )
 
-const DefaultID = "codex"
+const CodexID = "codex"
 const ClaudeID = "claude"
 const GeminiID = "gemini"
 const OpenCodeID = "opencode"
+
+// DefaultID is the provider selected when no provider is specified by a flag,
+// an issue label, or a persisted watch target. It is deliberately an alias of
+// another provider's ID rather than its own literal, so "the default" and
+// "which provider" stay separate concepts and changing the default stays a
+// one-line edit.
+const DefaultID = ClaudeID
 
 type Invocation struct {
 	Dir  string
@@ -68,7 +75,7 @@ type Provider interface {
 }
 
 var registry = map[string]Provider{
-	DefaultID:  codexProvider{},
+	CodexID:    codexProvider{},
 	ClaudeID:   claudeProvider{},
 	GeminiID:   geminiProvider{},
 	OpenCodeID: opencodeProvider{},

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -9,13 +9,74 @@ import (
 	"github.com/nicobistolfi/vigilante/internal/state"
 )
 
-func TestResolveDefaultsToCodex(t *testing.T) {
+func TestResolveDefaultsToClaude(t *testing.T) {
 	selectedProvider, err := Resolve("")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if selectedProvider.ID() != DefaultID {
+	if selectedProvider.ID() != ClaudeID {
 		t.Fatalf("unexpected provider id: %s", selectedProvider.ID())
+	}
+}
+
+// TestDefaultIDIsNotCodexID guards the decoupling of "the provider used when
+// none is specified" from "the Codex provider's identity". Re-merging the two
+// silently reroutes Codex dispatch and Codex's CLI version contract.
+func TestDefaultIDIsNotCodexID(t *testing.T) {
+	if DefaultID == CodexID {
+		t.Fatalf("DefaultID must stay distinct from CodexID, both are %q", DefaultID)
+	}
+	if DefaultID != ClaudeID {
+		t.Fatalf("unexpected default provider id: %s", DefaultID)
+	}
+}
+
+// TestRegisteredProviderIDsMatchRegistryKeys ensures no provider reports an ID
+// that disagrees with the key it is registered under.
+func TestRegisteredProviderIDsMatchRegistryKeys(t *testing.T) {
+	for _, id := range RegisteredIDs() {
+		selectedProvider, err := Resolve(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if selectedProvider.ID() != id {
+			t.Fatalf("provider registered as %q reports id %q", id, selectedProvider.ID())
+		}
+	}
+}
+
+func TestCompatibilityContractsStayBoundToTheirProvider(t *testing.T) {
+	cases := map[string]compatibilityContract{
+		CodexID:    {minInclusive: "0.114.0", maxExclusive: "2.0.0"},
+		ClaudeID:   {minInclusive: "2.0.0", maxExclusive: "3.0.0"},
+		GeminiID:   {minInclusive: "0.34.0", maxExclusive: "1.0.0"},
+		OpenCodeID: {minInclusive: "1.0.0", maxExclusive: "2.0.0"},
+	}
+	for id, want := range cases {
+		got, err := compatibilityFor(id)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got != want {
+			t.Fatalf("unexpected contract for %q: %#v", id, got)
+		}
+	}
+}
+
+func TestRequiredToolsetForCodexProvider(t *testing.T) {
+	selectedProvider, err := Resolve(CodexID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := RequiredToolset(selectedProvider)
+	want := []string{"codex", "gh", "git"}
+	if len(got) != len(want) {
+		t.Fatalf("unexpected tool count: %#v", got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected toolset: %#v", got)
+		}
 	}
 }
 
@@ -25,7 +86,7 @@ func TestRequiredToolsetIncludesSharedAndProviderTools(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := RequiredToolset(selectedProvider)
-	want := []string{"codex", "gh", "git"}
+	want := []string{"claude", "gh", "git"}
 	if len(got) != len(want) {
 		t.Fatalf("unexpected tool count: %#v", got)
 	}
@@ -235,8 +296,8 @@ func TestClaudeInvocationUsesWorktreeDirForHeadlessRuns(t *testing.T) {
 func TestResolveIssueLabelUsesRegisteredProviderIDs(t *testing.T) {
 	original := registry
 	registry = map[string]Provider{
-		DefaultID: codexProvider{},
-		"cursor":  testProvider{id: "cursor"},
+		CodexID:  codexProvider{},
+		"cursor": testProvider{id: "cursor"},
 	}
 	t.Cleanup(func() {
 		registry = original
@@ -254,14 +315,14 @@ func TestResolveIssueLabelUsesRegisteredProviderIDs(t *testing.T) {
 func TestResolveIssueLabelRejectsConflictingProviderLabels(t *testing.T) {
 	original := registry
 	registry = map[string]Provider{
-		DefaultID: codexProvider{},
-		"cursor":  testProvider{id: "cursor"},
+		CodexID:  codexProvider{},
+		"cursor": testProvider{id: "cursor"},
 	}
 	t.Cleanup(func() {
 		registry = original
 	})
 
-	_, err := ResolveIssueLabel([]ghcli.Label{{Name: DefaultID}, {Name: "cursor"}})
+	_, err := ResolveIssueLabel([]ghcli.Label{{Name: CodexID}, {Name: "cursor"}})
 	if err == nil {
 		t.Fatal("expected conflict error")
 	}
@@ -276,8 +337,8 @@ func TestValidateVersionOutputAcceptsSupportedVersions(t *testing.T) {
 		provider string
 		output   string
 	}{
-		{name: "codex current supported 0.x", provider: DefaultID, output: "codex 0.114.0"},
-		{name: "codex", provider: DefaultID, output: "codex 1.2.3"},
+		{name: "codex current supported 0.x", provider: CodexID, output: "codex 0.114.0"},
+		{name: "codex", provider: CodexID, output: "codex 1.2.3"},
 		{name: "claude 2.x", provider: ClaudeID, output: "Claude Code v2.1.3"},
 		{name: "gemini current supported 0.x", provider: GeminiID, output: "gemini-cli 0.34.0"},
 		{name: "opencode 1.x minimum", provider: OpenCodeID, output: "opencode 1.0.0"},
@@ -298,7 +359,7 @@ func TestValidateVersionOutputAcceptsSupportedVersions(t *testing.T) {
 }
 
 func TestValidateVersionOutputRejectsTooOldVersion(t *testing.T) {
-	selectedProvider, err := Resolve(DefaultID)
+	selectedProvider, err := Resolve(CodexID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -489,7 +550,7 @@ func TestBuildIssueCreateInvocationForAllProviders(t *testing.T) {
 				t.Fatal("expected non-empty invocation name")
 			}
 			// Codex uses --cd flag instead of Dir
-			if id != DefaultID && inv.Dir != "/tmp/repo" {
+			if id != CodexID && inv.Dir != "/tmp/repo" {
 				t.Fatalf("expected dir %q, got %q", "/tmp/repo", inv.Dir)
 			}
 			// Verify the prompt text is somewhere in the args

--- a/internal/runner/session_test.go
+++ b/internal/runner/session_test.go
@@ -57,7 +57,7 @@ func TestRunIssueSessionSuccess(t *testing.T) {
 			AccessLog: store.AppendAccessLogEntry,
 		},
 	}
-	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
+	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "codex", Status: state.SessionStatusRunning}
 	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 	// No PR was tracked, so the session is incomplete rather than success.
 	if got.Status != state.SessionStatusIncomplete {
@@ -122,7 +122,7 @@ func TestRunIssueSessionReconcilesExistingPullRequestAfterSuccessfulExit(t *test
 			AccessLog: store.AppendAccessLogEntry,
 		},
 	}
-	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
+	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "codex", Status: state.SessionStatusRunning}
 	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 	if got.Status != state.SessionStatusSuccess {
 		t.Fatalf("unexpected status: %s (expected success after PR reconciliation)", got.Status)
@@ -187,7 +187,7 @@ func TestRunIssueSessionLeavesIncompleteWhenBranchLookupFindsClosedPullRequest(t
 			AccessLog: store.AppendAccessLogEntry,
 		},
 	}
-	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
+	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "codex", Status: state.SessionStatusRunning}
 	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 	if got.Status != state.SessionStatusIncomplete {
 		t.Fatalf("unexpected status: %s (expected incomplete when only a closed PR exists)", got.Status)
@@ -248,7 +248,7 @@ func TestRunIssueSessionLeavesIncompleteWhenBranchLookupFindsNoPullRequest(t *te
 			AccessLog: store.AppendAccessLogEntry,
 		},
 	}
-	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
+	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "codex", Status: state.SessionStatusRunning}
 	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 	if got.Status != state.SessionStatusIncomplete {
 		t.Fatalf("unexpected status: %s (expected incomplete when branch lookup finds no PR)", got.Status)
@@ -300,6 +300,7 @@ func TestRunIssueSessionSuccessWithPR(t *testing.T) {
 		RepoPath:          "/tmp/repo",
 		IssueNumber:       7,
 		WorktreePath:      "/tmp/worktree",
+		Provider:          "codex",
 		Branch:            "vigilante/issue-7",
 		Status:            state.SessionStatusRunning,
 		PullRequestNumber: 42,
@@ -337,7 +338,7 @@ func TestRunIssueSessionSuccessInSandboxUsesDockerExec(t *testing.T) {
 				ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"},
 				state.Session{WorktreePath: "/workspace", Branch: "vigilante/issue-7", Provider: "codex", SandboxMode: true, SandboxContainerName: "vigilante-sandbox-sbx_test"},
 			)): "baseline ok",
-			testutil.Key("docker", "exec", "-w", "/workspace", "vigilante-sandbox-sbx_test", "codex", "exec", "--cd", "/workspace", "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePrompt(
+			testutil.Key("docker", "exec", "-w", "/workspace", "vigilante-sandbox-sbx_test", "codex", "exec", "--cd", "/workspace", "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePromptForRuntime(skill.RuntimeCodex,
 				state.WatchTarget{Path: "/workspace", Repo: "owner/repo"},
 				ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"},
 				state.Session{WorktreePath: "/workspace", Branch: "vigilante/issue-7", Provider: "codex", SandboxMode: true, SandboxContainerName: "vigilante-sandbox-sbx_test"},
@@ -363,6 +364,7 @@ func TestRunIssueSessionSuccessInSandboxUsesDockerExec(t *testing.T) {
 		RepoPath:             "/tmp/repo",
 		IssueNumber:          7,
 		WorktreePath:         "/tmp/worktree",
+		Provider:             "codex",
 		Branch:               "vigilante/issue-7",
 		Status:               state.SessionStatusRunning,
 		SandboxMode:          true,
@@ -415,7 +417,7 @@ func TestRunIssueSessionSandboxExit137IncludesOOMHint(t *testing.T) {
 			)): "baseline ok",
 		},
 		Errors: map[string]error{
-			testutil.Key("docker", "exec", "-w", "/workspace", "vigilante-sandbox-sbx_test", "codex", "exec", "--cd", "/workspace", "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePrompt(
+			testutil.Key("docker", "exec", "-w", "/workspace", "vigilante-sandbox-sbx_test", "codex", "exec", "--cd", "/workspace", "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePromptForRuntime(skill.RuntimeCodex,
 				state.WatchTarget{Path: "/workspace", Repo: "owner/repo"},
 				ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"},
 				state.Session{WorktreePath: "/workspace", Branch: "vigilante/issue-7", Provider: "codex", SandboxMode: true, SandboxContainerName: "vigilante-sandbox-sbx_test"},
@@ -431,6 +433,7 @@ func TestRunIssueSessionSandboxExit137IncludesOOMHint(t *testing.T) {
 		RepoPath:             "/tmp/repo",
 		IssueNumber:          7,
 		WorktreePath:         "/tmp/worktree",
+		Provider:             "codex",
 		Branch:               "vigilante/issue-7",
 		Status:               state.SessionStatusRunning,
 		SandboxMode:          true,
@@ -477,6 +480,7 @@ func TestRunIssueSessionStartCommentIncludesReusedRemoteBranchContext(t *testing
 		RepoPath:           "/tmp/repo",
 		IssueNumber:        7,
 		WorktreePath:       "/tmp/worktree",
+		Provider:           "codex",
 		Branch:             "vigilante/issue-7-demo",
 		BaseBranch:         "main",
 		ReusedRemoteBranch: "vigilante/issue-7-demo",
@@ -535,7 +539,7 @@ func TestRunIssueSessionFailureCommentsOnIssue(t *testing.T) {
 	if err := store.EnsureLayout(); err != nil {
 		t.Fatal(err)
 	}
-	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
+	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "codex", Status: state.SessionStatusRunning}
 	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 	if got.Status != state.SessionStatusBlocked {
 		t.Fatalf("unexpected status: %#v", got)
@@ -759,7 +763,7 @@ func TestRunIssueSessionUsesMonorepoSkillWhenClassified(t *testing.T) {
 				Tagline: "Make it simple, but significant.",
 			}): "ok",
 			preflightPromptCommand("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", "vigilante/issue-7"): "baseline ok",
-			testutil.Key("codex", "exec", "--cd", "/tmp/worktree", "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePrompt(
+			testutil.Key("codex", "exec", "--cd", "/tmp/worktree", "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePromptForRuntime(skill.RuntimeCodex,
 				target,
 				ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"},
 				state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "codex"},
@@ -771,7 +775,7 @@ func TestRunIssueSessionUsesMonorepoSkillWhenClassified(t *testing.T) {
 	if err := store.EnsureLayout(); err != nil {
 		t.Fatal(err)
 	}
-	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
+	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "codex", Status: state.SessionStatusRunning}
 
 	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), target, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 
@@ -812,7 +816,7 @@ func TestRunIssueSessionUsesNxSkillWhenClassified(t *testing.T) {
 				Tagline: "Make it simple, but significant.",
 			}): "ok",
 			preflightPromptCommand("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", "vigilante/issue-7"): "baseline ok",
-			testutil.Key("codex", "exec", "--cd", "/tmp/worktree", "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePrompt(
+			testutil.Key("codex", "exec", "--cd", "/tmp/worktree", "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePromptForRuntime(skill.RuntimeCodex,
 				target,
 				ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"},
 				state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "codex"},
@@ -824,7 +828,7 @@ func TestRunIssueSessionUsesNxSkillWhenClassified(t *testing.T) {
 	if err := store.EnsureLayout(); err != nil {
 		t.Fatal(err)
 	}
-	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
+	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "codex", Status: state.SessionStatusRunning}
 
 	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), target, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 
@@ -865,7 +869,7 @@ func TestRunIssueSessionUsesRushMonorepoSkillWhenClassified(t *testing.T) {
 				Tagline: "Make it simple, but significant.",
 			}): "ok",
 			preflightPromptCommand("/tmp/worktree", "owner/repo", "/tmp/repo", 7, "Demo", "https://github.com/owner/repo/issues/7", "vigilante/issue-7"): "baseline ok",
-			testutil.Key("codex", "exec", "--cd", "/tmp/worktree", "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePrompt(
+			testutil.Key("codex", "exec", "--cd", "/tmp/worktree", "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePromptForRuntime(skill.RuntimeCodex,
 				target,
 				ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"},
 				state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "codex"},
@@ -877,7 +881,7 @@ func TestRunIssueSessionUsesRushMonorepoSkillWhenClassified(t *testing.T) {
 	if err := store.EnsureLayout(); err != nil {
 		t.Fatal(err)
 	}
-	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
+	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "codex", Status: state.SessionStatusRunning}
 
 	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), target, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 
@@ -899,7 +903,7 @@ func TestRunIssueSessionFailsWhenProviderVersionIsIncompatible(t *testing.T) {
 	if err := store.EnsureLayout(); err != nil {
 		t.Fatal(err)
 	}
-	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
+	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "codex", Status: state.SessionStatusRunning}
 
 	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 
@@ -1136,7 +1140,7 @@ func issuePromptCommand(worktreePath string, repo string, repoPath string, issue
 }
 
 func issuePromptCommandForSession(worktreePath string, repo string, repoPath string, issueNumber int, title string, issueURL string, session state.Session) string {
-	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePrompt(
+	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildIssuePromptForRuntime(skill.RuntimeCodex,
 		state.WatchTarget{Path: repoPath, Repo: repo},
 		ghcli.Issue{Number: issueNumber, Title: title, URL: issueURL},
 		session,
@@ -1144,7 +1148,7 @@ func issuePromptCommandForSession(worktreePath string, repo string, repoPath str
 }
 
 func conflictResolutionPromptCommand(worktreePath string, repo string, repoPath string, session state.Session, pr ghcli.PullRequest) string {
-	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildConflictResolutionPrompt(
+	return testutil.Key("codex", "exec", "--cd", worktreePath, "--dangerously-bypass-approvals-and-sandbox", skill.BuildConflictResolutionPromptForRuntime(skill.RuntimeCodex,
 		state.WatchTarget{Path: repoPath, Repo: repo, Branch: session.BaseBranch},
 		session,
 		pr,
@@ -1185,7 +1189,7 @@ func TestRunIssueSessionWritesLifecycleEvents(t *testing.T) {
 			AccessLog: store.AppendAccessLogEntry,
 		},
 	}
-	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Status: state.SessionStatusRunning}
+	session := state.Session{RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7", Provider: "codex", Status: state.SessionStatusRunning}
 	got := RunIssueSession(context.Background(), env, store, githubbackend.NewBackend(&env.Runner), state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}, ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}, session)
 	if got.Status != state.SessionStatusIncomplete {
 		t.Fatalf("unexpected status (expected incomplete without PR): %s", got.Status)

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -77,7 +77,7 @@ func TestBuildConfigUsesShellPath(t *testing.T) {
 		},
 	}
 
-	selectedProvider, err := provider.Resolve(provider.DefaultID)
+	selectedProvider, err := provider.Resolve(provider.CodexID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +113,7 @@ func TestBuildConfigFailsWhenDaemonPathCannotResolveTools(t *testing.T) {
 		},
 	}
 
-	selectedProvider, err := provider.Resolve(provider.DefaultID)
+	selectedProvider, err := provider.Resolve(provider.CodexID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +202,7 @@ func TestBuildConfigFailsWhenProviderVersionIsIncompatible(t *testing.T) {
 		},
 	}
 
-	selectedProvider, err := provider.Resolve(provider.DefaultID)
+	selectedProvider, err := provider.Resolve(provider.CodexID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -187,14 +187,6 @@ func BuildIssueCreatePrompt(runtime string, target state.WatchTarget, prompt str
 	return strings.Join(lines, "\n")
 }
 
-func BuildIssueCreatePromptDefault(target state.WatchTarget, prompt string) string {
-	return BuildIssueCreatePrompt(RuntimeCodex, target, prompt)
-}
-
-func BuildIssuePrompt(target state.WatchTarget, issue ghcli.Issue, session state.Session) string {
-	return BuildIssuePromptForRuntime(RuntimeCodex, target, issue, session)
-}
-
 func BuildIssuePromptForRuntime(runtime string, target state.WatchTarget, issue ghcli.Issue, session state.Session) string {
 	selectedSkill := IssueImplementationSkill(target)
 	lines := []string{}
@@ -629,10 +621,6 @@ func displayProviderName(name string) string {
 	return strings.Join(parts, " ")
 }
 
-func BuildConflictResolutionPrompt(target state.WatchTarget, session state.Session, pr ghcli.PullRequest) string {
-	return BuildConflictResolutionPromptForRuntime(RuntimeCodex, target, session, pr)
-}
-
 func BuildConflictResolutionPromptForRuntime(runtime string, target state.WatchTarget, session state.Session, pr ghcli.PullRequest) string {
 	lines := []string{}
 	if runtimeUsesInlineSkillHeader(runtime) {
@@ -686,10 +674,6 @@ func promptBaseBranch(target state.WatchTarget, session state.Session) string {
 		return baseBranch
 	}
 	return "main"
-}
-
-func BuildCIRemediationPrompt(target state.WatchTarget, session state.Session, pr ghcli.PullRequest, checks []ghcli.StatusCheckRoll) string {
-	return BuildCIRemediationPromptForRuntime(RuntimeCodex, target, session, pr, checks)
 }
 
 func BuildCIRemediationPromptForRuntime(runtime string, target state.WatchTarget, session state.Session, pr ghcli.PullRequest, checks []ghcli.StatusCheckRoll) string {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -133,7 +133,7 @@ func TestBuildIssuePrompt(t *testing.T) {
 	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
 	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
 	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
-	prompt := BuildIssuePrompt(target, issue, session)
+	prompt := BuildIssuePromptForRuntime(RuntimeCodex, target, issue, session)
 	for _, text := range []string{"Use the `vigilante-issue-implementation` skill", "Detected repo shape: traditional", `Repo process context JSON: {"shape":"traditional"}`, "Selected issue implementation skill: vigilante-issue-implementation", "Issue: #12 - Fix bug", "Worktree path: /tmp/worktree", "vigilante gh issue comment", "vigilante commit", "vigilante git push", "vigilante gh pr create", "Closes #12", "Coding Agent Launched: Codex", "@vigilanteai resume", "@vigilanteai cleanup", "issue-comment commands rather than shell commands", "10-cell progress bar", "ETA: ~N minutes", "Use `vigilante commit` for all commit-producing operations", "Do not use `git commit` or GitHub CLI commit flows directly", "preserve the user's existing git author, committer, and signing configuration", "Do not add `Co-authored by:` trailers"} {
 		if !strings.Contains(prompt, text) {
 			t.Fatalf("prompt missing %q: %s", text, prompt)
@@ -152,7 +152,7 @@ func TestBuildIssuePromptIncludesReusedRemoteBranchContext(t *testing.T) {
 		BranchDiffSummary:  "README.md | 2 ++",
 		Provider:           "Codex",
 	}
-	prompt := BuildIssuePrompt(target, issue, session)
+	prompt := BuildIssuePromptForRuntime(RuntimeCodex, target, issue, session)
 	for _, text := range []string{
 		"Existing remote issue branch detected: origin/vigilante/issue-12-fix-bug",
 		"Base branch for comparison: main",
@@ -176,7 +176,7 @@ func TestBuildIssuePromptIncludesIssueBodyAndIterationContext(t *testing.T) {
 		IterationPromptContext: "Iteration context for this pass:\nPrimary focus comment:\n@vigilanteai tighten the validation path",
 	}
 
-	prompt := BuildIssuePrompt(target, issue, session)
+	prompt := BuildIssuePromptForRuntime(RuntimeCodex, target, issue, session)
 
 	for _, text := range []string{
 		"Full issue body:",
@@ -204,7 +204,7 @@ func TestBuildIssuePromptIncludesForkInstructions(t *testing.T) {
 		PushRepo:     "forker/repo",
 	}
 
-	prompt := BuildIssuePrompt(target, issue, session)
+	prompt := BuildIssuePromptForRuntime(RuntimeCodex, target, issue, session)
 	for _, text := range []string{
 		"Fork mode is enabled for this run.",
 		"Push the branch to remote `fork` (repo `forker/repo`) rather than `origin`.",
@@ -290,7 +290,7 @@ func TestBuildIssuePromptSelectsMonorepoSkill(t *testing.T) {
 	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
 	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
 
-	prompt := BuildIssuePrompt(target, issue, session)
+	prompt := BuildIssuePromptForRuntime(RuntimeCodex, target, issue, session)
 
 	for _, text := range []string{
 		"Use the `vigilante-issue-implementation-on-turborepo` skill",
@@ -323,7 +323,7 @@ func TestBuildIssuePromptFallsBackForUnknownMonorepoStack(t *testing.T) {
 	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
 	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
 
-	prompt := BuildIssuePrompt(target, issue, session)
+	prompt := BuildIssuePromptForRuntime(RuntimeCodex, target, issue, session)
 
 	for _, text := range []string{
 		"Use the `vigilante-issue-implementation-on-monorepo` skill",
@@ -352,7 +352,7 @@ func TestBuildIssuePromptSelectsTurborepoSkill(t *testing.T) {
 	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
 	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
 
-	prompt := BuildIssuePrompt(target, issue, session)
+	prompt := BuildIssuePromptForRuntime(RuntimeCodex, target, issue, session)
 
 	for _, text := range []string{
 		"Use the `vigilante-issue-implementation-on-turborepo` skill",
@@ -383,7 +383,7 @@ func TestBuildIssuePromptSelectsGradleMultiProjectSkill(t *testing.T) {
 	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
 	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
 
-	prompt := BuildIssuePrompt(target, issue, session)
+	prompt := BuildIssuePromptForRuntime(RuntimeCodex, target, issue, session)
 
 	for _, text := range []string{
 		"Use the `vigilante-issue-implementation-on-gradle-multi-project` skill",
@@ -414,7 +414,7 @@ func TestBuildIssuePromptSelectsNxSkill(t *testing.T) {
 	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
 	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
 
-	prompt := BuildIssuePrompt(target, issue, session)
+	prompt := BuildIssuePromptForRuntime(RuntimeCodex, target, issue, session)
 
 	for _, text := range []string{
 		"Use the `vigilante-issue-implementation-on-nx` skill",
@@ -448,7 +448,7 @@ func TestBuildIssuePromptSelectsRushMonorepoSkill(t *testing.T) {
 	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
 	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
 
-	prompt := BuildIssuePrompt(target, issue, session)
+	prompt := BuildIssuePromptForRuntime(RuntimeCodex, target, issue, session)
 
 	for _, text := range []string{
 		"Use the `vigilante-issue-implementation-on-rush-monorepo` skill",
@@ -481,7 +481,7 @@ func TestBuildIssuePromptSelectsBazelMonorepoSkill(t *testing.T) {
 	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
 	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
 
-	prompt := BuildIssuePrompt(target, issue, session)
+	prompt := BuildIssuePromptForRuntime(RuntimeCodex, target, issue, session)
 
 	for _, text := range []string{
 		"Use the `vigilante-issue-implementation-on-bazel-monorepo` skill",
@@ -536,7 +536,7 @@ func TestBuildConflictResolutionPrompt(t *testing.T) {
 	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
 	session := state.Session{IssueNumber: 12, IssueTitle: "Fix bug", IssueBody: "Preserve the original validation behavior.", IssueURL: "https://example.com/issues/12", BaseBranch: "main", WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", BranchDiffSummary: "Keep the error-state form inputs intact."}
 	pr := ghcli.PullRequest{Number: 88, URL: "https://example.com/pull/88", Title: "Fix bug", Body: "This PR keeps the original UX behavior.", Mergeable: "CONFLICTING", MergeStateStatus: "DIRTY"}
-	prompt := BuildConflictResolutionPrompt(target, session, pr)
+	prompt := BuildConflictResolutionPromptForRuntime(RuntimeCodex, target, session, pr)
 	for _, text := range []string{"Use the `vigilante-conflict-resolution` skill", "Issue specification: Preserve the original validation behavior.", "Pull Request title: Fix bug", "GitHub mergeability: mergeable=CONFLICTING mergeStateStatus=DIRTY", "Work through the rebase commit by commit.", "Use `vigilante commit` for all commit-producing operations", "Do not use `git commit` or GitHub CLI commit flows directly", "preserve the user's existing git author, committer, and signing configuration", "Do not add `Co-authored by:` trailers", "vigilante logs --repo <owner/name> --issue <n>", "go test ./...", "Existing branch summary: Keep the error-state form inputs intact."} {
 		if !strings.Contains(prompt, text) {
 			t.Fatalf("prompt missing %q: %s", text, prompt)
@@ -548,7 +548,7 @@ func TestBuildCIRemediationPrompt(t *testing.T) {
 	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
 	session := state.Session{IssueNumber: 12, IssueTitle: "Fix bug", IssueURL: "https://example.com/issues/12", WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12"}
 	pr := ghcli.PullRequest{Number: 88, URL: "https://example.com/pull/88"}
-	prompt := BuildCIRemediationPrompt(target, session, pr, []ghcli.StatusCheckRoll{{Context: "test", Conclusion: "FAILURE"}})
+	prompt := BuildCIRemediationPromptForRuntime(RuntimeCodex, target, session, pr, []ghcli.StatusCheckRoll{{Context: "test", Conclusion: "FAILURE"}})
 	for _, text := range []string{"Use the `vigilante-issue-implementation` skill", "Pull Request: #88", "CI remediation context", "Failing check: test", "Use `vigilante commit` for all commit-producing operations", "Do not use `git commit` or GitHub CLI commit flows directly", "preserve the user's existing git author, committer, and signing configuration", "Do not add `Co-authored by:` trailers", "do not open a new pull request", "exit with a non-zero status"} {
 		if !strings.Contains(prompt, text) {
 			t.Fatalf("prompt missing %q: %s", text, prompt)
@@ -1153,7 +1153,7 @@ func TestBuildIssuePromptIncludesSecurityGuidanceForNodeJSRepo(t *testing.T) {
 	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
 	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
 
-	prompt := BuildIssuePrompt(target, issue, session)
+	prompt := BuildIssuePromptForRuntime(RuntimeCodex, target, issue, session)
 
 	for _, text := range []string{
 		"JS/TS/Node security guidance",
@@ -1179,7 +1179,7 @@ func TestBuildIssuePromptExcludesSecurityGuidanceForNonNodeRepo(t *testing.T) {
 	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
 	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
 
-	prompt := BuildIssuePrompt(target, issue, session)
+	prompt := BuildIssuePromptForRuntime(RuntimeCodex, target, issue, session)
 
 	if strings.Contains(prompt, "JS/TS/Node security guidance") {
 		t.Fatalf("prompt should not include JS security guidance for non-Node repo")
@@ -1205,7 +1205,7 @@ func TestBuildIssuePromptIncludesSecurityGuidanceForMonorepoNodeJS(t *testing.T)
 	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
 	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-12", Provider: "Codex"}
 
-	prompt := BuildIssuePrompt(target, issue, session)
+	prompt := BuildIssuePromptForRuntime(RuntimeCodex, target, issue, session)
 
 	for _, text := range []string{
 		"JS/TS/Node security guidance",
@@ -1266,14 +1266,14 @@ func TestBuildIssueCreatePromptUsesInlineHeaderForClaudeAndGemini(t *testing.T) 
 	}
 }
 
-func TestBuildIssueCreatePromptDefaultUsesCodexRuntime(t *testing.T) {
+func TestBuildIssueCreatePromptForCodexReferencesSkillByName(t *testing.T) {
 	target := state.WatchTarget{
 		Repo: "owner/repo",
 		Path: "/tmp/repo",
 	}
-	result := BuildIssueCreatePromptDefault(target, "test prompt")
+	result := BuildIssueCreatePrompt(RuntimeCodex, target, "test prompt")
 	if !strings.Contains(result, "Use the `vigilante-create-issue` skill") {
-		t.Fatalf("expected default to use codex runtime")
+		t.Fatalf("expected the codex runtime to reference the skill by name")
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -477,6 +477,11 @@ func (s *Store) LoadWatchTargets() ([]WatchTarget, error) {
 		return nil, err
 	}
 	for i := range targets {
+		// Legacy migration shim, deliberately pinned to Codex: watch targets
+		// written before Vigilante persisted a provider were all running on
+		// Codex. Do not replace this with provider.DefaultID — that would
+		// silently migrate every pre-existing repository onto the current
+		// default provider on upgrade.
 		if strings.TrimSpace(targets[i].Provider) == "" {
 			targets[i].Provider = "codex"
 		}
@@ -498,6 +503,10 @@ func (s *Store) LoadSessions() ([]Session, error) {
 		return nil, err
 	}
 	for i := range sessions {
+		// Legacy migration shim, deliberately pinned to Codex; see the matching
+		// note in LoadWatchTargets. In-flight sessions recorded before the
+		// provider field existed must keep running on the agent that started
+		// them, so this must not become provider.DefaultID.
 		if strings.TrimSpace(sessions[i].Provider) == "" {
 			sessions[i].Provider = "codex"
 		}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -305,3 +305,80 @@ func TestServiceConfigPackageHardeningPersistence(t *testing.T) {
 		t.Error("expected package hardening to be disabled after save/load")
 	}
 }
+
+// TestLoadWatchTargetsBackfillsLegacyProviderAsCodex pins the legacy migration
+// shim. Watch targets written before Vigilante persisted a provider were all
+// running on Codex, so they must keep loading as Codex even though the default
+// provider for new targets is now Claude.
+func TestLoadWatchTargetsBackfillsLegacyProviderAsCodex(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	store := NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.watchlistPath(), []byte(`[{"path":"/tmp/repo","repo":"owner/repo"}]`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	targets, err := store.LoadWatchTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("unexpected targets: %#v", targets)
+	}
+	if targets[0].Provider != "codex" {
+		t.Fatalf("legacy watch target must stay on codex, got %q", targets[0].Provider)
+	}
+}
+
+// TestLoadWatchTargetsPreservesExplicitProvider makes sure the legacy backfill
+// only fills empty values.
+func TestLoadWatchTargetsPreservesExplicitProvider(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	store := NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.watchlistPath(), []byte(`[{"path":"/tmp/repo","repo":"owner/repo","provider":"claude"}]`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	targets, err := store.LoadWatchTargets()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(targets) != 1 || targets[0].Provider != "claude" {
+		t.Fatalf("unexpected targets: %#v", targets)
+	}
+}
+
+// TestLoadSessionsBackfillsLegacyProviderAsCodex keeps in-flight sessions on
+// the agent that started them. See the LoadWatchTargets counterpart.
+func TestLoadSessionsBackfillsLegacyProviderAsCodex(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	store := NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(store.sessionsPath(), []byte(`[{"repo":"owner/repo","issue_number":7}]`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := store.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("unexpected sessions: %#v", sessions)
+	}
+	if sessions[0].Provider != "codex" {
+		t.Fatalf("legacy session must stay on codex, got %q", sessions[0].Provider)
+	}
+}


### PR DESCRIPTION
## Summary

Makes **Claude Code** the coding agent Vigilante selects when no `--provider` flag, provider label, or persisted watch-target provider says otherwise. Codex remains fully supported and selectable.

`DefaultID` could not simply be reassigned because it doubled as *Codex's own identity* — flipping it would have produced a duplicate map key in the registry, made `codexProvider.ID()` report `"claude"`, and applied Codex's CLI version contract to Claude. So the constant is decoupled first.

## Changes

**`internal/provider`**
- Added `const CodexID = "codex"`; `DefaultID` is now `const DefaultID = ClaudeID` with a doc comment stating it means only "the provider used when none is specified".
- Repointed the Codex-identity usages: the `registry` map key, `codexProvider.ID()`, and the `compatibilityContracts` key. The `0.114.0 <= v < 2.0.0` range stays bound to Codex.

**`internal/app`**
- `buildResumeFailureSummaryInvocation` gave Codex its own `case provider.CodexID:` arm; Claude is now the `case provider.ClaudeID: fallthrough default:` arm, so the default path builds a `claude` invocation rather than `codex exec`.
- Every other `provider.DefaultID` site (the `--provider` flag default, `Setup`, watch-target creation, dispatch fallback) genuinely means "unspecified" and was left alone — they now resolve to Claude.

**`internal/skill`**
- Removed the four convenience wrappers that hardcoded `RuntimeCodex` (`BuildIssuePrompt`, `BuildConflictResolutionPrompt`, `BuildCIRemediationPrompt`, `BuildIssueCreatePromptDefault`). Their only production caller was `codex.go`, which now passes `skill.RuntimeCodex` explicitly to the runtime-aware variants. The runtime-aware variants and `runtimeUsesInlineSkillHeader` are unchanged.

**`internal/state`**
- The hardcoded `"codex"` backfill in `LoadWatchTargets` and `LoadSessions` is untouched, and now carries a comment explaining it is a deliberate legacy migration shim so a future reader does not "fix" it into `provider.DefaultID`. **Already-watched repositories and in-flight sessions keep running on Codex.**

**Docs** — `DOCS.md` now says `--provider` defaults to `claude` (for both `watch` and `setup`), and the README/DOCS quick-start examples drop `--provider codex`.

## Tests

New regression coverage:
- `provider`: `Resolve("")` returns Claude; `DefaultID != CodexID`; every provider's `ID()` matches its registry key; each compatibility contract stays bound to its own provider.
- `state`: legacy watch targets and sessions with an empty provider still load as `"codex"`, and an explicit provider is preserved.
- `app`: `Watch` with no provider persists `"claude"`; `--provider codex` still persists `"codex"`; the invocation builder returns the right binary per provider including the default; `ResolveIssueProvider` still lets a `codex` label override the default and still errors on conflicting labels.

Existing tests that exercised the Codex path through the implicit default were made explicit (`Provider: "codex"`, `provider.CodexID`) rather than reinterpreted — no assertion semantics changed. The setup test that used the default path was flipped to Claude fixtures, which is what now covers "`vigilante setup` with no `--provider` requires the `claude` CLI".

## Validation

- `gofmt -l .` — clean
- `go vet ./...` — clean
- `go test ./...` — pass; `-race -count=1` also pass on the touched packages
- `govulncheck ./...` — reports 3 pre-existing vulnerabilities in the OpenTelemetry exporter dependencies, unrelated to this change (no dependency changes here)

## Note for release notes

Someone who upgrades and re-runs `vigilante setup` without `--provider` will now be asked for the `claude` CLI instead of `codex`. No state migration and no config-format change — `watchlist.json` and `sessions.json` schemas are untouched.

Closes #481