### PR TITLE
docs: fix the Homebrew install command

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -52,7 +52,7 @@ Watch targets carry explicit backend identity fields (`issue_backend`, `git_back
 Install with Homebrew:
 
 ```sh
-brew install vigilante
+brew install --cask aliengiraffe/spaceship/vigilante
 ```
 
 Prepare the local machine. `--provider` defaults to `claude`, so pass the flag only when you want a different coding agent:
@@ -231,13 +231,13 @@ vigilante clone --depth 1 https://github.com/owner/hello-world-app.git ~/src/hel
 Install `vigilante` with Homebrew:
 
 ```sh
-brew install vigilante
+brew install --cask aliengiraffe/spaceship/vigilante
 ```
 
 Upgrade later with:
 
 ```sh
-brew upgrade vigilante
+brew upgrade --cask vigilante
 ```
 
 ### `vigilante watch [--assignee <value>] [--max-parallel <value>] [--provider <codex|claude|gemini|opencode>] [--issue-tracker <github|linear>] [--issue-tracker-stage <value>] [--branch <name> | --track-default-branch] <path>`
@@ -546,7 +546,7 @@ Tagged releases are built and published with GoReleaser. Pushing a version tag t
 - `darwin/arm64`
 - `linux/amd64`
 - a `checksums.txt` file for the published archives
-- an updated Homebrew formula in `homebrew/core` so `brew install vigilante` installs the tagged release
+- an updated Homebrew cask in the `aliengiraffe/homebrew-spaceship` tap so `brew install --cask aliengiraffe/spaceship/vigilante` installs the tagged release
 
 The release workflow requires a GitHub App that can write to the tap repository:
 
@@ -561,13 +561,13 @@ Nightly install path:
 
 ```sh
 brew tap aliengiraffe/spaceship
-brew install vigilante-nightly
+brew install --cask vigilante-nightly
 ```
 
 Stable installs remain on the tagged release path:
 
 ```sh
-brew install vigilante
+brew install --cask aliengiraffe/spaceship/vigilante
 ```
 
 Recommended release flow:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ See [SANDBOX.md](SANDBOX.md) for the design and current status.
 Install with Homebrew:
 
 ```sh
-brew install vigilante
+brew install --cask aliengiraffe/spaceship/vigilante
 ```
 
 Requirements:
@@ -93,7 +93,7 @@ vigilante watch ~/path/to/repo
 Typical first-run flow:
 
 ```sh
-brew install vigilante
+brew install --cask aliengiraffe/spaceship/vigilante
 vigilante setup -d
 vigilante watch ~/hello-world-app
 vigilante daemon run --once


### PR DESCRIPTION
`brew install vigilante` fails with `Warning: No available formula with the name "vigilante".` — which is the **first instruction in the README**, so it breaks for every new user.

Vigilante ships as a Homebrew **cask** in the `aliengiraffe/spaceship` tap, not as a formula in `homebrew/core`. `brew install` looks for a formula and finds nothing.

## Fix

Use the fully-qualified cask name. It auto-taps, so it works with no prior setup:

```sh
brew install --cask aliengiraffe/spaceship/vigilante
```

## Scope

The same broken command appeared **7 times**, not once:

| File | Was | Now |
|---|---|---|
| `README.md` ×2 | `brew install vigilante` | `brew install --cask aliengiraffe/spaceship/vigilante` |
| `DOCS.md` ×3 | `brew install vigilante` | same |
| `DOCS.md` nightly | `brew install vigilante-nightly` | `brew install --cask vigilante-nightly` |
| `DOCS.md` upgrade | `brew upgrade vigilante` | `brew upgrade --cask vigilante` |

Plus one prose claim in `DOCS.md`:

> ~~an updated Homebrew formula in `homebrew/core` so `brew install vigilante` installs the tagged release~~

That contradicted the very next paragraph, which correctly describes a token scoped to `aliengiraffe/homebrew-spaceship`. `.goreleaser.yml` uses `homebrew_casks` against that tap, so the tap wording is the accurate one.

## Notes

- `brew upgrade vigilante` was **not** actually broken — brew falls back to cask lookup, and the error is `Cask 'vigilante' is not installed`. Spelled with `--cask` anyway for consistency, and so it stays unambiguous if a `vigilante` formula ever lands in core.
- `brew install go-task/tap/go-task` in `DOCS.md` is a genuine formula in a tap and is left alone.

## Validation

```
$ brew info --cask aliengiraffe/spaceship/vigilante
==> vigilante (vigilante): 1.1.0
From: https://github.com/aliengiraffe/homebrew-spaceship/blob/HEAD/Casks/vigilante.rb
```

Docs-only change; no code paths touched.