### PR TITLE
Raise coverage above the 80% target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,19 +22,20 @@ threshold is a ratchet: it only moves up. If a change raises the total, raising
 the threshold in the same pull request is welcome.
 
 The target is **80% per non-data package**, which is the standard [awesome-go][ag]
-applies to listed projects. The repository is not there yet — the committed
-threshold starts at the measured baseline and climbs. New and changed code is held
-to 80% immediately through Codecov's patch status, so the way the number goes up is
-by covering what you touch rather than by bulk backfill.
+applies to listed projects. The committed threshold records the measured local
+baseline and only moves up. New and changed code is held to 80% immediately
+through Codecov's patch status, so the way the number stays healthy is by covering
+what you touch.
 
 Coverage reports are published to [Codecov][cc]. `internal/testutil` and the
 non-Go directories are excluded; see `codecov.yml`.
 
 Codecov's percentage is lower than `task coverage`'s and both are correct: Codecov
 converts the Go profile to **line** coverage, while Go tooling reports **statement**
-coverage. The same profile reads about 67% on Codecov and about 71% locally. The
-80% goal and the committed ratchet are statement-based, so compare against
-`task coverage` when judging whether coverage moved.
+coverage. After the targeted coverage backfill, the project is at the 80% Codecov
+line-coverage target and the same profile reports at least 82.6% local statement coverage.
+The committed ratchet is statement-based, so compare against `task coverage` when
+judging whether local coverage moved.
 
 [ag]: https://github.com/avelino/awesome-go/blob/main/CONTRIBUTING.md
 [cc]: https://app.codecov.io/gh/aliengiraffe/vigilante

--- a/cmd/gh-sandbox/main.go
+++ b/cmd/gh-sandbox/main.go
@@ -32,24 +32,28 @@ type ghResponse struct {
 }
 
 func main() {
-	os.Exit(run())
+	var stdin io.Reader
+	if stat, err := os.Stdin.Stat(); err == nil && (stat.Mode()&os.ModeCharDevice) == 0 {
+		stdin = os.Stdin
+	}
+	os.Exit(run(os.Args[1:], stdin, os.Stdout, os.Stderr))
 }
 
-func run() int {
+func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	proxyURL := os.Getenv("VIGILANTE_PROXY_URL")
 	if proxyURL == "" {
-		fmt.Fprintln(os.Stderr, "gh-sandbox: VIGILANTE_PROXY_URL not set")
+		fmt.Fprintln(stderr, "gh-sandbox: VIGILANTE_PROXY_URL not set")
 		return 1
 	}
 	token := os.Getenv("VIGILANTE_SANDBOX_TOKEN")
 	if token == "" {
-		fmt.Fprintln(os.Stderr, "gh-sandbox: VIGILANTE_SANDBOX_TOKEN not set")
+		fmt.Fprintln(stderr, "gh-sandbox: VIGILANTE_SANDBOX_TOKEN not set")
 		return 1
 	}
 
-	command := strings.Join(os.Args[1:], " ")
+	command := strings.Join(args, " ")
 	if command == "" {
-		fmt.Fprintln(os.Stderr, "usage: gh <command>")
+		fmt.Fprintln(stderr, "usage: gh <command>")
 		return 1
 	}
 
@@ -57,10 +61,11 @@ func run() int {
 	// invocations don't block waiting for input. Required so flags like
 	// `--body-file -` see the bytes the agent piped in.
 	var stdinBytes []byte
-	if stat, err := os.Stdin.Stat(); err == nil && (stat.Mode()&os.ModeCharDevice) == 0 {
-		stdinBytes, err = io.ReadAll(os.Stdin)
+	if stdin != nil {
+		var err error
+		stdinBytes, err = io.ReadAll(stdin)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "gh-sandbox: read stdin: %s\n", err)
+			fmt.Fprintf(stderr, "gh-sandbox: read stdin: %s\n", err)
 			return 1
 		}
 	}
@@ -71,35 +76,35 @@ func run() int {
 		Stdin:   string(stdinBytes),
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "gh-sandbox: marshal request: %s\n", err)
+		fmt.Fprintf(stderr, "gh-sandbox: marshal request: %s\n", err)
 		return 1
 	}
 
 	resp, err := http.Post(proxyURL+"/api/sandbox/gh", "application/json", bytes.NewReader(body))
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "gh-sandbox: proxy request failed: %s\n", err)
+		fmt.Fprintf(stderr, "gh-sandbox: proxy request failed: %s\n", err)
 		return 1
 	}
 	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "gh-sandbox: read response: %s\n", err)
+		fmt.Fprintf(stderr, "gh-sandbox: read response: %s\n", err)
 		return 1
 	}
 
 	var ghResp ghResponse
 	if err := json.Unmarshal(respBody, &ghResp); err != nil {
 		// Not JSON — print raw body as error.
-		fmt.Fprint(os.Stderr, string(respBody))
+		fmt.Fprint(stderr, string(respBody))
 		return 1
 	}
 
 	if ghResp.Stdout != "" {
-		fmt.Fprint(os.Stdout, ghResp.Stdout)
+		fmt.Fprint(stdout, ghResp.Stdout)
 	}
 	if ghResp.Stderr != "" {
-		fmt.Fprint(os.Stderr, ghResp.Stderr)
+		fmt.Fprint(stderr, ghResp.Stderr)
 	}
 	return ghResp.ExitCode
 }

--- a/cmd/gh-sandbox/main_test.go
+++ b/cmd/gh-sandbox/main_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRunValidatesEnvironmentAndCommand(t *testing.T) {
+	for _, tc := range []struct {
+		name, url, token, want string
+		args                   []string
+	}{
+		{"url", "", "token", "VIGILANTE_PROXY_URL", []string{"repo", "view"}},
+		{"token", "http://example.test", "", "VIGILANTE_SANDBOX_TOKEN", []string{"repo", "view"}},
+		{"command", "http://example.test", "token", "usage: gh", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("VIGILANTE_PROXY_URL", tc.url)
+			t.Setenv("VIGILANTE_SANDBOX_TOKEN", tc.token)
+			var stderr bytes.Buffer
+			if code := run(tc.args, strings.NewReader(""), io.Discard, &stderr); code != 1 || !strings.Contains(stderr.String(), tc.want) {
+				t.Fatalf("run()=%d stderr=%q", code, stderr.String())
+			}
+		})
+	}
+}
+
+func TestRunForwardsCommandInputAndResponse(t *testing.T) {
+	var got ghRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/sandbox/gh" {
+			t.Errorf("path=%q", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatal(err)
+		}
+		_ = json.NewEncoder(w).Encode(ghResponse{ExitCode: 7, Stdout: "out", Stderr: "warn"})
+	}))
+	defer server.Close()
+	t.Setenv("VIGILANTE_PROXY_URL", server.URL)
+	t.Setenv("VIGILANTE_SANDBOX_TOKEN", "secret")
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"issue", "comment", "42"}, strings.NewReader("body"), &stdout, &stderr); code != 7 {
+		t.Fatalf("code=%d", code)
+	}
+	if got.Command != "issue comment 42" || got.Token != "secret" || got.Stdin != "body" {
+		t.Fatalf("request=%#v", got)
+	}
+	if stdout.String() != "out" || stderr.String() != "warn" {
+		t.Fatalf("stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
+func TestRunReportsInputTransportAndInvalidResponseErrors(t *testing.T) {
+	t.Setenv("VIGILANTE_PROXY_URL", "http://127.0.0.1:1")
+	t.Setenv("VIGILANTE_SANDBOX_TOKEN", "secret")
+	var stderr bytes.Buffer
+	if code := run([]string{"repo", "view"}, failingReader{}, io.Discard, &stderr); code != 1 || !strings.Contains(stderr.String(), "read stdin") {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+	stderr.Reset()
+	if code := run([]string{"repo", "view"}, strings.NewReader(""), io.Discard, &stderr); code != 1 || !strings.Contains(stderr.String(), "proxy request failed") {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = io.WriteString(w, "not-json") }))
+	defer server.Close()
+	t.Setenv("VIGILANTE_PROXY_URL", server.URL)
+	stderr.Reset()
+	if code := run([]string{"repo", "view"}, strings.NewReader(""), io.Discard, &stderr); code != 1 || stderr.String() != "not-json" {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+}
+
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) { return 0, io.ErrUnexpectedEOF }

--- a/internal/app/helpers_test.go
+++ b/internal/app/helpers_test.go
@@ -1,14 +1,172 @@
 package app
 
 import (
+	"bytes"
+	"context"
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
 	"github.com/nicobistolfi/vigilante/internal/provider"
 	"github.com/nicobistolfi/vigilante/internal/state"
 )
+
+func TestCoverageFailureGuidanceHelpers(t *testing.T) {
+	base := state.Session{Repo: "owner/repo", IssueNumber: 42, Provider: "codex", Branch: "branch", WorktreePath: "/tmp/worktree"}
+	for _, tc := range []struct{ kind, stage, text string }{
+		{"provider_auth", "startup", "re-authenticate"}, {"provider_quota", "startup", "capacity"},
+		{"provider_missing", "startup", "runtime"}, {"provider_runtime_error", "startup", "runtime"},
+		{"", "dispatch", "worktree setup"}, {"", "startup", "startup problem"},
+	} {
+		s := base
+		s.BlockedReason.Kind = tc.kind
+		if got := dispatchFailureNextStep(s, tc.stage); !strings.Contains(got, tc.text) {
+			t.Errorf("dispatch %s/%s=%q", tc.kind, tc.stage, got)
+		}
+	}
+	s := base
+	s.LastError = "worktree already exists"
+	if got := dispatchFailureNextStep(s, "dispatch"); !strings.Contains(got, "cleanup") {
+		t.Fatalf("stale worktree=%q", got)
+	}
+	for _, tc := range []struct{ kind, text string }{
+		{"provider_auth", "Re-authenticate"}, {"provider_missing", "Install"}, {"git_auth", "git remote"}, {"gh_auth", "GitHub CLI"},
+		{"network_unreachable", "network"}, {"dirty_worktree", "worktree"}, {"validation_failed", "validation"}, {"other", "Fix the blocker"},
+	} {
+		s := base
+		s.BlockedReason.Kind = tc.kind
+		if got := resumeFailureNextStep(s); !strings.Contains(got, tc.text) {
+			t.Errorf("resume %s=%q", tc.kind, got)
+		}
+	}
+	if !strings.Contains(dispatchFailureFingerprint(base, "dispatch"), "branch") || !strings.Contains(resumeFailureFingerprint(base), "unknown") {
+		t.Fatal("fingerprints omit stable fields")
+	}
+}
+
+func TestCoveragePathThresholdAndCompletionHelpers(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	for raw, want := range map[string]string{"~": home, "~/repo": filepath.Join(home, "repo")} {
+		got, err := ExpandPath(raw)
+		if err != nil || got != want {
+			t.Errorf("ExpandPath(%q)=%q,%v want %q", raw, got, err, want)
+		}
+	}
+	if _, err := ExpandPath(""); err == nil {
+		t.Fatal("expected empty path error")
+	}
+	rel, err := ExpandPath("relative")
+	if err != nil || !filepath.IsAbs(rel) {
+		t.Fatalf("relative=%q err=%v", rel, err)
+	}
+	for raw, want := range map[string]time.Duration{"": defaultStalledSessionThreshold, "bad": defaultStalledSessionThreshold, "0s": defaultStalledSessionThreshold, "90s": 90 * time.Second} {
+		t.Setenv("VIGILANTE_STALLED_SESSION_THRESHOLD", raw)
+		if got := stalledSessionThreshold(); got != want {
+			t.Errorf("threshold %q=%s want %s", raw, got, want)
+		}
+	}
+	for _, shell := range []string{"bash", "fish", "zsh"} {
+		var out bytes.Buffer
+		a := &App{stdout: &out}
+		if err := a.runCompletionCommand([]string{shell}); err != nil || out.Len() == 0 {
+			t.Errorf("completion %s len=%d err=%v", shell, out.Len(), err)
+		}
+	}
+	var out bytes.Buffer
+	a := &App{stdout: &out}
+	if err := a.runCompletionCommand([]string{"powershell"}); err == nil {
+		t.Fatal("expected unsupported shell")
+	}
+	if err := a.runCompletionCommand(nil); err == nil {
+		t.Fatal("expected missing shell")
+	}
+}
+
+func TestCoverageSessionMessageAndStallBoundaries(t *testing.T) {
+	for _, tc := range []struct{ kind, want string }{{"provider_quota", "usage or subscription"}, {"other", "merge-ready"}} {
+		blocked := state.BlockedReason{Kind: tc.kind}
+		if got := maintenanceBlockedMessage(blocked, 42, "branch"); !strings.Contains(got, tc.want) {
+			t.Errorf("maintenance=%q", got)
+		}
+		if got := resumePreflightBlockedMessage(blocked, "branch"); !strings.Contains(got, map[bool]string{true: "usage or subscription", false: "did not pass"}[tc.kind == "provider_quota"]) {
+			t.Errorf("preflight=%q", got)
+		}
+		if got := resumeBlockedMessage(blocked, "branch"); !strings.Contains(got, map[bool]string{true: "usage or subscription", false: "did not complete"}[tc.kind == "provider_quota"]) {
+			t.Errorf("resume=%q", got)
+		}
+	}
+	for kind, want := range map[string]string{"provider_auth": "provider_related", "provider_missing": "provider_related", "provider_runtime_error": "provider_related", "network_unreachable": "transient", "other": "operator_fixable"} {
+		if got := resumeFailureClassification(kind); got != want {
+			t.Errorf("classification %s=%s", kind, got)
+		}
+	}
+	now := time.Now().UTC()
+	path := t.TempDir()
+	for _, tc := range []struct {
+		session   state.Session
+		threshold time.Duration
+		stalled   bool
+		want      string
+	}{
+		{state.Session{WorktreePath: filepath.Join(path, "missing")}, time.Hour, true, "missing"},
+		{state.Session{WorktreePath: path}, time.Hour, true, "heartbeat"},
+		{state.Session{WorktreePath: path, LastHeartbeatAt: now.Format(time.RFC3339)}, time.Hour, false, ""},
+		{state.Session{WorktreePath: path, LastHeartbeatAt: now.Add(-2 * time.Hour).Format(time.RFC3339), ProcessID: 123}, time.Hour, true, "process 123"},
+		{state.Session{WorktreePath: path, LastHeartbeatAt: now.Add(-2 * time.Hour).Format(time.RFC3339)}, time.Hour, true, "idle"},
+	} {
+		stalled, reason := isStalledSession(tc.session, now, tc.threshold)
+		if stalled != tc.stalled || !strings.Contains(reason, tc.want) {
+			t.Errorf("stalled=%v reason=%q want %v/%q", stalled, reason, tc.stalled, tc.want)
+		}
+	}
+}
+
+func TestRecoveryCommandArgumentValidation(t *testing.T) {
+	ctx := context.Background()
+	for name, fn := range map[string]func([]string) error{
+		"resume": func(args []string) error {
+			var out bytes.Buffer
+			return (&App{stdout: &out}).runResumeCommand(ctx, args)
+		},
+		"redispatch": func(args []string) error {
+			var out bytes.Buffer
+			return (&App{stdout: &out}).runRedispatchCommand(ctx, args)
+		},
+		"cleanup": func(args []string) error {
+			var out bytes.Buffer
+			return (&App{stdout: &out}).runCleanupCommand(ctx, args)
+		},
+	} {
+		if err := fn([]string{"--help"}); err != nil {
+			t.Errorf("%s help=%v", name, err)
+		}
+		if err := fn([]string{"--unknown"}); err == nil {
+			t.Errorf("%s accepted unknown flag", name)
+		}
+	}
+	for _, args := range [][]string{nil, {"--repo", "owner/repo"}, {"--issue", "1"}, {"--all-blocked", "--repo", "owner/repo"}} {
+		var out bytes.Buffer
+		if err := (&App{stdout: &out}).runResumeCommand(ctx, args); err == nil {
+			t.Errorf("resume accepted %#v", args)
+		}
+	}
+	for _, args := range [][]string{nil, {"--repo", "owner/repo"}, {"--issue", "1"}} {
+		var out bytes.Buffer
+		if err := (&App{stdout: &out}).runRedispatchCommand(ctx, args); err == nil {
+			t.Errorf("redispatch accepted %#v", args)
+		}
+	}
+	for _, args := range [][]string{nil, {"--issue", "1"}, {"--repo", "owner/repo", "--issue", "-1"}, {"--all", "--repo", "owner/repo"}} {
+		var out bytes.Buffer
+		if err := (&App{stdout: &out}).runCleanupCommand(ctx, args); err == nil {
+			t.Errorf("cleanup accepted %#v", args)
+		}
+	}
+}
 
 // stringListFlag backs repeatable --label flags. Rejecting an empty value here is
 // what stops `--label ""` from asking GitHub to apply a nameless label.

--- a/internal/app/logs_test.go
+++ b/internal/app/logs_test.go
@@ -3,6 +3,8 @@ package app
 import (
 	"bytes"
 	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,8 +12,59 @@ import (
 	"time"
 
 	"github.com/nicobistolfi/vigilante/internal/environment"
+	"github.com/nicobistolfi/vigilante/internal/logging"
+	"github.com/nicobistolfi/vigilante/internal/state"
 	"github.com/nicobistolfi/vigilante/internal/testutil"
 )
+
+func TestCoverageLogRotationAndStreamingBoundaries(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", root)
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "config.json"), []byte("bad"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	limits := configureLogRotation(store)
+	if limits != logging.DefaultLimits() {
+		t.Fatalf("fallback limits=%#v", limits)
+	}
+	t.Cleanup(func() { logging.Configure(logging.DefaultLimits(), nil, nil) })
+	var out bytes.Buffer
+	input := "\nnot-json\n" + `{"timestamp":"2026-03-26T10:00:00Z","context":"daemon","tool":"gh","success":true}` + "\n"
+	if err := renderAccessLogStream(&out, strings.NewReader(input)); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "[malformed]") || !strings.Contains(out.String(), "gh") {
+		t.Fatalf("stream=%q", out.String())
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := followFile(ctx, filepath.Join(root, "missing.log"), true, time.Millisecond, func(r io.Reader) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "data.log")
+	if err := os.WriteFile(path, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	want := errors.New("emit failed")
+	if err := followFile(context.Background(), path, false, time.Millisecond, func(r io.Reader) error { return want }); !errors.Is(err, want) {
+		t.Fatalf("follow error=%v", err)
+	}
+	rootFile := filepath.Join(root, "root-file")
+	if err := os.WriteFile(rootFile, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("VIGILANTE_HOME", rootFile)
+	a := New()
+	a.state = state.NewStore()
+	a.stdout = &out
+	if err := a.streamSessionLog(context.Background(), "owner/repo", 1); err == nil {
+		t.Fatal("expected session log mkdir error")
+	}
+}
 
 func TestFormatAccessLogEntry(t *testing.T) {
 	entry := environment.AccessLogEntry{

--- a/internal/app/report_test.go
+++ b/internal/app/report_test.go
@@ -5,15 +5,55 @@ import (
 	"context"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/nicobistolfi/vigilante/internal/backend"
+	"github.com/nicobistolfi/vigilante/internal/environment"
 	"github.com/nicobistolfi/vigilante/internal/state"
 	"github.com/nicobistolfi/vigilante/internal/testutil"
 )
+
+func TestGenerateReportAppWrapperAndErrorPaths(t *testing.T) {
+	t.Setenv("VIGILANTE_HOME", t.TempDir())
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveWatchTargets([]state.WatchTarget{{Repo: "owner/repo", Provider: "gemini"}}); err != nil {
+		t.Fatal(err)
+	}
+	runner := testutil.FakeRunner{Outputs: map[string]string{"gh api repos/owner/repo/issues?state=closed&per_page=100&page=1": "[]"}}
+	app := &App{state: store, env: &environment.Environment{Runner: runner}}
+	var out bytes.Buffer
+	if err := app.generateReport(context.Background(), "owner/repo", &out); err != nil {
+		t.Fatal(err)
+	}
+	records, err := csv.NewReader(strings.NewReader(out.String())).ReadAll()
+	if err != nil || len(records) != 1 {
+		t.Fatalf("records=%#v err=%v", records, err)
+	}
+	if _, ok := app.resolveRunner().(testutil.FakeRunner); !ok {
+		t.Fatalf("runner=%T", app.resolveRunner())
+	}
+	if _, ok := (&App{}).resolveRunner().(environment.ExecRunner); !ok {
+		t.Fatalf("fallback runner=%T", (&App{}).resolveRunner())
+	}
+	boom := errors.New("api failed")
+	if err := generateReportWithRunner(context.Background(), testutil.FakeRunner{Errors: map[string]error{"gh api repos/owner/repo/issues?state=closed&per_page=100&page=1": boom}}, "owner/repo", "", io.Discard); !errors.Is(err, boom) {
+		t.Fatalf("list error=%v", err)
+	}
+	if _, err := listClosedIssues(context.Background(), testutil.FakeRunner{Outputs: map[string]string{"gh api repos/owner/repo/issues?state=closed&per_page=100&page=1": "bad"}}, "owner/repo"); err == nil {
+		t.Fatal("expected issue JSON error")
+	}
+	if _, err := listIssueCommentsForReport(context.Background(), testutil.FakeRunner{Outputs: map[string]string{"gh api repos/owner/repo/issues/1/comments?per_page=100&page=1": "bad"}}, "owner/repo", 1); err == nil {
+		t.Fatal("expected comment JSON error")
+	}
+}
 
 func makeComment(id int64, body string, createdAt time.Time) backend.WorkItemComment {
 	return backend.WorkItemComment{

--- a/internal/app/status_tui_test.go
+++ b/internal/app/status_tui_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -435,5 +436,78 @@ func TestStatusDashboardDoesNotPollRateLimitEveryTick(t *testing.T) {
 	}
 	if !model.sessions.Loaded {
 		t.Fatal("expected session ticks to refresh the local session data")
+	}
+}
+
+func TestStatusRenderingBoundaryHelpers(t *testing.T) {
+	for height, want := range map[int]int{0: 1, 1: 1, 2: 1, 3: 1, 10: 8} {
+		if got := (statusModel{height: height}).pageSize(); got != want {
+			t.Errorf("pageSize(%d)=%d want %d", height, got, want)
+		}
+	}
+	for _, tc := range []struct {
+		info serviceStatusInfo
+		want string
+	}{
+		{serviceStatusInfo{DaemonVersion: "1.2.3", Running: true}, "1.2.3"},
+		{serviceStatusInfo{DaemonVersion: "1.2.3"}, "configured binary"},
+		{serviceStatusInfo{Running: true}, "unavailable"},
+		{serviceStatusInfo{}, "service not running"},
+	} {
+		if got := statusDaemonVersion(tc.info); !strings.Contains(got, tc.want) {
+			t.Errorf("daemon=%q want %q", got, tc.want)
+		}
+	}
+	for _, state := range []string{"running", "stopped", "unknown"} {
+		if got := statusStateStyle(state).Render("state"); !strings.Contains(got, "state") {
+			t.Errorf("style %s=%q", state, got)
+		}
+	}
+	for _, r := range []ghcli.RateLimitResource{{Limit: 100, Remaining: 80}, {Limit: 100, Remaining: 30}, {Limit: 100, Remaining: 10}, {Limit: 0}, {Limit: 10, Remaining: -2}, {Limit: 10, Remaining: 20}} {
+		row := formatRateLimitGaugeRow("core", r)
+		if !strings.Contains(row, "core") || !strings.Contains(row, fmt.Sprintf("%d/%d", r.Remaining, r.Limit)) {
+			t.Errorf("row=%q", row)
+		}
+	}
+	model := statusModel{service: statusServiceSnapshot{Loaded: true, Err: errors.New("offline")}}
+	if got := strings.Join(model.serviceLines(), "\n"); !strings.Contains(got, "offline") {
+		t.Fatalf("service lines=%q", got)
+	}
+	model.rateLimit = statusRateLimitSnapshot{Loaded: true, Available: true, Snapshot: ghcli.RateLimitSnapshot{}}
+	if got := strings.Join(model.rateLimitLines(), "\n"); !strings.Contains(got, "unavailable") {
+		t.Fatalf("rate lines=%q", got)
+	}
+}
+
+func TestStatusModelNavigationAndRefreshBranches(t *testing.T) {
+	m := loadedStatusModel()
+	m.height = 5
+	m.offset = 3
+	for _, key := range []tea.KeyMsg{{Type: tea.KeyPgUp}, {Type: tea.KeyPgDown}, {Type: tea.KeyHome}, {Type: tea.KeyRunes, Runes: []rune{'g'}}, {Type: tea.KeyEnd}} {
+		updated, _ := m.Update(key)
+		m = updated.(statusModel)
+		if m.offset < 0 || m.offset > len(m.contentLines()) {
+			t.Fatalf("key %s offset=%d", key.String(), m.offset)
+		}
+	}
+	updated, _ := m.Update(statusServiceMsg(statusServiceSnapshot{Info: serviceStatusInfo{State: "stopped"}}))
+	m = updated.(statusModel)
+	if !m.service.Loaded {
+		t.Fatal("service message not loaded")
+	}
+	updated, _ = m.Update(statusRateLimitMsg(statusRateLimitSnapshot{Available: true}))
+	m = updated.(statusModel)
+	if !m.rateLimit.Loaded {
+		t.Fatal("rate message not loaded")
+	}
+	for _, msg := range []tea.Msg{statusServiceTickMsg(time.Now()), statusSessionsTickMsg(time.Now()), statusRateLimitTickMsg(time.Now())} {
+		_, _ = m.Update(msg)
+	}
+	if statusTick(0, func(t time.Time) tea.Msg { return t }) != nil {
+		t.Fatal("zero tick should be nil")
+	}
+	empty := statusModel{}
+	if empty.serviceCmd() != nil || empty.sessionsCmd() != nil || empty.rateLimitCmd() != nil {
+		t.Fatal("nil loaders returned commands")
 	}
 }

--- a/internal/environment/runner_test.go
+++ b/internal/environment/runner_test.go
@@ -373,7 +373,8 @@ func TestLoggingRunnerRunWithStdin(t *testing.T) {
 		t.Parallel()
 
 		base := &stdinStreamingRunner{recordingRunner: recordingRunner{output: "ok"}}
-		r := LoggingRunner{Base: base}
+		var logs bytes.Buffer
+		r := LoggingRunner{Base: base, Logger: newTestLogger(&logs), LogSuccessOutput: true}
 
 		if _, err := r.RunWithStdin(context.Background(), "payload", "/dir", "gh", "api"); err != nil {
 			t.Fatal(err)
@@ -386,6 +387,9 @@ func TestLoggingRunnerRunWithStdin(t *testing.T) {
 		}
 		if base.runCalls != 0 {
 			t.Fatal("must not fall back to Run when the base supports stdin")
+		}
+		if !strings.Contains(logs.String(), "stdin_bytes=7") || !strings.Contains(logs.String(), "output=ok") {
+			t.Fatalf("logs=%q", logs.String())
 		}
 	})
 
@@ -409,10 +413,12 @@ func TestLoggingRunnerRunWithStdin(t *testing.T) {
 		t.Parallel()
 
 		base := &recordingRunner{err: errors.New("exit status 1")}
+		var logs bytes.Buffer
 		var exitCode int
 		var sawEntry bool
 		r := LoggingRunner{
 			Base:           base,
+			Logger:         newTestLogger(&logs),
 			CaptureCommand: func(_ context.Context, _ string, _ []string, code int, _ int64) { exitCode = code },
 			AccessLog:      func(AccessLogEntry) { sawEntry = true },
 		}
@@ -422,6 +428,9 @@ func TestLoggingRunnerRunWithStdin(t *testing.T) {
 		}
 		if exitCode == 0 || !sawEntry {
 			t.Fatalf("hooks not invoked correctly: exit=%d entry=%v", exitCode, sawEntry)
+		}
+		if !strings.Contains(logs.String(), "command failed") {
+			t.Fatalf("logs=%q", logs.String())
 		}
 	})
 }
@@ -436,7 +445,8 @@ func TestLoggingRunnerRunStreaming(t *testing.T) {
 			recordingRunner: recordingRunner{output: "full"},
 			streamedBytes:   "streamed",
 		}
-		r := LoggingRunner{Base: base}
+		var logs bytes.Buffer
+		r := LoggingRunner{Base: base, Logger: newTestLogger(&logs), LogSuccessOutput: true}
 		var buf bytes.Buffer
 
 		output, err := r.RunStreaming(context.Background(), "/dir", &buf, "go", "test")
@@ -451,6 +461,9 @@ func TestLoggingRunnerRunStreaming(t *testing.T) {
 		}
 		if buf.String() != "streamed" {
 			t.Fatalf("writer got %q", buf.String())
+		}
+		if !strings.Contains(logs.String(), "streaming=true") || !strings.Contains(logs.String(), "output=full") {
+			t.Fatalf("logs=%q", logs.String())
 		}
 	})
 
@@ -506,8 +519,10 @@ func TestLoggingRunnerRunStreaming(t *testing.T) {
 
 		base := &recordingRunner{err: errors.New("exit status 1")}
 		var exitCode int
+		var logs bytes.Buffer
 		r := LoggingRunner{
 			Base:           base,
+			Logger:         newTestLogger(&logs),
 			CaptureCommand: func(_ context.Context, _ string, _ []string, code int, _ int64) { exitCode = code },
 			AccessLog:      func(AccessLogEntry) {},
 		}
@@ -517,6 +532,9 @@ func TestLoggingRunnerRunStreaming(t *testing.T) {
 		}
 		if exitCode == 0 {
 			t.Fatal("expected a non-zero exit code in telemetry")
+		}
+		if !strings.Contains(logs.String(), "command failed") {
+			t.Fatalf("logs=%q", logs.String())
 		}
 	})
 }

--- a/internal/fork/fork_test.go
+++ b/internal/fork/fork_test.go
@@ -3,11 +3,123 @@ package fork
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/nicobistolfi/vigilante/internal/state"
 	"github.com/nicobistolfi/vigilante/internal/testutil"
 )
+
+func TestAuthenticatedOwner(t *testing.T) {
+	owner, err := AuthenticatedOwner(context.Background(), testutil.FakeRunner{Outputs: map[string]string{"gh api user": `{"login":" alice "}`}})
+	if err != nil || owner != "alice" {
+		t.Fatalf("owner=%q err=%v", owner, err)
+	}
+	for _, output := range []string{"not-json", `{"login":""}`} {
+		if _, err := AuthenticatedOwner(context.Background(), testutil.FakeRunner{Outputs: map[string]string{"gh api user": output}}); err == nil {
+			t.Fatalf("expected error for %q", output)
+		}
+	}
+	want := errors.New("auth failed")
+	if _, err := AuthenticatedOwner(context.Background(), testutil.FakeRunner{Errors: map[string]error{"gh api user": want}}); !errors.Is(err, want) {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestEnsureForkExistingRepositoryPaths(t *testing.T) {
+	base := map[string]string{"gh api repos/alice/repo": `{"full_name":"alice/repo","parent":{"full_name":"owner/repo"}}`}
+	if err := EnsureFork(context.Background(), testutil.FakeRunner{Outputs: base}, "owner/repo", "alice/repo", "alice", "alice"); err != nil {
+		t.Fatal(err)
+	}
+	wrong := map[string]string{"gh api repos/alice/repo": `{"full_name":"alice/repo","parent":{"full_name":"other/repo"}}`}
+	if err := EnsureFork(context.Background(), testutil.FakeRunner{Outputs: wrong}, "owner/repo", "alice/repo", "alice", "alice"); err == nil || !strings.Contains(err.Error(), "not a fork") {
+		t.Fatalf("error=%v", err)
+	}
+	broken := map[string]string{"gh api repos/alice/repo": `not-json`}
+	if err := EnsureFork(context.Background(), testutil.FakeRunner{Outputs: broken}, "owner/repo", "alice/repo", "alice", "alice"); err == nil || !strings.Contains(err.Error(), "parse gh api repos") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestRepositoryNotFoundClassification(t *testing.T) {
+	for _, err := range []error{errors.New("HTTP 404"), errors.New("repository Not Found")} {
+		if !isRepositoryNotFound(err) {
+			t.Errorf("not classified: %v", err)
+		}
+	}
+	for _, err := range []error{nil, errors.New("permission denied")} {
+		if isRepositoryNotFound(err) {
+			t.Errorf("misclassified: %v", err)
+		}
+	}
+}
+
+func TestPrepareTargetNoForkIsNoop(t *testing.T) {
+	target := state.WatchTarget{Repo: "owner/repo"}
+	got, err := PrepareTarget(context.Background(), testutil.FakeRunner{}, target)
+	if err != nil || got.Repo != target.Repo || got.ForkMode != target.ForkMode {
+		t.Fatalf("target=%#v err=%v", got, err)
+	}
+}
+
+func TestEnsureForkCreatesOrganizationFork(t *testing.T) {
+	r := &createForkRunner{}
+	if err := EnsureFork(context.Background(), r, "owner/repo", "acme/repo", "alice", "acme"); err != nil {
+		t.Fatal(err)
+	}
+	if !r.posted || r.lookups != 2 {
+		t.Fatalf("posted=%v lookups=%d calls=%#v", r.posted, r.lookups, r.calls)
+	}
+	want := "gh api --method POST repos/owner/repo/forks -f organization=acme"
+	if r.calls[1] != want {
+		t.Fatalf("create call=%q want %q", r.calls[1], want)
+	}
+}
+
+func TestConfigureWorktreeNoopAndErrors(t *testing.T) {
+	if err := ConfigureWorktree(context.Background(), testutil.FakeRunner{}, state.Session{}); err != nil {
+		t.Fatal(err)
+	}
+	for _, command := range []string{
+		"git config branch.branch.remote fork",
+		"git config branch.branch.merge refs/heads/branch",
+		"git config branch.branch.pushRemote fork",
+		"git config branch.branch.gh-merge-base main",
+	} {
+		r := testutil.FakeRunner{Outputs: map[string]string{
+			"git config branch.branch.remote fork": "ok", "git config branch.branch.merge refs/heads/branch": "ok",
+			"git config branch.branch.pushRemote fork": "ok", "git config branch.branch.gh-merge-base main": "ok",
+		}, Errors: map[string]error{command: errors.New("config failed")}}
+		if err := ConfigureWorktree(context.Background(), r, state.Session{WorktreePath: "/tmp", Branch: "branch", PushRemote: "fork", BaseBranch: "main"}); err == nil {
+			t.Errorf("expected error at %q", command)
+		}
+	}
+}
+
+type createForkRunner struct {
+	posted  bool
+	lookups int
+	calls   []string
+}
+
+func (r *createForkRunner) Run(_ context.Context, _ string, name string, args ...string) (string, error) {
+	key := testutil.Key(name, args...)
+	r.calls = append(r.calls, key)
+	if key == "gh api repos/acme/repo" {
+		r.lookups++
+		if !r.posted {
+			return "HTTP 404: Not Found", errors.New("HTTP 404: Not Found")
+		}
+		return `{"full_name":"acme/repo","parent":{"full_name":"owner/repo"}}`, nil
+	}
+	if key == "gh api --method POST repos/owner/repo/forks -f organization=acme" {
+		r.posted = true
+		return "", nil
+	}
+	return "", fmt.Errorf("unexpected command: %s", key)
+}
+func (*createForkRunner) LookPath(file string) (string, error) { return file, nil }
 
 func TestPrepareTargetReusesExistingForkAndConfiguresRemote(t *testing.T) {
 	runner := testutil.FakeRunner{

--- a/internal/github/comment_format_test.go
+++ b/internal/github/comment_format_test.go
@@ -104,3 +104,38 @@ func firstBodyLine(comment string) string {
 	}
 	return lines[1]
 }
+
+func TestCommentFormattingBoundaries(t *testing.T) {
+	for input, want := range map[int]int{-10: 0, 0: 0, 50: 50, 100: 100, 101: 100} {
+		if got := clampPercent(input); got != want {
+			t.Errorf("clamp(%d)=%d", input, got)
+		}
+	}
+	for input, want := range map[int]string{-1: "1 minute", 0: "1 minute", 1: "1 minute", 2: "2 minutes"} {
+		if got := formatMinutes(input); got != want {
+			t.Errorf("minutes(%d)=%q", input, got)
+		}
+	}
+	for _, tc := range []struct{ value, fallback, want string }{{"", "fallback", "fallback"}, {"  ", "fallback", "fallback"}, {" value ", "fallback", "value"}} {
+		if got := fallbackCommentValue(tc.value, tc.fallback); got != tc.want {
+			t.Errorf("fallback=%q", got)
+		}
+	}
+	for _, tc := range []struct {
+		resource RateLimitResource
+		want     int
+	}{{RateLimitResource{Limit: 100, Remaining: 40}, 60}, {RateLimitResource{Limit: 10, Remaining: 20}, 0}} {
+		if got := usedRequests(tc.resource); got != tc.want {
+			t.Errorf("used=%d", got)
+		}
+	}
+	if got := formatAbsoluteTime(time.Time{}); got != "unknown" {
+		t.Fatalf("zero time=%q", got)
+	}
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for reset, want := range map[time.Time]int{{}: 1, now.Add(-time.Minute): 1, now.Add(30 * time.Second): 1, now.Add(61 * time.Second): 2} {
+		if got := minutesUntil(now, reset); got != want {
+			t.Errorf("until %s=%d", reset, got)
+		}
+	}
+}

--- a/internal/github/sanitize_test.go
+++ b/internal/github/sanitize_test.go
@@ -1,10 +1,88 @@
 package ghcli
 
 import (
+	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestSanitizeBodyFlagFormsAndFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "body.md")
+	if err := os.WriteFile(path, []byte("Ready\n\nGenerated with Codex"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		tool string
+		args []string
+		want string
+	}{
+		{"gh", []string{"pr", "create", "--body=Ready\nGenerated with Gemini"}, "pr create --body=Ready"},
+		{"gh", []string{"pr", "edit", "--body-file=" + path}, "pr edit --body-file -"},
+		{"git", []string{"-C", "/tmp", "commit", "--message=Fix\nAuthored by Claude"}, "-C /tmp commit --message=Fix"},
+		{"git", []string{"commit", "--file", path}, "commit --file -"},
+	} {
+		args, stdin, err := SanitizeProxyInvocation(tc.tool, tc.args, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := strings.Join(args, " "); got != tc.want {
+			t.Errorf("args=%q want %q", got, tc.want)
+		}
+		if strings.Contains(tc.want, "-file -") || strings.Contains(tc.want, "--file -") {
+			body, _ := io.ReadAll(stdin)
+			if string(body) != "Ready" {
+				t.Errorf("body=%q", body)
+			}
+		}
+	}
+	if _, _, err := SanitizeProxyInvocation("gh", []string{"issue", "comment", "1", "--body-file", filepath.Join(dir, "missing")}, nil); err == nil {
+		t.Fatal("expected missing file error")
+	}
+	_, _, err := sanitizeFileOrStdinValue("-", errorReader{})
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("error=%v", err)
+	}
+	reader, _, err := sanitizeFileOrStdinValue("-", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(reader)
+	if len(body) != 0 {
+		t.Fatalf("body=%q", body)
+	}
+}
+
+func TestGitHubCommandRecognitionBoundaries(t *testing.T) {
+	for _, args := range [][]string{{"issue", "comment"}, {"--repo", "owner/repo", "pr", "create"}, {"pr", "edit"}} {
+		if !isGitHubBodyCommand(args) {
+			t.Errorf("not body command: %#v", args)
+		}
+	}
+	for _, args := range [][]string{nil, {"issue", "view"}, {"pr", "list"}} {
+		if isGitHubBodyCommand(args) {
+			t.Errorf("body command: %#v", args)
+		}
+	}
+	if !isGitHubAPIBodyCommand([]string{"api", "repos/owner/repo/pulls/1"}) || isGitHubAPIBodyCommand([]string{"api", "user"}) || isGitHubAPIBodyCommand(nil) {
+		t.Fatal("API recognition boundaries")
+	}
+	for _, tc := range []struct {
+		tool, flag string
+		want       bool
+	}{{"gh", "--repo", true}, {"gh", "--repo=x", false}, {"git", "--git-dir", true}, {"docker", "--config", false}} {
+		if got := proxyFlagNeedsValue(tc.tool, tc.flag); got != tc.want {
+			t.Errorf("flag %s/%s=%v", tc.tool, tc.flag, got)
+		}
+	}
+}
+
+type errorReader struct{}
+
+func (errorReader) Read([]byte) (int, error) { return 0, io.ErrUnexpectedEOF }
 
 func TestSanitizeGitHubVisibleTextRemovesAgentAttribution(t *testing.T) {
 	input := strings.Join([]string{

--- a/internal/hardening/hardening_test.go
+++ b/internal/hardening/hardening_test.go
@@ -2,11 +2,103 @@ package hardening
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestPackageJSONAndAuditBoundaryPaths(t *testing.T) {
+	var result Result
+	checkPackageJSON(filepath.Join(t.TempDir(), "missing.json"), "missing.json", &result)
+	if len(result.Findings) != 0 {
+		t.Fatalf("missing file findings=%#v", result.Findings)
+	}
+	dir := t.TempDir()
+	invalid := filepath.Join(dir, "package.json")
+	if err := os.WriteFile(invalid, []byte("bad"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	checkPackageJSON(invalid, "package.json", &result)
+	if len(result.Findings) != 1 || result.Findings[0].Check != "package-json-parse" {
+		t.Fatalf("parse findings=%#v", result.Findings)
+	}
+	deps := map[string]string{"blank": ""}
+	for i := 0; i < 12; i++ {
+		deps[fmt.Sprintf("pkg%02d", i)] = "^1.0.0"
+	}
+	result = Result{}
+	checkNonExactRanges(deps, "package.json", "dependencies", &result)
+	if len(result.Findings) != 1 || !strings.Contains(result.Findings[0].Message, "12 non-exact") || strings.Count(result.Findings[0].Message, "pkg") != 10 {
+		t.Fatalf("range finding=%#v", result.Findings)
+	}
+	result = Result{}
+	runNPMAudit(context.Background(), fakeRunner{outputs: map[string]string{"npm audit --json": "not-json"}}, dir, &result)
+	if !result.AuditRan || len(result.Findings) != 1 || result.Findings[0].Check != "npm-audit-parse" {
+		t.Fatalf("parse audit=%#v", result)
+	}
+	vulns := `{"vulnerabilities":{`
+	for i := 0; i < 17; i++ {
+		if i > 0 {
+			vulns += ","
+		}
+		vulns += fmt.Sprintf(`"pkg%02d":{"severity":"moderate"}`, i)
+	}
+	vulns += `}}`
+	result = Result{}
+	runNPMAudit(context.Background(), fakeRunner{outputs: map[string]string{"npm audit --json": vulns}}, dir, &result)
+	if len(result.Findings) != 1 || result.Findings[0].Severity != SeverityMedium || !strings.Contains(result.Findings[0].Message, "17 known") {
+		t.Fatalf("audit finding=%#v", result.Findings)
+	}
+	long := errors.New(strings.Repeat("x", 500))
+	if got := summarizeError(long); len(got) != 200 {
+		t.Fatalf("summary len=%d", len(got))
+	}
+	if summarizeError(errors.New(" short ")) != "short" {
+		t.Fatal("short summary")
+	}
+}
+
+func TestCIAuditPathPackageManagerBranches(t *testing.T) {
+	for _, pm := range []string{"pnpm", "yarn", "unknown"} {
+		t.Run(pm, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(dir, ".github", "workflows"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			writeFile(t, dir, ".github/workflows/ci.yaml", "steps:\n  - run: echo test\n")
+			// Directories and non-workflow files exercise the filters.
+			if err := os.MkdirAll(filepath.Join(dir, ".github", "workflows", "nested"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			writeFile(t, dir, ".github/workflows/notes.txt", "ignore")
+			var result Result
+			checkCIAuditPath(dir, pm, &result)
+			if len(result.Findings) != 2 || result.Findings[0].Check != "ci-deterministic-install" || result.Findings[1].Check != "ci-audit-step" {
+				t.Fatalf("findings=%#v", result.Findings)
+			}
+		})
+	}
+	for _, tc := range []struct{ pm, content string }{{"pnpm", "pnpm install --frozen-lockfile\npnpm audit"}, {"yarn", "yarn install --immutable\nyarn npm audit"}} {
+		dir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(dir, ".github", "workflows"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, dir, ".github/workflows/ci.yml", tc.content)
+		var result Result
+		checkCIAuditPath(dir, tc.pm, &result)
+		if len(result.Findings) != 0 {
+			t.Errorf("%s findings=%#v", tc.pm, result.Findings)
+		}
+	}
+	var result Result
+	checkCIAuditPath(t.TempDir(), "npm", &result)
+	if len(result.Findings) != 0 {
+		t.Fatalf("no CI findings=%#v", result.Findings)
+	}
+}
 
 type fakeRunner struct {
 	outputs map[string]string

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,76 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewDaemonLoggerWritesStructuredRecord(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "daemon.log")
+	logger, err := NewDaemonLogger(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logger.Info("started", "issue", 494)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	if !strings.Contains(text, "msg=started") || !strings.Contains(text, "issue=494") || !strings.Contains(text, "time=") {
+		t.Fatalf("log record=%q", text)
+	}
+}
+
+func TestNewDaemonLoggerRejectsInvalidParent(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(parent, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewDaemonLogger(filepath.Join(parent, "daemon.log")); err == nil {
+		t.Fatal("expected parent error")
+	}
+}
+
+func TestDiscardHandlerContract(t *testing.T) {
+	h := discardHandler{}
+	if h.Enabled(context.Background(), slog.LevelInfo) {
+		t.Fatal("discard handler enabled")
+	}
+	if err := h.Handle(context.Background(), slog.NewRecord(time.Now(), slog.LevelInfo, "ignored", 0)); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := h.WithAttrs([]slog.Attr{slog.String("key", "value")}).(discardHandler); !ok {
+		t.Fatal("WithAttrs changed handler")
+	}
+	if _, ok := h.WithGroup("group").(discardHandler); !ok {
+		t.Fatal("WithGroup changed handler")
+	}
+	Discard().Info("ignored")
+}
+
+func TestConfigureRetunesExistingWriter(t *testing.T) {
+	original := CurrentLimits()
+	t.Cleanup(func() { Configure(original, nil, nil) })
+	path := filepath.Join(t.TempDir(), "configured.log")
+	w := OpenWriter(path)
+	want := Limits{MaxFileSize: 8, MaxBackups: 1, MaxTotalSize: 64}
+	Configure(want, func() []string { return []string{path} }, nil)
+	if CurrentLimits() != want || w.limits != want {
+		t.Fatalf("limits current=%#v writer=%#v", CurrentLimits(), w.limits)
+	}
+	if got := livePaths(); len(got) != 1 || got[0] != path {
+		t.Fatalf("live paths=%#v", got)
+	}
+	if w.Path() != path {
+		t.Fatalf("path=%q", w.Path())
+	}
+	if n, err := Append(path, []byte("hello")); err != nil || n != 5 {
+		t.Fatalf("Append=%d, %v", n, err)
+	}
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,13 +1,124 @@
 package provider
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
 
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
 	"github.com/nicobistolfi/vigilante/internal/skill"
 	"github.com/nicobistolfi/vigilante/internal/state"
+	"github.com/nicobistolfi/vigilante/internal/testutil"
 )
+
+func TestCodexAndGeminiInvocations(t *testing.T) {
+	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
+	issue := ghcli.Issue{Number: 7, Title: "Demo", URL: "https://github.com/owner/repo/issues/7"}
+	session := state.Session{WorktreePath: "/tmp/worktree", Branch: "vigilante/issue-7"}
+	pr := ghcli.PullRequest{Number: 11, URL: "https://github.com/owner/repo/pull/11"}
+	checks := []ghcli.StatusCheckRoll{{Context: "test", Conclusion: "FAILURE"}}
+	for _, tc := range []struct {
+		id, name, display string
+		runtime           string
+		prefix, suffix    []string
+		dir               string
+	}{
+		{CodexID, "codex", "Codex", skill.RuntimeCodex, []string{"exec", "--cd", session.WorktreePath, "--dangerously-bypass-approvals-and-sandbox"}, nil, ""},
+		{GeminiID, "gemini", "Gemini CLI", skill.RuntimeGemini, []string{"--prompt"}, []string{"--yolo"}, session.WorktreePath},
+	} {
+		t.Run(tc.id, func(t *testing.T) {
+			p, err := Resolve(tc.id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if p.DisplayName() != tc.display || p.RequiredTools()[0] != tc.name {
+				t.Fatalf("provider=%s tools=%#v", p.DisplayName(), p.RequiredTools())
+			}
+			assert := func(got Invocation, prompt string) {
+				want := append(append(append([]string{}, tc.prefix...), prompt), tc.suffix...)
+				if got.Name != tc.name || got.Dir != tc.dir {
+					t.Fatalf("invocation=%#v", got)
+				}
+				assertInvocationArgs(t, got.Args, want)
+			}
+			got, err := p.BuildIssuePreflightInvocation(IssueTask{Target: target, Issue: issue, Session: session})
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert(got, skill.BuildIssuePreflightPrompt(target, issue, session))
+			got, err = p.BuildIssueInvocation(IssueTask{Target: target, Issue: issue, Session: session})
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert(got, skill.BuildIssuePromptForRuntime(tc.runtime, target, issue, session))
+			got, err = p.BuildConflictResolutionInvocation(ConflictTask{Target: target, Session: session, PR: pr})
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert(got, skill.BuildConflictResolutionPromptForRuntime(tc.runtime, target, session, pr))
+			got, err = p.BuildCIRemediationInvocation(CIRemediationTask{Target: target, Session: session, PR: pr, FailingChecks: checks})
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert(got, skill.BuildCIRemediationPromptForRuntime(tc.runtime, target, session, pr, checks))
+			create, err := p.BuildIssueCreateInvocation(IssueCreateTask{Target: target, Prompt: "new issue"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if create.Name != tc.name || (tc.id == GeminiID && create.Dir != target.Path) {
+				t.Fatalf("create=%#v", create)
+			}
+			packageRun, err := p.BuildPackageRemediationInvocation(PackageRemediationTask{Target: target, PRNumber: 11, PRBranch: "branch", FindingsCount: 2})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if packageRun.Name != tc.name || (tc.id == GeminiID && packageRun.Dir != target.Path) {
+				t.Fatalf("package=%#v", packageRun)
+			}
+		})
+	}
+}
+
+func TestValidateRuntimeCompatibilityUsesRunner(t *testing.T) {
+	p, err := Resolve(CodexID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateRuntimeCompatibility(context.Background(), testutil.FakeRunner{Outputs: map[string]string{"codex --version": "codex 0.114.0"}}, p); err != nil {
+		t.Fatal(err)
+	}
+	wantErr := errors.New("missing")
+	err = ValidateRuntimeCompatibility(context.Background(), testutil.FakeRunner{Errors: map[string]error{"codex --version": wantErr}}, p)
+	if !errors.Is(err, wantErr) || !strings.Contains(err.Error(), "detect codex CLI version") {
+		t.Fatalf("error=%v", err)
+	}
+	if got := describeCompatibility("unknown"); got != "unknown" {
+		t.Fatalf("description=%q", got)
+	}
+}
+
+func TestCompatibilityHelpersRejectInvalidInputs(t *testing.T) {
+	for _, raw := range []string{"1.2", "x.2.3", "1.x.3", "1.2.x"} {
+		if _, err := parseVersion(raw); err == nil {
+			t.Errorf("parseVersion(%q) unexpectedly succeeded", raw)
+		}
+	}
+	if _, err := compatibilityFor("unknown"); err == nil {
+		t.Fatal("expected missing compatibility contract error")
+	}
+	unknown := testProvider{id: "unknown"}
+	if err := ValidateVersionOutput(unknown, "unknown 1.2.3"); err == nil {
+		t.Fatal("expected unknown provider compatibility error")
+	}
+	if got := runtimeTool(unknown); got != "unknown" {
+		t.Fatalf("runtimeTool()=%q", got)
+	}
+	withTool := testProvider{id: "custom", tools: []string{"  custom-cli  "}}
+	if got := runtimeTool(withTool); got != "custom-cli" {
+		t.Fatalf("runtimeTool()=%q", got)
+	}
+}
 
 func TestResolveDefaultsToClaude(t *testing.T) {
 	selectedProvider, err := Resolve("")
@@ -484,7 +595,8 @@ func assertInvocationArgs(t *testing.T, got []string, want []string) {
 }
 
 type testProvider struct {
-	id string
+	id    string
+	tools []string
 }
 
 func (p testProvider) ID() string {
@@ -496,7 +608,7 @@ func (p testProvider) DisplayName() string {
 }
 
 func (p testProvider) RequiredTools() []string {
-	return nil
+	return p.tools
 }
 
 func (p testProvider) EnsureRuntimeInstalled(store *state.Store) error {

--- a/internal/runner/session_helpers_test.go
+++ b/internal/runner/session_helpers_test.go
@@ -1,0 +1,116 @@
+package runner
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/nicobistolfi/vigilante/internal/backend"
+	"github.com/nicobistolfi/vigilante/internal/environment"
+	ghcli "github.com/nicobistolfi/vigilante/internal/github"
+	"github.com/nicobistolfi/vigilante/internal/provider"
+	"github.com/nicobistolfi/vigilante/internal/state"
+	"github.com/nicobistolfi/vigilante/internal/testutil"
+)
+
+func TestSessionPullRequestTrackingHelpers(t *testing.T) {
+	for _, tc := range []struct {
+		session state.Session
+		want    string
+	}{
+		{state.Session{}, ""}, {state.Session{Branch: " branch "}, "branch"},
+		{state.Session{Branch: "branch", ForkOwner: "alice", PushRemote: "fork"}, "alice:branch"},
+		{state.Session{Branch: "branch", ForkOwner: "alice", PushRemote: "origin"}, "branch"},
+	} {
+		if got := sessionPullRequestHeadSelector(tc.session); got != tc.want {
+			t.Errorf("selector=%q want %q", got, tc.want)
+		}
+	}
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	pr := backend.PullRequest{Number: 42, URL: " url ", State: " OPEN ", BaseRefName: " main ", MergedAt: &now}
+	var session state.Session
+	session.Branch = "branch"
+	updateSessionPullRequestTracking(&session, pr)
+	if session.PullRequestNumber != 42 || session.PullRequestURL != "url" || session.PullRequestState != "OPEN" || session.PullRequestBaseBranch != "main" || session.PullRequestMergedAt != now.Format(time.RFC3339) {
+		t.Fatalf("session=%#v", session)
+	}
+	pr.MergedAt = nil
+	updateSessionPullRequestTracking(&session, pr)
+	if session.PullRequestMergedAt != "" {
+		t.Fatalf("mergedAt=%q", session.PullRequestMergedAt)
+	}
+	for _, tc := range []struct {
+		pr   backend.PullRequest
+		want bool
+	}{{backend.PullRequest{State: "open"}, true}, {backend.PullRequest{State: "closed", MergedAt: &now}, true}, {backend.PullRequest{State: "closed"}, false}} {
+		if got := pullRequestCountsAsCompletedImplementation(tc.pr); got != tc.want {
+			t.Errorf("counts=%v want %v", got, tc.want)
+		}
+	}
+}
+
+func TestProviderInvocationExecutionHelpers(t *testing.T) {
+	target := state.WatchTarget{Path: "/host/repo"}
+	session := state.Session{WorktreePath: "/host/worktree"}
+	invocation := provider.Invocation{Dir: "/host/worktree", Name: "codex", Args: []string{"exec", "--cd", "/host/worktree", "prompt /host/repo"}}
+	if got := providerInvocationForExecution(target, session, invocation); !reflect.DeepEqual(got, invocation) {
+		t.Fatalf("host invocation=%#v", got)
+	}
+	session.SandboxMode = true
+	session.SandboxContainerName = "sandbox-1"
+	want := provider.Invocation{Name: "docker", Args: []string{"exec", "-w", "/workspace", "sandbox-1", "codex", "exec", "--cd", "/workspace", "prompt /workspace"}}
+	if got := providerInvocationForExecution(target, session, invocation); !reflect.DeepEqual(got, want) {
+		t.Fatalf("sandbox invocation=%#v want %#v", got, want)
+	}
+	runner := testutil.FakeRunner{Outputs: map[string]string{"codex exec --cd /host/worktree prompt /host/repo": "ok"}}
+	session.SandboxMode = false
+	if got, err := runProviderInvocation(context.Background(), runner, target, session, invocation); err != nil || got != "ok" {
+		t.Fatalf("run=%q err=%v", got, err)
+	}
+}
+
+func TestFallbackSessionText(t *testing.T) {
+	if fallbackSessionText(" ", "fallback") != "fallback" || fallbackSessionText(" value ", "fallback") != " value " {
+		t.Fatal("fallback boundaries")
+	}
+}
+
+func TestMaintenanceSessionsSuccessAndProviderFailures(t *testing.T) {
+	t.Setenv("VIGILANTE_HOME", filepath.Join(t.TempDir(), ".vigilante"))
+	store := state.NewStore()
+	if err := store.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
+	session := state.Session{Repo: "owner/repo", RepoPath: "/tmp/repo", IssueNumber: 7, WorktreePath: "/tmp/worktree", Branch: "branch", Provider: "codex"}
+	pr := ghcli.PullRequest{Number: 17, URL: "https://github.com/owner/repo/pull/17"}
+	checks := []ghcli.StatusCheckRoll{{Context: "test", Conclusion: "FAILURE"}}
+	p, _ := provider.Resolve(provider.CodexID)
+	conflict, _ := p.BuildConflictResolutionInvocation(provider.ConflictTask{Target: target, Session: session, PR: pr})
+	ci, _ := p.BuildCIRemediationInvocation(provider.CIRemediationTask{Target: target, Session: session, PR: pr, FailingChecks: checks})
+	r := testutil.FakeRunner{Outputs: map[string]string{"codex --version": "codex 0.114.0", testutil.Key(conflict.Name, conflict.Args...): "resolved", testutil.Key(ci.Name, ci.Args...): "fixed"}}
+	env := &environment.Environment{Runner: r}
+	if err := RunConflictResolutionSession(context.Background(), env, store, nil, target, session, pr); err != nil {
+		t.Fatal(err)
+	}
+	if err := RunCIRemediationSession(context.Background(), env, store, nil, target, session, pr, checks); err != nil {
+		t.Fatal(err)
+	}
+	invalid := session
+	invalid.Provider = "unknown"
+	if err := RunConflictResolutionSession(context.Background(), env, store, nil, target, invalid, pr); err == nil {
+		t.Fatal("expected conflict provider error")
+	}
+	if err := RunCIRemediationSession(context.Background(), env, store, nil, target, invalid, pr, checks); err == nil {
+		t.Fatal("expected CI provider error")
+	}
+	badEnv := &environment.Environment{Runner: testutil.FakeRunner{Outputs: map[string]string{"codex --version": "codex 9.0.0"}}}
+	if err := RunConflictResolutionSession(context.Background(), badEnv, store, nil, target, session, pr); err == nil {
+		t.Fatal("expected conflict compatibility error")
+	}
+	if err := RunCIRemediationSession(context.Background(), badEnv, store, nil, target, session, pr, checks); err == nil {
+		t.Fatal("expected CI compatibility error")
+	}
+}

--- a/internal/sandbox/container/container_test.go
+++ b/internal/sandbox/container/container_test.go
@@ -116,3 +116,87 @@ func TestIsRunningReturnsFalseForMissing(t *testing.T) {
 		t.Error("expected running=false for missing container")
 	}
 }
+
+func TestContainerLifecycleAndInspection(t *testing.T) {
+	ctx := context.Background()
+	r := &fakeRunner{out: "started"}
+	if err := Start(ctx, r, "c1"); err != nil || r.calls[0] != "docker start c1" {
+		t.Fatalf("Start calls=%#v err=%v", r.calls, err)
+	}
+	r = &fakeRunner{out: "command output"}
+	if got, err := Exec(ctx, r, "c1", []string{"go", "test", "./..."}); err != nil || got != "command output" || r.calls[0] != "docker exec c1 go test ./..." {
+		t.Fatalf("Exec=%q calls=%#v err=%v", got, r.calls, err)
+	}
+	r = &fakeRunner{out: "id\n"}
+	if exists, err := Exists(ctx, r, "c1"); err != nil || !exists {
+		t.Fatalf("Exists=%v err=%v", exists, err)
+	}
+	r = &fakeRunner{err: fmt.Errorf("No such object")}
+	if exists, err := Exists(ctx, r, "missing"); err != nil || exists {
+		t.Fatalf("missing Exists=%v err=%v", exists, err)
+	}
+	r = &fakeRunner{out: "vigilante-sandbox-a\nvigilante-sandbox-b\n"}
+	if got, err := ListSandboxContainers(ctx, r); err != nil || len(got) != 2 || got[1] != "vigilante-sandbox-b" {
+		t.Fatalf("containers=%#v err=%v", got, err)
+	}
+	r = &fakeRunner{out: "  "}
+	if got, err := ListSandboxContainers(ctx, r); err != nil || got != nil {
+		t.Fatalf("empty containers=%#v err=%v", got, err)
+	}
+	r = &fakeRunner{out: `[{"State":{"Status":"running"},"Name":"c1"}]`}
+	if got, err := InspectStatus(ctx, r, "c1"); err != nil || got["Name"] != "c1" {
+		t.Fatalf("inspect=%#v err=%v", got, err)
+	}
+	for _, output := range []string{"not-json", "[]"} {
+		if _, err := InspectStatus(ctx, &fakeRunner{out: output}, "c1"); err == nil {
+			t.Fatalf("expected inspect error for %q", output)
+		}
+	}
+}
+
+func TestContainerErrorPaths(t *testing.T) {
+	ctx := context.Background()
+	boom := fmt.Errorf("docker unavailable")
+	for name, fn := range map[string]func(*fakeRunner) error{
+		"create": func(r *fakeRunner) error {
+			_, err := Create(ctx, r, Config{Name: "c", WorktreePath: "/tmp/repo", Image: "image"})
+			return err
+		},
+		"start":   func(r *fakeRunner) error { return Start(ctx, r, "c") },
+		"stop":    func(r *fakeRunner) error { return Stop(ctx, r, "c", 5) },
+		"remove":  func(r *fakeRunner) error { return Remove(ctx, r, "c") },
+		"list":    func(r *fakeRunner) error { _, err := ListSandboxContainers(ctx, r); return err },
+		"inspect": func(r *fakeRunner) error { _, err := InspectStatus(ctx, r, "c"); return err },
+	} {
+		if err := fn(&fakeRunner{out: "details", err: boom}); err == nil || !strings.Contains(err.Error(), "docker") {
+			t.Errorf("%s error=%v", name, err)
+		}
+	}
+	if running, err := IsRunning(ctx, &fakeRunner{err: boom}, "c"); err == nil || running {
+		t.Fatalf("IsRunning=%v err=%v", running, err)
+	}
+	if exists, err := Exists(ctx, &fakeRunner{err: boom}, "c"); err == nil || exists {
+		t.Fatalf("Exists=%v err=%v", exists, err)
+	}
+}
+
+func TestExtractArtifactsIncludesSuccessAndFailure(t *testing.T) {
+	r := &sequenceRunner{outputs: []string{"abc commit", "", "main"}, errors: []error{nil, fmt.Errorf("diff failed"), nil}}
+	got, err := ExtractArtifacts(context.Background(), r, "c1")
+	if err != nil || !strings.Contains(got, "abc commit") || !strings.Contains(got, "git failed: diff failed") || !strings.Contains(got, "main") {
+		t.Fatalf("artifacts=%q err=%v", got, err)
+	}
+}
+
+type sequenceRunner struct {
+	outputs []string
+	errors  []error
+	call    int
+}
+
+func (r *sequenceRunner) Run(_ context.Context, _ string, _ string, _ ...string) (string, error) {
+	i := r.call
+	r.call++
+	return r.outputs[i], r.errors[i]
+}
+func (*sequenceRunner) LookPath(file string) (string, error) { return file, nil }

--- a/internal/sandbox/proxy/proxy_test.go
+++ b/internal/sandbox/proxy/proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,68 @@ import (
 
 	"github.com/nicobistolfi/vigilante/internal/sandbox/token"
 )
+
+func TestProxyLifecycleAndRefresh(t *testing.T) {
+	key, _ := token.GenerateSigningKey()
+	p := New(key, &fakeRunner{}, slog.Default())
+	if p.Addr() != "" {
+		t.Fatalf("unstarted addr=%q", p.Addr())
+	}
+	entry := SessionEntry{SessionID: "session", Repository: "owner/repo", ExpiresAt: time.Now()}
+	p.RegisterSession(entry)
+	body, _ := json.Marshal(TokenRefreshRequest{SessionID: "session", ExtendSeconds: 60})
+	w := httptest.NewRecorder()
+	p.handleTokenRefresh(w, httptest.NewRequest(http.MethodPost, "/api/sandbox/token/refresh", bytes.NewReader(body)))
+	if w.Code != http.StatusOK || !p.sessions["session"].ExpiresAt.Equal(entry.ExpiresAt.Add(time.Minute)) {
+		t.Fatalf("refresh status=%d entry=%#v", w.Code, p.sessions["session"])
+	}
+	w = httptest.NewRecorder()
+	p.handleTokenRefresh(w, httptest.NewRequest(http.MethodPost, "/api/sandbox/token/refresh", strings.NewReader("bad")))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("bad refresh=%d", w.Code)
+	}
+	p.DeregisterSession("session")
+	w = httptest.NewRecorder()
+	p.handleTokenRefresh(w, httptest.NewRequest(http.MethodPost, "/api/sandbox/token/refresh", bytes.NewReader(body)))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("missing refresh=%d", w.Code)
+	}
+	if err := p.Start("127.0.0.1:0"); err != nil {
+		t.Fatal(err)
+	}
+	if p.Addr() == "" {
+		t.Fatal("started proxy has empty address")
+	}
+	if err := p.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGHEndpointInvalidMissingSessionAndRunnerError(t *testing.T) {
+	key, _ := token.GenerateSigningKey()
+	runner := &fakeRunner{err: fmt.Errorf("gh failed")}
+	p := New(key, runner, slog.Default())
+	w := httptest.NewRecorder()
+	p.handleGH(w, httptest.NewRequest(http.MethodPost, "/api/sandbox/gh", strings.NewReader("bad")))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("invalid=%d", w.Code)
+	}
+	tok, _ := token.Issue(key, token.Claims{SessionID: "missing", Repository: "owner/repo", ExpiresAt: time.Now().Add(time.Hour).Unix()})
+	body, _ := json.Marshal(GHRequest{Command: "issue list", Token: tok})
+	w = httptest.NewRecorder()
+	p.handleGH(w, httptest.NewRequest(http.MethodPost, "/api/sandbox/gh", bytes.NewReader(body)))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("missing=%d", w.Code)
+	}
+	p.RegisterSession(SessionEntry{SessionID: "missing", Repository: "owner/repo"})
+	w = httptest.NewRecorder()
+	p.handleGH(w, httptest.NewRequest(http.MethodPost, "/api/sandbox/gh", bytes.NewReader(body)))
+	var resp GHResponse
+	_ = json.NewDecoder(w.Body).Decode(&resp)
+	if w.Code != http.StatusOK || resp.ExitCode != 1 || !strings.Contains(resp.Stderr, "gh failed") {
+		t.Fatalf("status=%d response=%#v", w.Code, resp)
+	}
+}
 
 type fakeRunner struct {
 	lastArgs  []string

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -2,11 +2,111 @@ package sandbox
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestManagerSessionLifecycleHelpers(t *testing.T) {
+	r := &fakeRunner{}
+	m, err := NewManager(r, slog.Default(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.ProxyAddr() != "" {
+		t.Fatalf("unstarted proxy=%q", m.ProxyAddr())
+	}
+	if err := m.StartProxy("127.0.0.1:0"); err != nil {
+		t.Fatal(err)
+	}
+	if m.ProxyAddr() == "" {
+		t.Fatal("started proxy has no address")
+	}
+	defer m.StopProxy(context.Background())
+	sess := &Session{ID: "s1", ContainerName: "container-1", Status: "provisioned"}
+	m.sessions[sess.ID] = sess
+	if got, ok := m.GetSession("s1"); !ok || got != sess {
+		t.Fatalf("session=%#v ok=%v", got, ok)
+	}
+	if ids := m.ActiveSessions(); len(ids) != 1 || ids[0] != "s1" {
+		t.Fatalf("active=%#v", ids)
+	}
+	if err := m.Start(context.Background(), "s1"); err != nil || sess.Status != "running" {
+		t.Fatalf("status=%q err=%v calls=%#v", sess.Status, err, r.calls)
+	}
+	if err := m.StopContainer(context.Background(), "s1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.Start(context.Background(), "missing"); err == nil {
+		t.Fatal("expected missing start error")
+	}
+	if err := m.StopContainer(context.Background(), "missing"); err == nil {
+		t.Fatal("expected missing stop error")
+	}
+}
+
+func TestManagerTeardownAndReconcile(t *testing.T) {
+	r := &fakeRunner{}
+	m, err := NewManager(r, slog.Default(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	sshDir := filepath.Join(t.TempDir(), "ssh")
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	sess := &Session{ID: "s1", ContainerName: "vigilante-sandbox-s1", SSHKeyDir: sshDir, Status: "running"}
+	m.sessions[sess.ID] = sess
+	if err := m.Teardown(context.Background(), "s1", "test complete"); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := m.GetSession("s1"); ok || sess.Status != "terminated" {
+		t.Fatalf("session retained status=%q", sess.Status)
+	}
+	if _, err := os.Stat(sshDir); !os.IsNotExist(err) {
+		t.Fatalf("ssh dir still exists: %v", err)
+	}
+	if err := m.Teardown(context.Background(), "missing", "test"); err == nil {
+		t.Fatal("expected missing teardown error")
+	}
+	r.out = "vigilante-sandbox-orphan\n"
+	if err := m.ReconcileStale(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	joined := strings.Join(r.calls, "\n")
+	if !strings.Contains(joined, "docker stop") || !strings.Contains(joined, "docker rm") {
+		t.Fatalf("calls=%s", joined)
+	}
+}
+
+func TestManagerRunnerErrorPaths(t *testing.T) {
+	r := &fakeRunner{err: fmt.Errorf("docker failed")}
+	m, err := NewManager(r, slog.Default(), t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	m.sessions["s1"] = &Session{ID: "s1", ContainerName: "c1"}
+	if err := m.Start(context.Background(), "s1"); err == nil {
+		t.Fatal("expected start error")
+	}
+	if err := m.StopContainer(context.Background(), "s1"); err == nil {
+		t.Fatal("expected stop error")
+	}
+	if err := m.ReconcileStale(context.Background()); err == nil || !strings.Contains(err.Error(), "reconcile stale") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestProxyPortBoundaries(t *testing.T) {
+	for input, want := range map[string]int{"": 0, "invalid": 0, "127.0.0.1:notaport": 0, "127.0.0.1:9821": 9821} {
+		if got := proxyPort(input); got != want {
+			t.Errorf("proxyPort(%q)=%d want %d", input, got, want)
+		}
+	}
+}
 
 type fakeRunner struct {
 	calls []string

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -20,6 +20,86 @@ type recordingRunner struct {
 	calls []string
 }
 
+func TestServiceParsingHelpers(t *testing.T) {
+	for input, want := range map[string]string{
+		"ExecStart=/usr/local/bin/vigilante daemon run": "/usr/local/bin/vigilante",
+		"ExecStart=/usr/local/bin/vigilante --flag":     "/usr/local/bin/vigilante",
+		"ExecStart=": "", "Description=x": "",
+	} {
+		if got := parseSystemdExecutable(input); got != want {
+			t.Errorf("parseSystemdExecutable(%q)=%q want %q", input, got, want)
+		}
+	}
+	for input, want := range map[string]string{
+		"vigilante version v1.2.3": "1.2.3", "\n custom build\nmore": "custom build", "   ": "",
+	} {
+		if got := normalizeDaemonVersionOutput(input); got != want {
+			t.Errorf("normalize(%q)=%q want %q", input, got, want)
+		}
+	}
+	dir := t.TempDir()
+	launchd := filepath.Join(dir, "agent.plist")
+	if err := os.WriteFile(launchd, []byte(`<key>ProgramArguments</key><array><string>/Applications/Vigilante &amp; Tools/vigilante</string><string>daemon</string></array>`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := daemonExecutableFromServiceDefinition("darwin", launchd); err != nil || got != "/Applications/Vigilante & Tools/vigilante" {
+		t.Fatalf("launchd=%q err=%v", got, err)
+	}
+	unit := filepath.Join(dir, "vigilante.service")
+	if err := os.WriteFile(unit, []byte("[Service]\nExecStart=/bin/vigilante daemon run\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := daemonExecutableFromServiceDefinition("linux", unit); err != nil || got != "/bin/vigilante" {
+		t.Fatalf("systemd=%q err=%v", got, err)
+	}
+	if _, err := daemonExecutableFromServiceDefinition("windows", unit); err == nil {
+		t.Fatal("expected unsupported OS")
+	}
+	if _, err := daemonExecutableFromServiceDefinition("linux", filepath.Join(dir, "missing")); err == nil {
+		t.Fatal("expected read error")
+	}
+}
+
+func TestShellDerivedPath(t *testing.T) {
+	key := `/bin/zsh -lic printf "%s" "$PATH"`
+	got, err := shellDerivedPath(context.Background(), testutil.FakeRunner{Outputs: map[string]string{key: " /opt/bin:/usr/bin \n"}}, "/bin/zsh")
+	if err != nil || got != "/opt/bin:/usr/bin" {
+		t.Fatalf("path=%q err=%v", got, err)
+	}
+	if _, err := shellDerivedPath(context.Background(), testutil.FakeRunner{Outputs: map[string]string{key: " "}}, "/bin/zsh"); err == nil || !strings.Contains(err.Error(), "empty PATH") {
+		t.Fatalf("error=%v", err)
+	}
+	want := errors.New("shell failed")
+	if _, err := shellDerivedPath(context.Background(), testutil.FakeRunner{Errors: map[string]error{key: want}}, "/bin/zsh"); !errors.Is(err, want) {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestInstallSystemdUserService(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	store := state.NewStore()
+	cfg := Config{Executable: "/usr/bin/vigilante", PathEnv: "/usr/bin", HomeDir: home}
+	runner := testutil.FakeRunner{Outputs: map[string]string{"systemctl --user daemon-reload": "ok", "systemctl --user enable --now vigilante.service": "ok"}}
+	env := &environment.Environment{OS: "linux", Runner: runner}
+	if err := installSystemdUserService(context.Background(), env, store, cfg); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".config", "systemd", "user", systemdUnitName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "ExecStart=/usr/bin/vigilante daemon run") {
+		t.Fatalf("unit=%s", data)
+	}
+	for _, command := range []string{"systemctl --user daemon-reload", "systemctl --user enable --now vigilante.service"} {
+		r := testutil.FakeRunner{Outputs: runner.Outputs, Errors: map[string]error{command: errors.New("systemctl failed")}}
+		if err := installSystemdUserService(context.Background(), &environment.Environment{OS: "linux", Runner: r}, store, cfg); err == nil {
+			t.Errorf("expected failure for %q", command)
+		}
+	}
+}
+
 func (r *recordingRunner) Run(ctx context.Context, dir string, name string, args ...string) (string, error) {
 	r.calls = append(r.calls, testutil.Key(name, args...))
 	return r.FakeRunner.Run(ctx, dir, name, args...)

--- a/internal/state/coverage_test.go
+++ b/internal/state/coverage_test.go
@@ -1,0 +1,106 @@
+package state
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCoverageStateDefaultsAndHomeOverrides(t *testing.T) {
+	if got := (WatchTarget{}).EffectiveIssueStage(); got != "" {
+		t.Fatalf("github stage=%q", got)
+	}
+	if got := (WatchTarget{IssueBackend: "linear"}).EffectiveIssueStage(); got != "Todo" {
+		t.Fatalf("linear stage=%q", got)
+	}
+	if got := (WatchTarget{IssueStage: " Doing "}).EffectiveIssueStage(); got != "Doing" {
+		t.Fatalf("explicit stage=%q", got)
+	}
+	t.Setenv("VIGILANTE_HOME", t.TempDir())
+	t.Setenv("CODEX_HOME", "/tmp/codex")
+	t.Setenv("CLAUDE_HOME", "/tmp/claude")
+	t.Setenv("GEMINI_HOME", "/tmp/gemini")
+	t.Setenv("OPENCODE_HOME", "/tmp/opencode")
+	s := NewStore()
+	if s.CodexHome() != "/tmp/codex" || s.ClaudeHome() != "/tmp/claude" || s.GeminiHome() != "/tmp/gemini" || s.OpenCodeHome() != "/tmp/opencode" {
+		t.Fatal("home overrides")
+	}
+}
+
+func TestCoverageStateFileErrorPaths(t *testing.T) {
+	dir := t.TempDir()
+	rootFile := filepath.Join(dir, "root-file")
+	if err := os.WriteFile(rootFile, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("VIGILANTE_HOME", rootFile)
+	s := NewStore()
+	if err := s.EnsureLayout(); err == nil {
+		t.Fatal("expected layout error")
+	}
+	if ok, err := s.TryWithScanLock(func() error { return nil }); ok || err == nil {
+		t.Fatalf("lock=%v err=%v", ok, err)
+	}
+	missingParent := filepath.Join(dir, "missing", "array.json")
+	if err := ensureJSONArrayFile(missingParent); err == nil {
+		t.Fatal("expected array write error")
+	}
+	existing := filepath.Join(dir, "existing.json")
+	if err := os.WriteFile(existing, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureJSONArrayFile(existing); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureJSONFile(existing, map[string]string{"x": "y"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureJSONFile(filepath.Join(dir, "new.json"), map[string]string{"x": "y"}); err != nil {
+		t.Fatal(err)
+	}
+	var value map[string]string
+	if err := readJSONFile(filepath.Join(dir, "missing.json"), &value); err == nil {
+		t.Fatal("expected read error")
+	}
+	if err := writeJSONFile(filepath.Join(dir, "bad.json"), func() {}); err == nil {
+		t.Fatal("expected marshal error")
+	}
+	if err := writeJSONFile(filepath.Join(rootFile, "bad.json"), map[string]string{"x": "y"}); err == nil {
+		t.Fatal("expected mkdir error")
+	}
+	appendJSONLine(filepath.Join(dir, "ignored.log"), func() {})
+}
+
+func TestCoverageStateLoadErrorsAndLivePaths(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", root)
+	s := NewStore()
+	if err := s.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		path string
+		load func() error
+	}{
+		{s.watchlistPath(), func() error { _, err := s.LoadWatchTargets(); return err }},
+		{s.sessionsPath(), func() error { _, err := s.LoadSessions(); return err }},
+		{s.serviceConfigPath(), func() error { _, err := s.LoadServiceConfig(); return err }},
+	} {
+		if err := os.WriteFile(tc.path, []byte("bad"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := tc.load(); err == nil {
+			t.Errorf("expected load error for %s", tc.path)
+		}
+	}
+	paths := s.LiveLogPaths()
+	if len(paths) != 2 {
+		t.Fatalf("fallback live paths=%#v", paths)
+	}
+	want := errors.New("callback failed")
+	ok, err := s.TryWithScanLock(func() error { return want })
+	if !ok || !errors.Is(err, want) {
+		t.Fatalf("lock=%v err=%v", ok, err)
+	}
+}

--- a/internal/telemetry/helpers_test.go
+++ b/internal/telemetry/helpers_test.go
@@ -1,9 +1,136 @@
 package telemetry
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/nicobistolfi/vigilante/internal/state"
 )
+
+func TestCoverageClassifiersAndCommandParsers(t *testing.T) {
+	for _, tc := range []struct {
+		diagnostic, want string
+		retry, ok        bool
+	}{
+		{"secondary rate limit", "rate_limit", true, true}, {"HTTP 429", "rate_limit", true, true},
+		{"usage limit", "quota", false, true}, {"credits exhausted; purchase more", "quota", false, true}, {"ordinary error", "", false, false},
+	} {
+		got, retry, ok := classifyDownstreamRateLimit(state.BlockedReason{}, tc.diagnostic)
+		if got != tc.want || retry != tc.retry || ok != tc.ok {
+			t.Errorf("classify(%q)=(%q,%v,%v)", tc.diagnostic, got, retry, ok)
+		}
+	}
+	if got, retry, ok := classifyDownstreamRateLimit(state.BlockedReason{Kind: "provider_quota"}, ""); got != "quota" || retry || !ok {
+		t.Fatalf("provider quota=(%q,%v,%v)", got, retry, ok)
+	}
+	for _, tc := range []struct{ operation, kind, diagnostic, want string }{
+		{"gh pr view", "", "", "github"}, {"", "provider_quota", "", "provider"}, {"", "", "otlp failure", "telemetry_export"}, {"other", "", "", "unknown"},
+	} {
+		if got := downstreamServiceCategory(tc.operation, state.BlockedReason{Kind: tc.kind}, tc.diagnostic); got != tc.want {
+			t.Errorf("category=%q want %q", got, tc.want)
+		}
+	}
+	if boundedOperation("   ") != "unknown" || boundedOperation(" ok ") != "ok" || len(boundedOperation(strings.Repeat("x", 90))) != 80 {
+		t.Fatal("boundedOperation boundaries")
+	}
+	for category, want := range map[string]string{"git": "tool_proxy", "coding_agent": "coding_agent", "other": "internal_subprocess"} {
+		if got := internalCommandFeatureArea(category); got != want {
+			t.Errorf("feature=%q", got)
+		}
+	}
+	for group, want := range map[string]string{"setup": "setup", "watch": "watch_management", "status": "service_management", "daemon": "daemon", "cleanup": "cleanup", "resume": "issue_session", "gh": "tool_proxy", "help": "operator_cli", "weird": "operator_cli"} {
+		if got := commandFeatureArea(group); got != want {
+			t.Errorf("group %q=%q", group, got)
+		}
+	}
+	for _, tc := range []struct {
+		tool string
+		args []string
+		want string
+	}{
+		{"codex", []string{"--model", "gpt", "exec"}, "exec"}, {"codex", []string{"--help"}, "help"}, {"claude", []string{"--permission-mode", "plan", "doctor"}, "doctor"}, {"gemini", []string{"--prompt=hi", "mcp"}, "mcp"}, {"gemini", []string{"secret"}, ""},
+	} {
+		if got := internalCommandPath(tc.tool, tc.args); got != tc.want {
+			t.Errorf("path %s %#v=%q want %q", tc.tool, tc.args, got, tc.want)
+		}
+	}
+	for _, tc := range []struct {
+		tool string
+		args []string
+		want string
+	}{
+		{"gh", []string{"--repo", "owner/repo", "pr", "view"}, "pr view"}, {"git", []string{"-C", "/tmp", "worktree", "list"}, "worktree list"}, {"docker", []string{"--context=local", "compose", "up"}, "compose up"}, {"gh", []string{"--help"}, "help"}, {"git", nil, ""},
+	} {
+		if got := proxyCommandPath(tc.tool, tc.args); got != tc.want {
+			t.Errorf("proxy %s %#v=%q want %q", tc.tool, tc.args, got, tc.want)
+		}
+	}
+}
+
+func TestHTTPAnalyticsExporter(t *testing.T) {
+	var got analyticsBatch
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/batch/" || r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("request %s %#v", r.URL.Path, r.Header)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatal(err)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+	exporter := &httpAnalyticsExporter{baseURL: server.URL, apiKey: "key", client: server.Client()}
+	if err := exporter.Export(context.Background(), nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := exporter.Export(context.Background(), []analyticsEvent{{Event: "command"}}); err != nil {
+		t.Fatal(err)
+	}
+	if got.APIKey != "key" || len(got.Messages) != 1 {
+		t.Fatalf("batch=%#v", got)
+	}
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, " slow down ")
+	}))
+	defer bad.Close()
+	exporter.baseURL, exporter.client = bad.URL, bad.Client()
+	if err := exporter.Export(context.Background(), []analyticsEvent{{Event: "command"}}); err == nil || !strings.Contains(err.Error(), "slow down") {
+		t.Fatalf("error=%v", err)
+	}
+}
+
+func TestEnsureLocalStateCreateReuseAndInvalid(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "telemetry")
+	created, fresh, err := ensureLocalState(root)
+	if err != nil || !fresh || strings.TrimSpace(created.AnonymousID) == "" {
+		t.Fatalf("created=%#v fresh=%v err=%v", created, fresh, err)
+	}
+	reused, fresh, err := ensureLocalState(root)
+	if err != nil || fresh || reused.AnonymousID != created.AnonymousID {
+		t.Fatalf("reused=%#v fresh=%v err=%v", reused, fresh, err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "state.json"), []byte("not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := ensureLocalState(root); err == nil {
+		t.Fatal("expected invalid state error")
+	}
+	fileRoot := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(fileRoot, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := ensureLocalState(fileRoot); err == nil {
+		t.Fatal("expected root creation error")
+	}
+}
 
 // The command name becomes the telemetry event name, so it has to be stable and
 // must never carry user data. Flags and help tokens collapse rather than being

--- a/scripts/coverage-threshold
+++ b/scripts/coverage-threshold
@@ -14,4 +14,4 @@
 # the per-package figures it prints match `go test`'s own per-package output.
 #
 # Codecov reports lower still (line coverage, not statements). See codecov.yml.
-77.3
+82.6


### PR DESCRIPTION
## Summary

- add high-density behavioral coverage across provider construction, telemetry classification/export, GitHub command sanitization, logging, service/fork helpers, sandbox lifecycle, runner maintenance, state/hardening boundaries, and operator status/error paths
- introduce a behavior-preserving `cmd/gh-sandbox` seam that injects args/stdin/stdout/stderr while `main` retains the existing terminal-aware stdin behavior
- raise the local statement coverage ratchet from 77.3% to the cross-platform measured floor of 82.6% and refresh the coverage documentation

## Validation

- `task test`
- `task coverage` — 82.8% locally; threshold 82.6%
- Codecov — 80.05% (10,676 / 13,336 lines)
- `go vet ./...`
- `go test -race ./cmd/gh-sandbox ./internal/app ./internal/environment ./internal/fork ./internal/github ./internal/hardening ./internal/logging ./internal/provider ./internal/runner ./internal/sandbox/... ./internal/service ./internal/state ./internal/telemetry -count=1`
- `golangci-lint run` — 0 issues
- GitHub `build`, `verify`, and Workers checks — passing

## Known existing finding

- `govulncheck ./...` reports reachable advisory `GO-2026-6061` in existing dependency `google.golang.org/grpc@v1.80.0` (fixed in v1.82.1). This PR does not change dependencies; remediation is outside this coverage-only scope.

Closes #494