### PR TITLE
Stop redispatching blocked issues without human input

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4680,6 +4680,10 @@ func (a *App) cleanupInactiveBlockedSessions(ctx context.Context, sessions []sta
 		if session.Status != state.SessionStatusBlocked {
 			continue
 		}
+		if !isMaintenanceBlockedStage(session.BlockedStage) {
+			a.logger.Info("blocked session waiting for explicit resume", "repo", session.Repo, "issue", session.IssueNumber, "branch", session.Branch, "stage", session.BlockedStage)
+			continue
+		}
 
 		evaluationTimeout := timeout
 		if shouldAutoRecoverBlockedSession(*session) {
@@ -4810,9 +4814,7 @@ func (a *App) cleanupBlockedSessionForInactivity(ctx context.Context, session *s
 }
 
 func shouldAutoRecoverBlockedSession(session state.Session) bool {
-	switch session.BlockedStage {
-	case "pr_maintenance", "ci_remediation", "conflict_resolution":
-	default:
+	if !isMaintenanceBlockedStage(session.BlockedStage) {
 		return false
 	}
 
@@ -4822,6 +4824,15 @@ func shouldAutoRecoverBlockedSession(session state.Session) bool {
 
 	text := strings.ToLower(strings.TrimSpace(session.BlockedReason.Summary + " " + session.BlockedReason.Detail))
 	return strings.Contains(text, "worktree is not clean")
+}
+
+func isMaintenanceBlockedStage(stage string) bool {
+	switch strings.TrimSpace(stage) {
+	case "pr_maintenance", "ci_remediation", "conflict_resolution":
+		return true
+	default:
+		return false
+	}
 }
 
 func (a *App) autoRecoverBlockedMaintenanceSession(ctx context.Context, session *state.Session, timeout time.Duration) error {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -5268,7 +5268,7 @@ func TestBlockedDirtyWorktreeSessionSkipsAutoRecoveryBeforeTimeout(t *testing.T)
 	}
 }
 
-func TestScanOnceCleansUpBlockedSessionAfterDefaultInactivityTimeout(t *testing.T) {
+func TestScanOnceKeepsNonMaintenanceSessionBlockedAfterRepeatedInactivityTimeouts(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
 	t.Setenv("HOME", home)
@@ -5291,26 +5291,9 @@ func TestScanOnceCleansUpBlockedSessionAfterDefaultInactivityTimeout(t *testing.
 	app.clock = func() time.Time { return now }
 	app.env.Runner = testutil.FakeRunner{
 		Outputs: map[string]string{
-			"gh api repos/owner/repo/issues/1/comments":                  "[]",
-			"gh api repos/owner/repo/issues/1":                           "{}",
-			"git worktree prune":                                         "ok",
-			"git worktree remove --force " + worktreePath:                "ok",
-			"git worktree list --porcelain":                              "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
-			"git show-ref --verify --quiet refs/heads/vigilante/issue-1": "ok",
-			"git branch -D vigilante/issue-1":                            "Deleted branch vigilante/issue-1\n",
-			"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
-				Stage:      "Inactive Blocked Session Cleaned Up",
-				Emoji:      "🧹",
-				Percent:    100,
-				ETAMinutes: 1,
-				Items: []string{
-					"No qualifying user comments, session updates, or worktree changes were detected for `vigilante/issue-1` longer than `20m0s`.",
-					"Vigilante cleaned up the local blocked-session artifacts conservatively.",
-					"Next step: the issue is ready for a future redispatch in a fresh worktree.",
-				},
-				Tagline: "What is left idle grows loud.",
-			}): "ok",
-			"gh api user --jq .login": "nicobistolfi\n",
+			"gh api repos/owner/repo/issues/1/comments": "[]",
+			"gh api repos/owner/repo/issues/1":          "{\"labels\":[{\"name\":\"vigilante:blocked\"}]}",
+			"gh api user --jq .login":                   "nicobistolfi\n",
 			"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
 		},
 	}
@@ -5342,8 +5325,10 @@ func TestScanOnceCleansUpBlockedSessionAfterDefaultInactivityTimeout(t *testing.
 		t.Fatal(err)
 	}
 
-	if err := app.ScanOnce(context.Background()); err != nil {
-		t.Fatal(err)
+	for range 3 {
+		if err := app.ScanOnce(context.Background()); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	sessions, err := app.state.LoadSessions()
@@ -5353,11 +5338,123 @@ func TestScanOnceCleansUpBlockedSessionAfterDefaultInactivityTimeout(t *testing.
 	if len(sessions) != 1 {
 		t.Fatalf("unexpected sessions: %#v", sessions)
 	}
-	if sessions[0].Status != state.SessionStatusFailed || sessions[0].CleanupCompletedAt == "" || sessions[0].LastCleanupSource != "blocked_inactivity_timeout" {
-		t.Fatalf("expected blocked session cleanup to complete: %#v", sessions[0])
+	if sessions[0].Status != state.SessionStatusBlocked || sessions[0].CleanupCompletedAt != "" || sessions[0].LastCleanupSource != "" {
+		t.Fatalf("expected inactive session to remain blocked: %#v", sessions[0])
 	}
-	if sessions[0].BlockedStage != "" || sessions[0].ResumeRequired {
-		t.Fatalf("expected blocked state to be cleared after inactivity cleanup: %#v", sessions[0])
+	if sessions[0].BlockedStage != "issue_execution" || sessions[0].BlockedReason.Kind != "provider_auth" {
+		t.Fatalf("expected blocked state to remain intact: %#v", sessions[0])
+	}
+}
+
+func TestScanOnceStillCleansUpInactiveMaintenanceSession(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+	t.Setenv("HOME", home)
+
+	repoPath := filepath.Join(home, "repo")
+	worktreePath := filepath.Join(repoPath, ".worktrees", "vigilante", "issue-1")
+	if err := os.MkdirAll(worktreePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 3, 12, 18, 0, 0, 0, time.UTC)
+	old := now.Add(-45 * time.Minute)
+	if err := os.Chtimes(worktreePath, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.stdout = &bytes.Buffer{}
+	app.stderr = testutil.IODiscard{}
+	app.clock = func() time.Time { return now }
+	app.env.Runner = testutil.FakeRunner{Outputs: map[string]string{
+		"gh api repos/owner/repo/issues/1/comments":                  "[]",
+		"gh api repos/owner/repo/issues/1":                           "{}",
+		"git worktree prune":                                         "ok",
+		"git worktree remove --force " + worktreePath:                "ok",
+		"git worktree list --porcelain":                              "worktree " + repoPath + "\nHEAD abcdef\nbranch refs/heads/main\n",
+		"git show-ref --verify --quiet refs/heads/vigilante/issue-1": "ok",
+		"git branch -D vigilante/issue-1":                            "Deleted branch vigilante/issue-1\n",
+		"gh issue comment --repo owner/repo 1 --body " + ghcli.FormatProgressComment(ghcli.ProgressComment{
+			Stage:      "Inactive Blocked Session Cleaned Up",
+			Emoji:      "🧹",
+			Percent:    100,
+			ETAMinutes: 1,
+			Items: []string{
+				"No qualifying user comments, session updates, or worktree changes were detected for `vigilante/issue-1` longer than `20m0s`.",
+				"Vigilante cleaned up the local blocked-session artifacts conservatively.",
+				"Next step: the issue is ready for a future redispatch in a fresh worktree.",
+			},
+			Tagline: "What is left idle grows loud.",
+		}): "ok",
+		"gh api user --jq .login": "nicobistolfi\n",
+		"gh issue list --repo owner/repo --state open --assignee nicobistolfi --json number,title,createdAt,url,labels": "[]",
+	}}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveWatchTargets([]state.WatchTarget{{Path: repoPath, Repo: "owner/repo", Branch: "main", Assignee: "me"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.state.SaveSessions([]state.Session{{
+		RepoPath:     repoPath,
+		Repo:         "owner/repo",
+		IssueNumber:  1,
+		IssueTitle:   "first",
+		IssueURL:     "https://github.com/owner/repo/issues/1",
+		Branch:       "vigilante/issue-1",
+		WorktreePath: worktreePath,
+		Status:       state.SessionStatusBlocked,
+		BlockedAt:    old.Format(time.RFC3339),
+		BlockedStage: "pr_maintenance",
+		BlockedReason: state.BlockedReason{
+			Kind:    "provider_auth",
+			Summary: "session expired",
+		},
+		UpdatedAt: old.Format(time.RFC3339),
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := app.ScanOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.state.LoadSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 || sessions[0].Status != state.SessionStatusFailed || sessions[0].CleanupCompletedAt == "" {
+		t.Fatalf("expected maintenance session cleanup to complete: %#v", sessions)
+	}
+	if sessions[0].LastBlockedStage != "pr_maintenance" || sessions[0].BlockedStage != "" {
+		t.Fatalf("expected maintenance blocked stage to be preserved as history: %#v", sessions[0])
+	}
+}
+
+func TestCleanupInactiveBlockedSessionsRecordsMaintenanceEvaluationError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("VIGILANTE_HOME", filepath.Join(home, ".vigilante"))
+
+	app := New()
+	app.clock = func() time.Time { return time.Date(2026, 3, 12, 18, 0, 0, 0, time.UTC) }
+	app.env.Runner = testutil.FakeRunner{}
+	if err := app.state.EnsureLayout(); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := app.cleanupInactiveBlockedSessions(context.Background(), []state.Session{{
+		Repo:         "owner/repo",
+		IssueNumber:  1,
+		Branch:       "vigilante/issue-1",
+		Status:       state.SessionStatusBlocked,
+		BlockedStage: "pr_maintenance",
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 || sessions[0].Status != state.SessionStatusBlocked || sessions[0].LastError == "" {
+		t.Fatalf("expected evaluation error to be recorded without clearing the block: %#v", sessions)
 	}
 }
 
@@ -5489,7 +5586,7 @@ func TestScanOnceLeavesBlockedSessionVisibleWhenInactivityCleanupFails(t *testin
 		WorktreePath: worktreePath,
 		Status:       state.SessionStatusBlocked,
 		BlockedAt:    old.Format(time.RFC3339),
-		BlockedStage: "issue_execution",
+		BlockedStage: "pr_maintenance",
 		UpdatedAt:    old.Format(time.RFC3339),
 	}}); err != nil {
 		t.Fatal(err)

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -128,6 +128,9 @@ func SelectIssues(issues []Issue, sessions []state.Session, target state.WatchTa
 		if len(selected) >= limit {
 			break
 		}
+		if issueHasLabel(issues[i], "vigilante:blocked") {
+			continue
+		}
 		if active[issues[i].Number] {
 			continue
 		}
@@ -141,6 +144,15 @@ func SelectIssues(issues []Issue, sessions []state.Session, target state.WatchTa
 		active[issues[i].Number] = true
 	}
 	return selected
+}
+
+func issueHasLabel(issue Issue, name string) bool {
+	for _, label := range issue.Labels {
+		if strings.EqualFold(strings.TrimSpace(label.Name), name) {
+			return true
+		}
+	}
+	return false
 }
 
 func ActiveSessionCount(sessions []state.Session, target state.WatchTarget) int {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -104,6 +104,37 @@ func TestSelectIssuesHonorsRequestedLimit(t *testing.T) {
 	}
 }
 
+func TestSelectIssuesSkipsIssueWithBlockedLabelRegardlessOfLocalSession(t *testing.T) {
+	tests := []struct {
+		name     string
+		sessions []state.Session
+	}{
+		{name: "missing session"},
+		{
+			name: "stale failed session",
+			sessions: []state.Session{{
+				Repo:        "owner/repo",
+				IssueNumber: 1,
+				Status:      state.SessionStatusFailed,
+			}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			issues := []Issue{
+				{Number: 1, Labels: []Label{{Name: "vigilante:blocked"}, {Name: "to-do"}}},
+				{Number: 2, Labels: []Label{{Name: "to-do"}}},
+			}
+
+			selected := SelectIssues(issues, tc.sessions, state.WatchTarget{Repo: "owner/repo", Labels: []string{"to-do"}}, 2)
+			if len(selected) != 1 || selected[0].Number != 2 {
+				t.Fatalf("expected only unblocked issue to be selected, got %#v", selected)
+			}
+		})
+	}
+}
+
 func TestSelectIssuesHonorsConfiguredStageForLinearTargets(t *testing.T) {
 	issues := []Issue{
 		{Number: 1, Labels: []Label{{Name: "to-do"}}, Stage: "Todo"},


### PR DESCRIPTION
## Summary

- exclude issues carrying the live `vigilante:blocked` label from dispatch selection, independent of local session state
- keep non-maintenance blocked sessions blocked across inactivity scans until an explicit resume signal
- preserve existing maintenance cleanup and auto-recovery behavior
- add regression coverage for stale/missing sessions and repeated inactive scans

## Validation

- `go test -count=1 ./...`
- `go test -race -count=1 ./internal/github ./internal/app`
- `go vet ./...`
- `golangci-lint run`
- `gofmt -l .`
- `./scripts/coverage.sh` (77.3%, threshold 77.3%)

Closes #502