### PR TITLE
Cap automatic worktree cleanup retries

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -387,6 +387,14 @@ Expected behavior:
 - `--repo <owner/name>` cleans up all running sessions for one repository
 - removes the running-session blockage from local state
 - removes the local worktree and issue branch when those artifacts are present and safe to delete
+- retries cleanup even when automatic closed-issue cleanup already reached its three-attempt cap
+
+When an issue is closed, the daemon automatically attempts to remove its local
+worktree and branch up to three times. If all three attempts fail, Vigilante
+comments with the concrete git error and recovery commands, applies the
+`vigilante:needs-git-fix` label, and stops monitoring the terminal session while
+preserving the cleanup error. After repairing the repository state by hand, run
+`vigilante cleanup --repo <owner/name> --issue <n>` to force an uncapped retry.
 
 ### `vigilante cleanup --all`
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -53,6 +53,7 @@ const defaultMaintenanceAutoRecoveryTimeout = 10 * time.Minute
 const defaultSuccessfulSessionPollInterval = 5 * time.Minute
 const issueDetailsCacheTTL = 3 * time.Minute
 const staleAutoRestartAttemptLimit = 3
+const maxAutomaticCleanupAttempts = 3
 const githubCoreLowQuotaThreshold = 5
 const unsetMaxParallel = -2147483648
 const autoRecoverySource = "auto_recovery"
@@ -2263,7 +2264,9 @@ func (a *App) ScanOnce(ctx context.Context) error {
 				if strings.TrimSpace(wt.ReusedRemoteBranch) != "" {
 					diffSummary, err = summarizeIssueBranchDiff(issueCtx, a.env.Runner, target.Path, target.Branch, wt.Branch)
 					if err != nil {
-						_ = worktree.CleanupIssueArtifacts(issueCtx, a.env.Runner, target.Path, wt.Path, wt.Branch)
+						if cleanupErr := worktree.CleanupIssueArtifacts(issueCtx, a.env.Runner, target.Path, wt.Path, wt.Branch); cleanupErr != nil {
+							a.logger.Error("reused remote issue branch cleanup failed", "repo", target.Repo, "issue", next.Number, "branch", wt.Branch, "worktree", wt.Path, "err", cleanupErr)
+						}
 						session := blockedIssueSessionForDispatchFailure(*target, next, selectedProvider, fmt.Errorf("analyze reused remote issue branch %q against %q: %w", wt.Branch, target.Branch, err), a.clock())
 						session.Branch = wt.Branch
 						session.BaseBranch = target.Branch
@@ -2700,9 +2703,21 @@ func (a *App) cleanupClosedIssueSessions(ctx context.Context, sessions []state.S
 		if !strings.EqualFold(strings.TrimSpace(issue.State), "closed") {
 			continue
 		}
+		if session.CleanupAttempts >= maxAutomaticCleanupAttempts {
+			if err := a.stopAutomaticCleanupAfterLimit(sessionCtx, session); err != nil {
+				a.logger.Error("cleanup retry limit notification failed", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "worktree", session.WorktreePath, "err", err)
+			}
+			continue
+		}
 
 		if err := a.cleanupSessionArtifacts(sessionCtx, session, "issue_closed"); err != nil {
+			session.CleanupAttempts++
 			a.logger.Error("cleanup failed", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "worktree", session.WorktreePath, "err", err)
+			if session.CleanupAttempts >= maxAutomaticCleanupAttempts {
+				if notifyErr := a.stopAutomaticCleanupAfterLimit(sessionCtx, session); notifyErr != nil {
+					a.logger.Error("cleanup retry limit notification failed", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "worktree", session.WorktreePath, "err", notifyErr)
+				}
+			}
 			continue
 		}
 
@@ -2726,9 +2741,55 @@ func (a *App) cleanupSessionArtifacts(ctx context.Context, session *state.Sessio
 	}
 
 	session.CleanupCompletedAt = now
+	session.CleanupAttempts = 0
 	session.CleanupError = ""
+	if session.BlockedStage == "automatic_worktree_cleanup" {
+		session.BlockedStage = ""
+		session.BlockedReason = state.BlockedReason{}
+	}
 	session.LastMaintenanceError = ""
 	session.UpdatedAt = now
+	return nil
+}
+
+func (a *App) stopAutomaticCleanupAfterLimit(ctx context.Context, session *state.Session) error {
+	cleanupErr := session.CleanupError
+	session.BlockedStage = "automatic_worktree_cleanup"
+	session.BlockedReason = state.BlockedReason{
+		Kind:      "dirty_worktree",
+		Operation: "git worktree remove",
+		Summary:   fmt.Sprintf("automatic worktree cleanup failed after %d attempts", session.CleanupAttempts),
+		Detail:    cleanupErr,
+	}
+	body := ghcli.FormatProgressComment(ghcli.ProgressComment{
+		Stage:      "Manual Git Repair Required",
+		Emoji:      "🛠️",
+		Percent:    100,
+		ETAMinutes: 5,
+		Items: []string{
+			fmt.Sprintf("Automatic cleanup for issue #%d on branch `%s` failed after %d attempts. Worktree: `%s`.", session.IssueNumber, session.Branch, session.CleanupAttempts, session.WorktreePath),
+			fmt.Sprintf("Git error:\n```text\n%s\n```", cleanupErr),
+			fmt.Sprintf("Repair the repository manually, then retry with `vigilante cleanup --repo %s --issue %d`:\n```bash\ncd %q\ngit worktree remove --force %q # or: rm -rf %q\ngit worktree prune\ngit branch -D %q\n```", session.Repo, session.IssueNumber, session.RepoPath, session.WorktreePath, session.WorktreePath, session.Branch),
+		},
+		Tagline: "Automatic retries stopped; the evidence remains.",
+	})
+	if err := a.commentBlockedIssue(ctx, session, body, "automatic_cleanup_limit"); err != nil {
+		return err
+	}
+
+	now := a.clock().Format(time.RFC3339)
+	previousStatus := session.Status
+	session.Status = state.SessionStatusClosed
+	session.MonitoringStoppedAt = now
+	session.ProcessID = 0
+	session.LastHeartbeatAt = ""
+	session.EndedAt = now
+	session.UpdatedAt = now
+	session.LastMaintenanceError = ""
+	session.LastError = session.BlockedReason.Summary
+	a.emitSessionTransition(previousStatus, *session, "automatic_cleanup_limit")
+	a.logger.Error("automatic cleanup retry limit reached", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "worktree", session.WorktreePath, "attempts", session.CleanupAttempts, "err", cleanupErr)
+	a.syncSessionIssueLabelsBestEffort(ctx, session, nil, nil, nil)
 	return nil
 }
 
@@ -3806,11 +3867,19 @@ func (a *App) CleanupSession(ctx context.Context, repo string, issue int, source
 	found := false
 	var cleanedSession *state.Session
 	for i := range sessions {
-		if sessions[i].Status != state.SessionStatusRunning || sessions[i].Repo != repo || sessions[i].IssueNumber != issue {
+		if sessions[i].Repo != repo || sessions[i].IssueNumber != issue {
 			continue
 		}
-		if err := a.cleanupRunningSession(ctx, &sessions[i], source); err != nil {
-			return err
+		if sessions[i].Status == state.SessionStatusRunning {
+			if err := a.cleanupRunningSession(ctx, &sessions[i], source); err != nil {
+				return err
+			}
+		} else if sessions[i].CleanupAttempts >= maxAutomaticCleanupAttempts {
+			if err := a.cleanupSessionArtifacts(ctx, &sessions[i], source); err != nil {
+				a.logger.Error("manual cleanup retry failed", "repo", sessions[i].Repo, "issue", sessions[i].IssueNumber, "source", source, "branch", sessions[i].Branch, "worktree", sessions[i].WorktreePath, "err", err)
+			}
+		} else {
+			continue
 		}
 		found = true
 		cleanedSession = &sessions[i]
@@ -5842,7 +5911,7 @@ func desiredSessionLabels(session state.Session, pr *ghcli.PullRequest) (string,
 	case state.SessionStatusBlocked:
 		return labelBlocked, blockedInterventionLabel(session.BlockedReason)
 	case state.SessionStatusClosed:
-		return labelDone, ""
+		return labelDone, blockedInterventionLabel(session.BlockedReason)
 	case state.SessionStatusSuccess:
 		if pr != nil && pr.MergedAt != nil {
 			return labelDone, ""

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -37,9 +37,32 @@ type capturedAnalyticsEvent struct {
 }
 
 type countingRunner struct {
-	base   testutil.FakeRunner
-	mu     sync.Mutex
-	counts map[string]int
+	base              testutil.FakeRunner
+	mu                sync.Mutex
+	counts            map[string]int
+	allowUnexpectedGH bool
+}
+
+type cleanupSequenceRunner struct {
+	base              testutil.FakeRunner
+	removeCommand     string
+	remainingFailures int
+	removeAttempts    int
+}
+
+func (r *cleanupSequenceRunner) Run(ctx context.Context, dir string, name string, args ...string) (string, error) {
+	if key := testutil.Key(name, args...); key == r.removeCommand {
+		r.removeAttempts++
+		if r.remainingFailures > 0 {
+			r.remainingFailures--
+			return "", errors.New("corrupt worktree gitdir")
+		}
+	}
+	return r.base.Run(ctx, dir, name, args...)
+}
+
+func (r *cleanupSequenceRunner) LookPath(file string) (string, error) {
+	return r.base.LookPath(file)
 }
 
 type blockingMaintenanceRunner struct {
@@ -57,7 +80,11 @@ func (r *countingRunner) Run(ctx context.Context, dir string, name string, args 
 	}
 	r.counts[testutil.Key(name, args...)]++
 	r.mu.Unlock()
-	return r.base.Run(ctx, dir, name, args...)
+	output, err := r.base.Run(ctx, dir, name, args...)
+	if err != nil && r.allowUnexpectedGH && name == "gh" {
+		return "ok", nil
+	}
+	return output, err
 }
 
 func (r *countingRunner) LookPath(file string) (string, error) {
@@ -7301,6 +7328,144 @@ func TestScanOnceCleansUpClosedIssueSession(t *testing.T) {
 	}
 	if sessions[0].Status != state.SessionStatusClosed {
 		t.Fatalf("expected session status to transition to closed after issue closure cleanup, got %q", sessions[0].Status)
+	}
+}
+
+func TestCleanupClosedIssueSessionsStopsAfterAutomaticCleanupLimit(t *testing.T) {
+	repoPath := t.TempDir()
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &countingRunner{allowUnexpectedGH: true, base: testutil.FakeRunner{
+		Outputs: map[string]string{
+			"git worktree prune":                          "ok",
+			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:iterating"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"vigilante:flagged-security-review"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
+			"gh api repos/owner/repo/issues/1":            `{"labels":[]}`,
+		},
+		Errors: map[string]error{
+			"git worktree remove --force " + worktreePath: errors.New("corrupt worktree gitdir"),
+		},
+	}}
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = runner
+	sessions := []state.Session{{
+		RepoPath: repoPath, Repo: "owner/repo", IssueNumber: 1, Branch: "vigilante/issue-1",
+		WorktreePath: worktreePath, Status: state.SessionStatusSuccess,
+	}}
+	issue := &ghcli.IssueDetails{State: "closed"}
+	cache := scanIssueDetailsCache{sessionKey("owner/repo", 1): {details: issue}}
+
+	for range maxAutomaticCleanupAttempts + 1 {
+		var err error
+		sessions, err = app.cleanupClosedIssueSessions(context.Background(), sessions, cache)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	session := sessions[0]
+	if got := runner.counts["git worktree remove --force "+worktreePath]; got != maxAutomaticCleanupAttempts {
+		t.Fatalf("cleanup attempts = %d, want %d", got, maxAutomaticCleanupAttempts)
+	}
+	if session.CleanupAttempts != maxAutomaticCleanupAttempts || session.Status != state.SessionStatusClosed || session.MonitoringStoppedAt == "" {
+		t.Fatalf("expected terminal capped session, got %#v", session)
+	}
+	if session.CleanupError != "corrupt worktree gitdir" {
+		t.Fatalf("CleanupError = %q, want verbatim git error", session.CleanupError)
+	}
+	commentCount := 0
+	gitFixLabelCount := 0
+	for command, count := range runner.counts {
+		if strings.HasPrefix(command, "gh issue comment --repo owner/repo 1 --body ") {
+			commentCount += count
+			if !strings.Contains(command, worktreePath) || !strings.Contains(command, "corrupt worktree gitdir") || !strings.Contains(command, "git worktree prune") {
+				t.Fatalf("cleanup comment is missing actionable details: %s", command)
+			}
+		}
+		if strings.Contains(command, "gh issue edit --repo owner/repo 1") && strings.Contains(command, "--add-label vigilante:needs-git-fix") {
+			gitFixLabelCount += count
+		}
+	}
+	if commentCount != 1 {
+		t.Fatalf("cleanup comments = %d, want 1", commentCount)
+	}
+	if gitFixLabelCount != 1 {
+		t.Fatalf("needs-git-fix applications = %d, want 1; commands=%#v", gitFixLabelCount, runner.counts)
+	}
+}
+
+func TestCleanupClosedIssueSessionsResetsAttemptsAfterTransientFailure(t *testing.T) {
+	repoPath := t.TempDir()
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runner := &cleanupSequenceRunner{
+		base: testutil.FakeRunner{Outputs: map[string]string{
+			"git worktree prune":                                         "ok",
+			"git worktree remove --force " + worktreePath:                "ok",
+			"git worktree list --porcelain":                              "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
+			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": "ok",
+			"git branch -D vigilante/issue-1":                            "ok",
+		}},
+		removeCommand:     "git worktree remove --force " + worktreePath,
+		remainingFailures: 2,
+	}
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = runner
+	sessions := []state.Session{{RepoPath: repoPath, Repo: "owner/repo", IssueNumber: 1, Branch: "vigilante/issue-1", WorktreePath: worktreePath, Status: state.SessionStatusSuccess}}
+	cache := scanIssueDetailsCache{sessionKey("owner/repo", 1): {details: &ghcli.IssueDetails{State: "closed"}}}
+
+	for range 3 {
+		var err error
+		sessions, err = app.cleanupClosedIssueSessions(context.Background(), sessions, cache)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if runner.removeAttempts != 3 || sessions[0].CleanupAttempts != 0 || sessions[0].CleanupError != "" || sessions[0].Status != state.SessionStatusClosed {
+		t.Fatalf("expected transient cleanup recovery, attempts=%d session=%#v", runner.removeAttempts, sessions[0])
+	}
+}
+
+func TestCleanupSessionRetriesCappedAutomaticCleanup(t *testing.T) {
+	repoPath := t.TempDir()
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-44")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("VIGILANTE_HOME", filepath.Join(t.TempDir(), ".vigilante"))
+	app := New()
+	app.stdout = testutil.IODiscard{}
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{Outputs: map[string]string{
+		"git worktree prune":                                          "ok",
+		"git worktree remove --force " + worktreePath:                 "ok",
+		"git worktree list --porcelain":                               "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
+		"git show-ref --verify --quiet refs/heads/vigilante/issue-44": "ok",
+		"git branch -D vigilante/issue-44":                            "ok",
+	}}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{RepoPath: repoPath, Repo: "owner/repo", IssueNumber: 44, Branch: "vigilante/issue-44", WorktreePath: worktreePath, Status: state.SessionStatusClosed, BlockedStage: "automatic_worktree_cleanup", BlockedReason: state.BlockedReason{Kind: "dirty_worktree"}, CleanupAttempts: maxAutomaticCleanupAttempts, CleanupError: "corrupt worktree gitdir"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.CleanupSession(context.Background(), "owner/repo", 44, "cli"); err != nil {
+		t.Fatal(err)
+	}
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessions[0].CleanupAttempts != 0 || sessions[0].CleanupError != "" || sessions[0].CleanupCompletedAt == "" || sessions[0].BlockedStage != "" || sessions[0].BlockedReason != (state.BlockedReason{}) {
+		t.Fatalf("expected manual cleanup to clear capped failure, got %#v", sessions[0])
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -288,6 +288,7 @@ type Session struct {
 	RecoveredAt                    string              `json:"recovered_at,omitempty"`
 	MonitoringStoppedAt            string              `json:"monitoring_stopped_at,omitempty"`
 	CleanupCompletedAt             string              `json:"cleanup_completed_at,omitempty"`
+	CleanupAttempts                int                 `json:"cleanup_attempts,omitempty"`
 	CleanupError                   string              `json:"cleanup_error,omitempty"`
 	ProcessID                      int                 `json:"process_id,omitempty"`
 	StartedAt                      string              `json:"started_at,omitempty"`

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,12 +1,23 @@
 package state
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestSessionJSONWithoutCleanupAttemptsDefaultsToZero(t *testing.T) {
+	var session Session
+	if err := json.Unmarshal([]byte(`{"repo_path":"/tmp/repo","repo":"owner/repo","issue_number":1}`), &session); err != nil {
+		t.Fatal(err)
+	}
+	if session.CleanupAttempts != 0 {
+		t.Fatalf("CleanupAttempts = %d, want 0", session.CleanupAttempts)
+	}
+}
 
 func TestTryWithScanLockIsExclusive(t *testing.T) {
 	home := t.TempDir()


### PR DESCRIPTION
## Summary

- Cap automatic closed-issue worktree cleanup at three failed attempts across scans.
- Post one actionable repair comment, retain the concrete cleanup error, apply the git-fix label, and stop monitoring in the closed terminal state.
- Keep human-triggered cleanup uncapped, reset cleanup state after success, log the previously discarded cleanup failure, and document recovery.

The closed terminal status keeps completed sessions out of pending status output, while `CleanupError` and the intervention label preserve visibility that local artifacts remain.

## Validation

```sh
gofmt -l .
go vet ./...
go test ./... -count=1
go test -race ./internal/app ./internal/state -count=1
```

Closes #486