### PR TITLE
Support Claude model selection labels

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -154,6 +154,30 @@
       ]
     },
     {
+      "name": "claude:sonnet",
+      "color": "D4A574",
+      "group": "provider-routing",
+      "behavior": "control",
+      "applied_by": "human",
+      "description": "Routes the issue to Claude using the latest Sonnet model alias."
+    },
+    {
+      "name": "claude:opus",
+      "color": "A56CC1",
+      "group": "provider-routing",
+      "behavior": "control",
+      "applied_by": "human",
+      "description": "Routes the issue to Claude using the latest Opus model alias."
+    },
+    {
+      "name": "claude:fable",
+      "color": "E8B4B8",
+      "group": "provider-routing",
+      "behavior": "control",
+      "applied_by": "human",
+      "description": "Routes the issue to Claude using the Fable model alias."
+    },
+    {
       "name": "gemini",
       "color": "006B75",
       "group": "provider-routing",

--- a/DOCS.md
+++ b/DOCS.md
@@ -727,7 +727,9 @@ Initial rules:
 - count both running implementation sessions and open-PR maintenance sessions against that repository limit
 - avoid duplicate work across multiple daemon scans
 - allow an issue label that exactly matches a registered provider id, such as `codex`, `claude`, `gemini`, or `opencode`, to override the watch target provider for that issue only
-- if more than one provider-id label is present on the same issue, skip dispatch instead of choosing a provider arbitrarily
+- allow `claude:sonnet`, `claude:opus`, or `claude:fable` to route to Claude and select that model alias for the persisted session
+- allow bare `claude` together with one Claude model label; reject multiple Claude model labels or a Claude model label combined with another provider label
+- ignore unrecognized names such as `claude:haiku`, like any unrelated label
 - prefer oldest eligible open issue first unless later prioritization rules are added
 
 Future policy can expand to richer label filters, assignment rules, and priority queues.
@@ -822,14 +824,14 @@ Label ownership rules:
 
 - Work-classification labels such as `bug`, `feature`, and `good first issue` remain repository-managed and should not be changed by Vigilante.
 - `vigilante:*` lifecycle and intervention labels are primarily informational and should be set or cleared by Vigilante as the issue moves through execution.
-- Provider-routing labels `codex`, `claude`, `gemini`, and `opencode` keep their existing control semantics and remain human-managed overrides.
+- Provider-routing labels `codex`, `claude`, `gemini`, and `opencode` keep their existing control semantics and remain human-managed overrides. Human-managed `claude:sonnet`, `claude:opus`, and `claude:fable` labels additionally select a Claude model for the whole persisted session.
 - `vigilante:resume` is the preferred control label for unblocking a paused session; `resume` remains a legacy-compatible alias.
 
 Proposed groups:
 
 - Execution state: `vigilante:queued`, `vigilante:running`, `vigilante:blocked`, `vigilante:ready-for-review`, `vigilante:awaiting-user-validation`, `vigilante:done`
 - Human-intervention state: `vigilante:needs-human-input`, `vigilante:needs-provider-fix`, `vigilante:needs-git-fix`
-- Provider routing controls: `codex`, `claude`, `gemini`, `opencode`
+- Provider routing controls: `codex`, `claude`, `gemini`, `opencode`, `claude:sonnet`, `claude:opus`, `claude:fable`
 - Explicit control labels: `vigilante:resume` and legacy `resume`
 
 Recommended lifecycle:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ Bootstrap the local machine and install the managed service. `--provider` defaul
 vigilante setup -d
 ```
 
+For per-issue Claude model selection, add one of the human-managed labels
+`claude:sonnet`, `claude:opus`, or `claude:fable`. For example, labeling an
+issue `claude:opus` routes it to Claude and launches that session with
+`--model opus`; resumes keep the model captured when the session started.
+
 ## Quick Start
 
 Register a repository and let Vigilante manage the issue-to-PR loop:

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1279,7 +1279,7 @@ func (a *App) StartOneOffSession(ctx context.Context, rawPath string, issueNumbe
 		Labels: labelsToBackendLabels(issueLabels),
 	}
 
-	selectedProvider, err := resolveIssueProvider(target, ghIssue)
+	selectedProvider, selectedModel, err := resolveIssueProvider(target, ghIssue)
 	if err != nil {
 		return err
 	}
@@ -1320,6 +1320,7 @@ func (a *App) StartOneOffSession(ctx context.Context, rawPath string, issueNumbe
 		RepoPath:           target.Path,
 		Repo:               target.Repo,
 		Provider:           selectedProvider,
+		Model:              selectedModel,
 		IssueBackend:       target.EffectiveIssueBackend(),
 		GitBackend:         target.EffectiveGitBackend(),
 		PRBackend:          target.EffectivePRBackend(),
@@ -2236,7 +2237,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 			for _, next := range nextIssues {
 				a.logger.Info("scan repo selected issue", "repo", target.Repo, "issue", next.Number, "title", next.Title)
 
-				selectedProvider, providerErr := resolveIssueProvider(*target, next)
+				selectedProvider, selectedModel, providerErr := resolveIssueProvider(*target, next)
 				if providerErr != nil {
 					a.logger.Info("scan repo issue provider conflict", "repo", target.Repo, "issue", next.Number, "err", providerErr)
 					fmt.Fprintf(a.stdout, "repo: %s skipped issue #%d: %s\n", target.Repo, next.Number, summarizeText(providerErr.Error()))
@@ -2325,6 +2326,7 @@ func (a *App) ScanOnce(ctx context.Context) error {
 					RepoPath:           target.Path,
 					Repo:               target.Repo,
 					Provider:           selectedProvider,
+					Model:              selectedModel,
 					IssueBackend:       target.EffectiveIssueBackend(),
 					GitBackend:         target.EffectiveGitBackend(),
 					PRBackend:          target.EffectivePRBackend(),
@@ -4154,7 +4156,7 @@ func (a *App) RedispatchSession(ctx context.Context, repoSlug string, issue int,
 		return fmt.Errorf("redispatch would exceed max parallel sessions for %s", repoSlug)
 	}
 
-	selectedProvider, err := resolveIssueProvider(target, *selectedIssue)
+	selectedProvider, selectedModel, err := resolveIssueProvider(target, *selectedIssue)
 	if err != nil {
 		return err
 	}
@@ -4173,6 +4175,7 @@ func (a *App) RedispatchSession(ctx context.Context, repoSlug string, issue int,
 		RepoPath:           target.Path,
 		Repo:               target.Repo,
 		Provider:           selectedProvider,
+		Model:              selectedModel,
 		IssueBackend:       target.EffectiveIssueBackend(),
 		GitBackend:         target.EffectiveGitBackend(),
 		PRBackend:          target.EffectivePRBackend(),
@@ -5457,20 +5460,20 @@ func summarizeText(text string) string {
 	return text
 }
 
-func resolveIssueProvider(target state.WatchTarget, issue ghcli.Issue) (string, error) {
+func resolveIssueProvider(target state.WatchTarget, issue ghcli.Issue) (string, string, error) {
 	selected := strings.TrimSpace(target.Provider)
 	if selected == "" {
 		selected = provider.DefaultID
 	}
 
-	override, err := provider.ResolveIssueLabel(issue.Labels)
+	override, model, err := provider.ResolveIssueLabels(issue.Labels)
 	if err != nil {
-		return "", fmt.Errorf("issue #%d has conflicting provider labels: %w", issue.Number, err)
+		return "", "", fmt.Errorf("issue #%d has conflicting provider labels: %w", issue.Number, err)
 	}
 	if override == "" {
-		return selected, nil
+		return selected, "", nil
 	}
-	return override, nil
+	return override, model, nil
 }
 
 func blockedIssueSessionForDispatchFailure(target state.WatchTarget, issue ghcli.Issue, selectedProvider string, err error, now time.Time) state.Session {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1663,7 +1663,7 @@ func TestSyncIssueManagedLabelsQueued(t *testing.T) {
 	app.stderr = testutil.IODiscard{}
 	app.env.Runner = testutil.FakeRunner{
 		Outputs: map[string]string{
-			"gh api repos/owner/repo/labels?per_page=100":                                                     `[{"name":"bug"},{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:iterating"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"vigilante:flagged-security-review"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
+			"gh api repos/owner/repo/labels?per_page=100":                                                     `[{"name":"bug"},{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:iterating"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"vigilante:flagged-security-review"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"claude:sonnet"},{"name":"claude:opus"},{"name":"claude:fable"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
 			"gh api repos/owner/repo/issues/7":                                                                `{"labels":[{"name":"bug"},{"name":"vigilante:running"}]}`,
 			"gh issue edit --repo owner/repo 7 --add-label vigilante:queued --remove-label vigilante:running": "ok",
 		},
@@ -1696,7 +1696,7 @@ func TestSyncIssueManagedLabelsNoopDoesNotEmitTelemetry(t *testing.T) {
 	app.stderr = testutil.IODiscard{}
 	app.env.Runner = testutil.FakeRunner{
 		Outputs: map[string]string{
-			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:iterating"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"vigilante:flagged-security-review"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
+			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:iterating"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"vigilante:flagged-security-review"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"claude:sonnet"},{"name":"claude:opus"},{"name":"claude:fable"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
 			"gh api repos/owner/repo/issues/7":            `{"labels":[{"name":"vigilante:queued"}]}`,
 		},
 	}
@@ -1897,7 +1897,7 @@ func TestSyncSessionIssueLabelsUsesPullRequestReviewState(t *testing.T) {
 	app.stderr = testutil.IODiscard{}
 	app.env.Runner = testutil.FakeRunner{
 		Outputs: map[string]string{
-			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:iterating"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"vigilante:flagged-security-review"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
+			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:iterating"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"vigilante:flagged-security-review"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"claude:sonnet"},{"name":"claude:opus"},{"name":"claude:fable"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
 			"gh pr view --repo owner/repo 17 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,baseRefName,headRefOid": `{"number":17,"title":"Demo PR","body":"PR body","url":"https://github.com/owner/repo/pull/17","state":"OPEN","mergedAt":null,"labels":[],"isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[{"context":"test","state":"COMPLETED","conclusion":"SUCCESS"}],"baseRefName":"main"}`,
 			"gh api repos/owner/repo/issues/7": `{"labels":[{"name":"vigilante:ready-for-review"},{"name":"vigilante:needs-review"}]}`,
 			"gh issue edit --repo owner/repo 7 --add-label vigilante:awaiting-user-validation --remove-label vigilante:needs-review --remove-label vigilante:ready-for-review": "ok",
@@ -1924,7 +1924,7 @@ func TestSyncSessionIssueLabelsStopsMonitoringUnavailableIssue(t *testing.T) {
 	app.clock = func() time.Time { return time.Date(2026, 3, 26, 17, 0, 0, 0, time.UTC) }
 	app.env.Runner = testutil.FakeRunner{
 		Outputs: map[string]string{
-			"gh api repos/owner/repo/labels?per_page=100":                `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:iterating"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"vigilante:flagged-security-review"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
+			"gh api repos/owner/repo/labels?per_page=100":                `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:iterating"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"vigilante:flagged-security-review"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"claude:sonnet"},{"name":"claude:opus"},{"name":"claude:fable"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
 			"git worktree prune":                                         "ok",
 			"git worktree list --porcelain":                              "worktree /tmp/repo\nHEAD abcdef\nbranch refs/heads/main\n",
 			"git show-ref --verify --quiet refs/heads/vigilante/issue-7": "ok",
@@ -1976,6 +1976,9 @@ func TestSyncIssueManagedLabelsProvisionMissingRepositoryLabels(t *testing.T) {
 			"gh api --method POST repos/owner/repo/labels -f name=codex -f color=1D76DB -f description=Routes the issue to the Codex provider for execution.":                                                                  "ok",
 			"gh api --method POST repos/owner/repo/labels -f name=claude -f color=0052CC -f description=Routes the issue to the Claude provider for execution.":                                                                "ok",
 			"gh api --method POST repos/owner/repo/labels -f name=gemini -f color=006B75 -f description=Routes the issue to the Gemini provider for execution.":                                                                "ok",
+			"gh api --method POST repos/owner/repo/labels -f name=claude:sonnet -f color=D4A574 -f description=Routes the issue to Claude using the latest Sonnet model alias.":                                                "ok",
+			"gh api --method POST repos/owner/repo/labels -f name=claude:opus -f color=A56CC1 -f description=Routes the issue to Claude using the latest Opus model alias.":                                                    "ok",
+			"gh api --method POST repos/owner/repo/labels -f name=claude:fable -f color=E8B4B8 -f description=Routes the issue to Claude using the Fable model alias.":                                                         "ok",
 			"gh api --method POST repos/owner/repo/labels -f name=vigilante:resume -f color=C5DEF5 -f description=Requests that Vigilante resume a blocked session.":                                                           "ok",
 			"gh api --method POST repos/owner/repo/labels -f name=vigilante:automerge -f color=0E8A16 -f description=Requests automatic squash merge once required checks and merge requirements are satisfied.":               "ok",
 			"gh api --method POST repos/owner/repo/labels -f name=resume -f color=C5DEF5 -f description=Legacy compatibility alias for vigilante:resume.":                                                                      "ok",
@@ -5667,7 +5670,7 @@ func TestScanOnceAutoRecoversStaleBlockedMaintenanceSession(t *testing.T) {
 			"git rebase origin/main":                                     "Current branch vigilante/issue-1 is up to date.\n",
 			"gh pr view --repo owner/repo 31 --json number,title,body,url,state,mergedAt,labels,isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup,baseRefName,headRefOid": `{"number":31,"title":"Test PR","body":"body","url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null,"labels":[],"isDraft":false,"mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","reviewDecision":"APPROVED","statusCheckRollup":[{"context":"test","state":"COMPLETED","conclusion":"SUCCESS"}]}`,
 			"gh issue comment --repo owner/repo 1 --body " + successComment: "ok",
-			"gh api repos/owner/repo/labels?per_page=100":                   `[{"name":"vigilante:running"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"vigilante:queued"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
+			"gh api repos/owner/repo/labels?per_page=100":                   `[{"name":"vigilante:running"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"vigilante:queued"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"claude:sonnet"},{"name":"claude:opus"},{"name":"claude:fable"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
 			"gh api repos/owner/repo/issues/1":                              `{"labels":[{"name":"vigilante:blocked"},{"name":"vigilante:needs-git-fix"}]}`,
 			"gh issue edit --repo owner/repo 1 --add-label vigilante:recovering --remove-label vigilante:blocked --remove-label vigilante:needs-git-fix": "ok",
 			"gh issue edit --repo owner/repo 1 --add-label vigilante:awaiting-user-validation --remove-label vigilante:recovering":                       "ok",
@@ -7438,7 +7441,7 @@ func TestCleanupClosedIssueSessionsStopsAfterAutomaticCleanupLimit(t *testing.T)
 	runner := &countingRunner{allowUnexpectedGH: true, base: testutil.FakeRunner{
 		Outputs: map[string]string{
 			"git worktree prune":                          "ok",
-			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:iterating"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"vigilante:flagged-security-review"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
+			"gh api repos/owner/repo/labels?per_page=100": `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:iterating"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"vigilante:flagged-security-review"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"claude:sonnet"},{"name":"claude:opus"},{"name":"claude:fable"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
 			"gh api repos/owner/repo/issues/1":            `{"labels":[]}`,
 		},
 		Errors: map[string]error{
@@ -8106,7 +8109,7 @@ func TestScanOnceReusesIssueDetailsAcrossMaintenanceAndLabelSync(t *testing.T) {
 			Outputs: map[string]string{
 				"gh api repos/owner/repo/issues/1":                                                                   `{"title":"first","body":"Issue body","html_url":"https://github.com/owner/repo/issues/1","state":"open","labels":[{"name":"vigilante:automerge"}]}`,
 				"gh api repos/owner/repo/issues/1/comments":                                                          "[]",
-				"gh api repos/owner/repo/labels?per_page=100":                                                        `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:iterating"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"vigilante:flagged-security-review"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
+				"gh api repos/owner/repo/labels?per_page=100":                                                        `[{"name":"vigilante:queued"},{"name":"vigilante:running"},{"name":"vigilante:iterating"},{"name":"vigilante:blocked"},{"name":"vigilante:recovering"},{"name":"vigilante:ready-for-review"},{"name":"vigilante:awaiting-user-validation"},{"name":"vigilante:done"},{"name":"vigilante:needs-review"},{"name":"vigilante:needs-human-input"},{"name":"vigilante:needs-provider-fix"},{"name":"vigilante:needs-git-fix"},{"name":"vigilante:flagged-security-review"},{"name":"codex"},{"name":"claude"},{"name":"gemini"},{"name":"claude:sonnet"},{"name":"claude:opus"},{"name":"claude:fable"},{"name":"vigilante:resume"},{"name":"vigilante:automerge"},{"name":"resume"}]`,
 				"gh pr list --repo owner/repo --head vigilante/issue-1 --state all --json number,url,state,mergedAt": `[{"number":31,"url":"https://github.com/owner/repo/pull/31","state":"OPEN","mergedAt":null}]`,
 				"git fetch origin main":                                                                              "ok",
 				"git status --porcelain":                                                                             "",
@@ -10781,23 +10784,37 @@ func TestBuildResumeFailureSummaryInvocationPerProvider(t *testing.T) {
 func TestResolveIssueProviderPrefersLabelOverDefault(t *testing.T) {
 	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
 
-	selected, err := resolveIssueProvider(target, ghcli.Issue{Number: 7})
+	selected, model, err := resolveIssueProvider(target, ghcli.Issue{Number: 7})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if selected != provider.ClaudeID {
 		t.Fatalf("expected unlabeled issue to default to claude, got %q", selected)
 	}
+	if model != "" {
+		t.Fatalf("expected unlabeled issue to have no model, got %q", model)
+	}
 
-	selected, err = resolveIssueProvider(target, ghcli.Issue{Number: 7, Labels: []ghcli.Label{{Name: provider.CodexID}}})
+	selected, model, err = resolveIssueProvider(target, ghcli.Issue{Number: 7, Labels: []ghcli.Label{{Name: provider.CodexID}}})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if selected != provider.CodexID {
 		t.Fatalf("expected codex label to override the default, got %q", selected)
 	}
+	if model != "" {
+		t.Fatalf("expected codex routing to have no Claude model, got %q", model)
+	}
 
-	if _, err := resolveIssueProvider(target, ghcli.Issue{Number: 7, Labels: []ghcli.Label{{Name: provider.CodexID}, {Name: provider.GeminiID}}}); err == nil {
+	selected, model, err = resolveIssueProvider(target, ghcli.Issue{Number: 7, Labels: []ghcli.Label{{Name: "claude:opus"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selected != provider.ClaudeID || model != "opus" {
+		t.Fatalf("expected Claude Opus routing, got provider=%q model=%q", selected, model)
+	}
+
+	if _, _, err := resolveIssueProvider(target, ghcli.Issue{Number: 7, Labels: []ghcli.Label{{Name: provider.CodexID}, {Name: provider.GeminiID}}}); err == nil {
 		t.Fatal("expected conflicting provider labels to error")
 	}
 }

--- a/internal/github/labels_manifest_test.go
+++ b/internal/github/labels_manifest_test.go
@@ -75,6 +75,15 @@ func TestIssueLabelManifestKeepsCompatibilityControls(t *testing.T) {
 			t.Fatalf("expected provider label %q to remain a control routing label: %#v", provider, label)
 		}
 	}
+	for _, name := range []string{"claude:sonnet", "claude:opus", "claude:fable"} {
+		label, ok := labels[name]
+		if !ok {
+			t.Fatalf("expected Claude model label %q", name)
+		}
+		if label.Group != "provider-routing" || label.Behavior != "control" {
+			t.Fatalf("expected model label %q to be a control routing label: %#v", name, label)
+		}
+	}
 
 	resume, ok := labels["vigilante:resume"]
 	if !ok {

--- a/internal/provider/claude.go
+++ b/internal/provider/claude.go
@@ -30,11 +30,11 @@ func (claudeProvider) BuildIssuePreflightInvocation(task IssueTask) (Invocation,
 		// a stable --cwd option in headless mode.
 		Dir:  task.Session.WorktreePath,
 		Name: "claude",
-		Args: []string{
+		Args: claudeSessionArgs(task.Session.Model, []string{
 			"--print",
 			"--dangerously-skip-permissions",
 			skill.BuildIssuePreflightPrompt(task.Target, task.Issue, task.Session),
-		},
+		}),
 	}, nil
 }
 
@@ -42,11 +42,11 @@ func (claudeProvider) BuildIssueInvocation(task IssueTask) (Invocation, error) {
 	return Invocation{
 		Dir:  task.Session.WorktreePath,
 		Name: "claude",
-		Args: []string{
+		Args: claudeSessionArgs(task.Session.Model, []string{
 			"--print",
 			"--dangerously-skip-permissions",
 			skill.BuildIssuePromptForRuntime(skill.RuntimeClaude, task.Target, task.Issue, task.Session),
-		},
+		}),
 	}, nil
 }
 
@@ -54,11 +54,11 @@ func (claudeProvider) BuildConflictResolutionInvocation(task ConflictTask) (Invo
 	return Invocation{
 		Dir:  task.Session.WorktreePath,
 		Name: "claude",
-		Args: []string{
+		Args: claudeSessionArgs(task.Session.Model, []string{
 			"--print",
 			"--dangerously-skip-permissions",
 			skill.BuildConflictResolutionPromptForRuntime(skill.RuntimeClaude, task.Target, task.Session, task.PR),
-		},
+		}),
 	}, nil
 }
 
@@ -66,12 +66,19 @@ func (claudeProvider) BuildCIRemediationInvocation(task CIRemediationTask) (Invo
 	return Invocation{
 		Dir:  task.Session.WorktreePath,
 		Name: "claude",
-		Args: []string{
+		Args: claudeSessionArgs(task.Session.Model, []string{
 			"--print",
 			"--permission-mode", "acceptEdits",
 			skill.BuildCIRemediationPromptForRuntime(skill.RuntimeClaude, task.Target, task.Session, task.PR, task.FailingChecks),
-		},
+		}),
 	}, nil
+}
+
+func claudeSessionArgs(model string, args []string) []string {
+	if model == "" {
+		return args
+	}
+	return append([]string{"--model", model}, args...)
 }
 
 func (claudeProvider) BuildIssueCreateInvocation(task IssueCreateTask) (Invocation, error) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -20,6 +20,12 @@ const ClaudeID = "claude"
 const GeminiID = "gemini"
 const OpenCodeID = "opencode"
 
+var claudeModelLabels = map[string]string{
+	"claude:sonnet": "sonnet",
+	"claude:opus":   "opus",
+	"claude:fable":  "fable",
+}
+
 // DefaultID is the provider selected when no provider is specified by a flag,
 // an issue label, or a persisted watch target. It is deliberately an alias of
 // another provider's ID rather than its own literal, so "the default" and
@@ -97,20 +103,52 @@ func RegisteredIDs() []string {
 }
 
 func ResolveIssueLabel(labels []ghcli.Label) (string, error) {
+	providerID, _, err := ResolveIssueLabels(labels)
+	return providerID, err
+}
+
+// ResolveIssueLabels resolves provider and model routing labels attached to an issue.
+func ResolveIssueLabels(labels []ghcli.Label) (string, string, error) {
 	matches := make([]string, 0, len(registry))
 	for _, providerID := range RegisteredIDs() {
 		if ghcli.HasAnyLabel(labels, providerID) {
 			matches = append(matches, providerID)
 		}
 	}
+	models := make([]string, 0, 1)
+	for label, model := range claudeModelLabels {
+		if ghcli.HasAnyLabel(labels, label) {
+			models = append(models, model)
+		}
+	}
+	sort.Strings(models)
+	if len(models) > 1 {
+		return "", "", fmt.Errorf("multiple model labels: claude:%s", strings.Join(models, ", claude:"))
+	}
+	if len(models) == 1 && !containsString(matches, ClaudeID) {
+		matches = append(matches, ClaudeID)
+		sort.Strings(matches)
+	}
 	switch len(matches) {
 	case 0:
-		return "", nil
+		return "", "", nil
 	case 1:
-		return matches[0], nil
+		if len(models) == 1 {
+			return matches[0], models[0], nil
+		}
+		return matches[0], "", nil
 	default:
-		return "", fmt.Errorf("multiple provider labels: %s", strings.Join(matches, ", "))
+		return "", "", fmt.Errorf("multiple provider labels: %s", strings.Join(matches, ", "))
 	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func Resolve(id string) (Provider, error) {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -331,6 +331,70 @@ func TestResolveIssueLabelRejectsConflictingProviderLabels(t *testing.T) {
 	}
 }
 
+func TestResolveIssueLabelsSelectsClaudeModel(t *testing.T) {
+	for _, model := range []string{"sonnet", "opus", "fable"} {
+		providerID, gotModel, err := ResolveIssueLabels([]ghcli.Label{{Name: "claude:" + model}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if providerID != ClaudeID || gotModel != model {
+			t.Fatalf("claude:%s resolved to provider=%q model=%q", model, providerID, gotModel)
+		}
+	}
+}
+
+func TestResolveIssueLabelsClaudeConflictRules(t *testing.T) {
+	tests := []struct {
+		name      string
+		labels    []ghcli.Label
+		provider  string
+		model     string
+		wantError bool
+	}{
+		{name: "bare and model", labels: []ghcli.Label{{Name: ClaudeID}, {Name: "claude:sonnet"}}, provider: ClaudeID, model: "sonnet"},
+		{name: "two models", labels: []ghcli.Label{{Name: "claude:sonnet"}, {Name: "claude:opus"}}, wantError: true},
+		{name: "other provider", labels: []ghcli.Label{{Name: "claude:opus"}, {Name: CodexID}}, wantError: true},
+		{name: "unknown model", labels: []ghcli.Label{{Name: "claude:haiku"}}, provider: "", model: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			providerID, model, err := ResolveIssueLabels(tt.labels)
+			if (err != nil) != tt.wantError {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if providerID != tt.provider || model != tt.model {
+				t.Fatalf("resolved provider=%q model=%q", providerID, model)
+			}
+		})
+	}
+}
+
+func TestClaudeInvocationIncludesPersistedModel(t *testing.T) {
+	selectedProvider, err := Resolve(ClaudeID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
+	issue := ghcli.Issue{Number: 7, Title: "Demo"}
+	session := state.Session{WorktreePath: "/tmp/worktree", Model: "opus"}
+	pr := ghcli.PullRequest{Number: 11}
+
+	invocations := []Invocation{}
+	preflight, _ := selectedProvider.BuildIssuePreflightInvocation(IssueTask{Target: target, Issue: issue, Session: session})
+	invocations = append(invocations, preflight)
+	issueRun, _ := selectedProvider.BuildIssueInvocation(IssueTask{Target: target, Issue: issue, Session: session})
+	invocations = append(invocations, issueRun)
+	conflict, _ := selectedProvider.BuildConflictResolutionInvocation(ConflictTask{Target: target, Session: session, PR: pr})
+	invocations = append(invocations, conflict)
+	ci, _ := selectedProvider.BuildCIRemediationInvocation(CIRemediationTask{Target: target, Session: session, PR: pr})
+	invocations = append(invocations, ci)
+	for _, invocation := range invocations {
+		if len(invocation.Args) < 2 || invocation.Args[0] != "--model" || invocation.Args[1] != "opus" {
+			t.Fatalf("model missing from invocation: %#v", invocation.Args)
+		}
+	}
+}
+
 func TestValidateVersionOutputAcceptsSupportedVersions(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -217,6 +217,7 @@ type Session struct {
 	RepoPath                       string              `json:"repo_path"`
 	Repo                           string              `json:"repo"`
 	Provider                       string              `json:"provider,omitempty"`
+	Model                          string              `json:"model,omitempty"`
 	IssueBackend                   string              `json:"issue_backend,omitempty"`
 	GitBackend                     string              `json:"git_backend,omitempty"`
 	PRBackend                      string              `json:"pr_backend,omitempty"`

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -132,7 +132,7 @@ func TestSessionStatusClosedRoundTrips(t *testing.T) {
 	}
 
 	sessions := []Session{
-		{Repo: "owner/repo", IssueNumber: 1, Branch: "vigilante/issue-1", Status: SessionStatusClosed},
+		{Repo: "owner/repo", Provider: "claude", Model: "opus", IssueNumber: 1, Branch: "vigilante/issue-1", Status: SessionStatusClosed},
 		{Repo: "owner/repo", IssueNumber: 2, Branch: "vigilante/issue-2", Status: SessionStatusSuccess},
 	}
 	if err := store.SaveSessions(sessions); err != nil {
@@ -148,6 +148,9 @@ func TestSessionStatusClosedRoundTrips(t *testing.T) {
 	}
 	if loaded[0].Status != SessionStatusClosed {
 		t.Fatalf("expected closed status, got %q", loaded[0].Status)
+	}
+	if loaded[0].Provider != "claude" || loaded[0].Model != "opus" {
+		t.Fatalf("expected provider and model to round-trip, got provider=%q model=%q", loaded[0].Provider, loaded[0].Model)
 	}
 	if loaded[1].Status != SessionStatusSuccess {
 		t.Fatalf("expected success status, got %q", loaded[1].Status)

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -401,6 +401,14 @@ func TestInternalCommandName(t *testing.T) {
 			wantOK:       true,
 		},
 		{
+			name:         "claude skips model value",
+			command:      "claude",
+			args:         []string{"--model", "opus", "--print", "free form prompt"},
+			wantName:     "claude",
+			wantCategory: "coding_agent",
+			wantOK:       true,
+		},
+		{
 			name:         "gemini skips prompt flag value",
 			command:      "gemini",
 			args:         []string{"--prompt", "free form prompt", "--yolo"},


### PR DESCRIPTION
## Summary

- recognize `claude:sonnet`, `claude:opus`, and `claude:fable` as Claude provider/model routing labels with deterministic conflict handling
- persist the selected model on issue sessions and add `--model <alias>` to every session-backed Claude invocation
- add repository labels, documentation, persistence/invocation/redaction tests, and label-provisioning fixture coverage

`IssueCreateTask` and `PackageRemediationTask` intentionally remain unchanged because they are target-scoped flows without an issue session or per-issue model selection context.

The installed Claude CLI help lists `fable`, `opus`, and `sonnet` as accepted aliases.

## Validation

- `go test ./...`
- `go vet ./...`
- `golangci-lint run`
- `go test -race ./internal/provider ./internal/state ./internal/telemetry`
- `task coverage` (77.4%, threshold 77.3%; one unrelated telemetry timing test flaked once and then passed 10 uncached repetitions plus the full rerun)
- `git diff --check`

Closes #496