### PR TITLE
fix(status): show last scan in local timezone

### DIFF
--- a/internal/app/status.go
+++ b/internal/app/status.go
@@ -325,7 +325,7 @@ func formatLastScan(raw string) string {
 	if err != nil {
 		return "last scan unknown"
 	}
-	return fmt.Sprintf("last scan %s", t.UTC().Format("2006-01-02 15:04 UTC"))
+	return fmt.Sprintf("last scan %s", t.In(time.Local).Format("2006-01-02 15:04 MST"))
 }
 
 func valueOrUnknown(value string) string {

--- a/internal/app/status_test.go
+++ b/internal/app/status_test.go
@@ -492,6 +492,10 @@ func TestWriteSessionGroupsCompletedFailedShowsTotalsOnly(t *testing.T) {
 }
 
 func TestStatusCommandShowsWatchedRepositories(t *testing.T) {
+	originalLocal := time.Local
+	time.Local = time.FixedZone("TEST", -8*60*60)
+	t.Cleanup(func() { time.Local = originalLocal })
+
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
@@ -560,14 +564,39 @@ func TestStatusCommandShowsWatchedRepositories(t *testing.T) {
 	output := stdout.String()
 	for _, want := range []string{
 		"Watched repositories (2)",
-		"owner/alpha (branch main (pinned), provider codex, assignee me, max 2, 1 active, 1 blocked, last scan 2026-03-19 11:55 UTC)",
+		"owner/alpha (branch main (pinned), provider codex, assignee me, max 2, 1 active, 1 blocked, last scan 2026-03-19 03:55 TEST)",
 		"path: /repos/alpha",
-		"owner/beta (branch develop (pinned), provider claude, labels to-do,bug, idle, last scan 2026-03-19 11:40 UTC)",
+		"owner/beta (branch develop (pinned), provider claude, labels to-do,bug, idle, last scan 2026-03-19 03:40 TEST)",
 		"path: /repos/beta",
 	} {
 		if !strings.Contains(output, want) {
 			t.Errorf("expected output to contain %q, got:\n%s", want, output)
 		}
+	}
+}
+
+func TestFormatLastScan(t *testing.T) {
+	originalLocal := time.Local
+	t.Cleanup(func() { time.Local = originalLocal })
+
+	tests := []struct {
+		name  string
+		local *time.Location
+		raw   string
+		want  string
+	}{
+		{name: "local timezone", local: time.FixedZone("PDT", -7*60*60), raw: "2026-08-07T19:25:00Z", want: "last scan 2026-08-07 12:25 PDT"},
+		{name: "UTC timezone", local: time.UTC, raw: "2026-08-07T19:25:00Z", want: "last scan 2026-08-07 19:25 UTC"},
+		{name: "empty", local: time.UTC, raw: "", want: "last scan never"},
+		{name: "malformed", local: time.UTC, raw: "not-a-time", want: "last scan unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			time.Local = tt.local
+			if got := formatLastScan(tt.raw); got != tt.want {
+				t.Fatalf("formatLastScan(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/app/status_tui_test.go
+++ b/internal/app/status_tui_test.go
@@ -288,8 +288,14 @@ func TestStatusModelQuitKeys(t *testing.T) {
 }
 
 func TestStatusModelRendersLoadedData(t *testing.T) {
-	view := loadedStatusModel().View()
-	for _, want := range []string{"Service", "running", "owner/repo", "Actively working", "Issue #42", "GitHub rate limits", "4000/5000"} {
+	originalLocal := time.Local
+	time.Local = time.FixedZone("PDT", -7*60*60)
+	t.Cleanup(func() { time.Local = originalLocal })
+
+	model := loadedStatusModel()
+	model.sessions.Repos[0].Target.LastScanAt = "2026-08-07T19:25:00Z"
+	view := model.View()
+	for _, want := range []string{"Service", "running", "owner/repo", "last scan 2026-08-07 12:25 PDT", "Actively working", "Issue #42", "GitHub rate limits", "4000/5000"} {
 		if !strings.Contains(view, want) {
 			t.Errorf("expected view to contain %q, got:\n%s", want, view)
 		}


### PR DESCRIPTION
## Summary

- render status last-scan timestamps in the user's local timezone
- retain an explicit timezone indicator in plain and dashboard output
- add deterministic local, UTC, fallback, and render-path coverage

## Validation

- `gofmt -l .`
- `go vet ./...`
- `go test -count=1 ./...`
- `go test -race -count=1 ./internal/app/...`

Closes #489