### PR TITLE
Infer recreate repo from current checkout

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -413,6 +413,13 @@ Expected behavior:
 - immediately launches a brand-new implementation session using the current watched-repo configuration
 - does not delete remote pull requests or remote branches
 
+### `vigilante recreate [--repo <owner/name>] --issue <n>`
+
+Recreate a stuck issue as a fresh duplicate and clean up its stale artifacts.
+`--issue` is always required. `--repo` may be omitted when the command runs
+inside a git checkout whose `origin` matches a repository Vigilante watches;
+an explicit `--repo` always takes precedence.
+
 ### `vigilante unwatch <path>`
 
 Remove a repository from the watchlist without deleting the repository itself.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1412,10 +1412,11 @@ func labelsToBackendLabels(names []string) []ghcli.Label {
 func (a *App) runRecreateCommand(ctx context.Context, args []string) error {
 	fs := flag.NewFlagSet("recreate", flag.ContinueOnError)
 	configureFlagSet(fs, func(w io.Writer) {
-		fmt.Fprintln(w, "usage: vigilante recreate --repo <owner/name> --issue <n>")
+		fmt.Fprintln(w, "usage: vigilante recreate [--repo <owner/name>] --issue <n>")
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, "Recreate a stuck issue as a fresh duplicate, close the original as not planned,")
 		fmt.Fprintln(w, "and clean up stale PR/branch/session artifacts.")
+		fmt.Fprintln(w, "When --repo is omitted, the repository is inferred from the current watched checkout.")
 		fmt.Fprintln(w)
 		fs.SetOutput(w)
 		fs.PrintDefaults()
@@ -1428,10 +1429,38 @@ func (a *App) runRecreateCommand(ctx context.Context, args []string) error {
 		}
 		return err
 	}
-	if *repo == "" || *issue <= 0 {
+	if *issue <= 0 {
 		return errors.New("usage: vigilante recreate --repo <owner/name> --issue <n>")
 	}
+	if *repo == "" {
+		resolved, err := a.resolveRepoSlugFromCWD(ctx)
+		if err != nil {
+			return err
+		}
+		*repo = resolved
+	}
 	return a.RecreateSession(ctx, *repo, *issue, "cli")
+}
+
+func (a *App) resolveRepoSlugFromCWD(ctx context.Context) (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("could not determine the current directory; supply --repo <owner/name>: %w", err)
+	}
+	repoSlug, err := repo.DiscoverSlug(ctx, a.env.Runner, wd)
+	if err != nil {
+		return "", fmt.Errorf("no repository could be inferred from the current directory; supply --repo <owner/name>: %w", err)
+	}
+	targets, err := a.state.LoadWatchTargets()
+	if err != nil {
+		return "", fmt.Errorf("load watch targets: %w", err)
+	}
+	for _, target := range targets {
+		if strings.EqualFold(target.Repo, repoSlug) {
+			return target.Repo, nil
+		}
+	}
+	return "", fmt.Errorf("repository %s inferred from the current directory is not watched by Vigilante; add it with vigilante watch or supply --repo", repoSlug)
 }
 
 func (a *App) runDaemonCommand(ctx context.Context, args []string) error {
@@ -6690,7 +6719,7 @@ func (a *App) printUsage(w io.Writer) {
 	fmt.Fprintln(w, "  vigilante cleanup --repo <owner/name> [--issue <n>]")
 	fmt.Fprintln(w, "  vigilante cleanup --all")
 	fmt.Fprintln(w, "  vigilante redispatch --repo <owner/name> --issue <n>")
-	fmt.Fprintln(w, "  vigilante recreate --repo <owner/name> --issue <n>")
+	fmt.Fprintln(w, "  vigilante recreate [--repo <owner/name>] --issue <n>")
 	fmt.Fprintln(w, "  vigilante resume --repo <owner/name> --issue <n>")
 	fmt.Fprintln(w, "  vigilante resume --all-blocked")
 	fmt.Fprintln(w, "  vigilante service restart")

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -9743,7 +9743,7 @@ func TestRecreateCommandParsing(t *testing.T) {
 	if exitCode != 0 {
 		t.Fatalf("expected exit code 0 for --help, got %d", exitCode)
 	}
-	if !strings.Contains(stdout.String(), "vigilante recreate --repo") {
+	if !strings.Contains(stdout.String(), "vigilante recreate [--repo") || !strings.Contains(stdout.String(), "inferred from the current watched checkout") {
 		t.Fatalf("expected usage text in help output, got: %s", stdout.String())
 	}
 }
@@ -9764,6 +9764,127 @@ func TestRecreateCommandMissingFlags(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "usage: vigilante recreate") {
 		t.Fatalf("expected usage error, got: %s", stderr.String())
+	}
+}
+
+func TestRecreateCommandInfersWatchedRepoFromCWD(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Chdir(home)
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{Outputs: mergeStringMaps(
+		map[string]string{
+			"git rev-parse --is-inside-work-tree": "true\n",
+			"git remote get-url origin":           "git@github.com:owner/repo.git\n",
+		},
+		recreateCommandOutputs("Owner/Repo", 70, 71),
+	)}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: home, Repo: "Owner/Repo"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if exitCode := app.Run(context.Background(), []string{"recreate", "--issue", "70"}); exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if !strings.Contains(stdout.String(), "recreated Owner/Repo issue #70 as #71") {
+		t.Fatalf("unexpected output: %s", stdout.String())
+	}
+}
+
+func TestRecreateCommandRejectsUnwatchedInferredRepo(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Chdir(home)
+
+	app := New()
+	var stderr bytes.Buffer
+	app.stdout = testutil.IODiscard{}
+	app.stderr = &stderr
+	app.env.Runner = testutil.FakeRunner{Outputs: map[string]string{
+		"git rev-parse --is-inside-work-tree": "true\n",
+		"git remote get-url origin":           "git@github.com:owner/unwatched.git\n",
+	}}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets(nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if exitCode := app.Run(context.Background(), []string{"recreate", "--issue", "70"}); exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "repository owner/unwatched") || !strings.Contains(stderr.String(), "not watched by Vigilante") {
+		t.Fatalf("unexpected error: %s", stderr.String())
+	}
+}
+
+func TestRecreateCommandRejectsNonGitCWD(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Chdir(home)
+
+	app := New()
+	var stderr bytes.Buffer
+	app.stdout = testutil.IODiscard{}
+	app.stderr = &stderr
+	app.env.Runner = testutil.FakeRunner{Errors: map[string]error{
+		"git rev-parse --is-inside-work-tree": errors.New("not a git repository"),
+	}}
+
+	if exitCode := app.Run(context.Background(), []string{"recreate", "--issue", "70"}); exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", exitCode)
+	}
+	if !strings.Contains(stderr.String(), "no repository could be inferred") || !strings.Contains(stderr.String(), "supply --repo") {
+		t.Fatalf("unexpected error: %s", stderr.String())
+	}
+}
+
+func TestRecreateCommandExplicitRepoTakesPrecedenceOverCWD(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+	t.Chdir(home)
+
+	app := New()
+	var stdout bytes.Buffer
+	app.stdout = &stdout
+	app.stderr = testutil.IODiscard{}
+	app.env.Runner = testutil.FakeRunner{Outputs: recreateCommandOutputs("explicit/repo", 70, 71)}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: home, Repo: "explicit/repo"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if exitCode := app.Run(context.Background(), []string{"recreate", "--repo", "explicit/repo", "--issue", "70"}); exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+	if !strings.Contains(stdout.String(), "recreated explicit/repo issue #70 as #71") {
+		t.Fatalf("unexpected output: %s", stdout.String())
+	}
+}
+
+func recreateCommandOutputs(repoSlug string, oldIssue int, newIssue int) map[string]string {
+	oldIssueText := fmt.Sprintf("%d", oldIssue)
+	newIssueText := fmt.Sprintf("%d", newIssue)
+	body := "body\n\n---\n_Recreated from #" + oldIssueText + " by Vigilante._"
+	return map[string]string{
+		"gh api repos/" + repoSlug + "/issues/" + oldIssueText: `{"title":"title","body":"body","html_url":"https://example.test/issue","state":"open","labels":[],"assignees":[]}`,
+		testutil.Key("gh", "api", "--method", "POST", "-H", "Accept: application/vnd.github+json", "repos/"+repoSlug+"/issues", "-f", "title=title", "-f", "body="+body):                                                                                                           `{"number":` + newIssueText + `,"html_url":"https://example.test/new"}`,
+		"gh issue comment --repo " + repoSlug + " " + oldIssueText + " --body ## ♻️ Issue Recreated\n\nThis issue has been recreated as #" + newIssueText + ".\n\nThe original issue is being closed as `not planned` and stale artifacts are being cleaned up.\n\nSource: `cli`.": "ok",
+		testutil.Key("gh", "api", "--method", "PATCH", "-H", "Accept: application/vnd.github+json", "repos/"+repoSlug+"/issues/"+oldIssueText, "-f", "state=closed", "-f", "state_reason=not_planned"):                                                                             "ok",
 	}
 }
 

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -90,15 +90,7 @@ func Discover(ctx context.Context, runner environment.Runner, path string) (Info
 	if err != nil {
 		return Info{}, err
 	}
-	if _, err := runner.Run(ctx, absPath, "git", "rev-parse", "--is-inside-work-tree"); err != nil {
-		return Info{}, fmt.Errorf("%s is not a git repository: %w", absPath, err)
-	}
-
-	remoteURL, err := runner.Run(ctx, absPath, "git", "remote", "get-url", "origin")
-	if err != nil {
-		return Info{}, fmt.Errorf("origin remote not found: %w", err)
-	}
-	repo, err := ParseGitHubRepo(strings.TrimSpace(remoteURL))
+	repo, err := DiscoverSlug(ctx, runner, absPath)
 	if err != nil {
 		return Info{}, err
 	}
@@ -114,6 +106,27 @@ func Discover(ctx context.Context, runner environment.Runner, path string) (Info
 		Branch:         branch,
 		Classification: Classify(absPath),
 	}, nil
+}
+
+// DiscoverSlug resolves the GitHub owner/name slug for a local git checkout.
+func DiscoverSlug(ctx context.Context, runner environment.Runner, path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	if _, err := runner.Run(ctx, absPath, "git", "rev-parse", "--is-inside-work-tree"); err != nil {
+		return "", fmt.Errorf("%s is not a git repository: %w", absPath, err)
+	}
+
+	remoteURL, err := runner.Run(ctx, absPath, "git", "remote", "get-url", "origin")
+	if err != nil {
+		return "", fmt.Errorf("origin remote not found: %w", err)
+	}
+	repo, err := ParseGitHubRepo(strings.TrimSpace(remoteURL))
+	if err != nil {
+		return "", err
+	}
+	return repo, nil
 }
 
 func ResolveBranch(ctx context.Context, runner environment.Runner, repoPath string, branchMode string, branch string) (string, error) {

--- a/internal/repo/repo_test.go
+++ b/internal/repo/repo_test.go
@@ -65,6 +65,22 @@ func TestDiscoverRepositoryWithRealGit(t *testing.T) {
 	}
 }
 
+func TestDiscoverSlugOnlyRunsCheckoutAndRemoteCommands(t *testing.T) {
+	dir := t.TempDir()
+	runner := environment.ExecRunner{}
+	ctx := context.Background()
+
+	mustRun(t, runner, ctx, dir, "git", "init", "--initial-branch=main")
+	mustRun(t, runner, ctx, dir, "git", "remote", "add", "origin", "git@github.com:owner/repo.git")
+	slug, err := DiscoverSlug(ctx, runner, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slug != "owner/repo" {
+		t.Fatalf("unexpected repo slug: %s", slug)
+	}
+}
+
 func TestClassifyTraditionalRepo(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/demo\n"), 0o644); err != nil {


### PR DESCRIPTION
## Summary

- infer a missing `recreate --repo` from the current git checkout
- require the inferred slug to match a watched repository case-insensitively
- preserve explicit repo precedence and mandatory issue validation
- document the optional repo flag and cover success/error paths

## Validation

- `go test ./internal/repo ./internal/app -count=1`
- `go test -race ./... -count=1`
- `go vet ./...`
- `golangci-lint run`
- `./scripts/coverage.sh` (77.4%, threshold 77.3%)
- `go build ./cmd/vigilante`

Closes #500