### PR TITLE
Confirm Claude model alias in launch comment

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -727,7 +727,7 @@ Initial rules:
 - count both running implementation sessions and open-PR maintenance sessions against that repository limit
 - avoid duplicate work across multiple daemon scans
 - allow an issue label that exactly matches a registered provider id, such as `codex`, `claude`, `gemini`, or `opencode`, to override the watch target provider for that issue only
-- allow `claude:sonnet`, `claude:opus`, or `claude:fable` to route to Claude and select that model alias for the persisted session
+- allow `claude:sonnet`, `claude:opus`, or `claude:fable` to route to Claude and select that model alias for the persisted session; the coding-agent launch comment echoes the active alias
 - allow bare `claude` together with one Claude model label; reject multiple Claude model labels or a Claude model label combined with another provider label
 - ignore unrecognized names such as `claude:haiku`, like any unrelated label
 - prefer oldest eligible open issue first unless later prioritization rules are added

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ vigilante setup -d
 For per-issue Claude model selection, add one of the human-managed labels
 `claude:sonnet`, `claude:opus`, or `claude:fable`. For example, labeling an
 issue `claude:opus` routes it to Claude and launches that session with
-`--model opus`; resumes keep the model captured when the session started.
+`--model opus`; resumes keep the model captured when the session started, and
+the coding-agent launch comment echoes the active model alias.
 
 ## Quick Start
 

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -213,7 +213,7 @@ func BuildIssuePromptForRuntime(runtime string, target state.WatchTarget, issue 
 		fmt.Sprintf("Branch: %s", session.Branch),
 		"Use `vigilante gh issue comment` to comment on the issue when you start working, post a concise implementation plan before substantial coding, add milestone progress comments as you make progress, comment again when the PR is opened, commit with `vigilante commit`, push the branch with `vigilante git push`, open a pull request with `vigilante gh pr create`, and report any execution failure back to the issue.",
 		fmt.Sprintf("When you open the pull request, the final PR body must include `Closes #%d` even if you write a custom summary or the summary is otherwise minimal.", issue.Number),
-		fmt.Sprintf("For the coding-agent start comment, use `## 🕹️ Coding Agent Launched: %s` instead of a generic session-start title.", displayProviderName(session.Provider)),
+		fmt.Sprintf("For the coding-agent start comment, use `## 🕹️ Coding Agent Launched: %s` instead of a generic session-start title.", displayProviderNameWithModel(session.Provider, session.Model)),
 		"For the coding-agent start comment, include a short GitHub issue-command hint block with at least `@vigilanteai resume` and `@vigilanteai cleanup`, and make clear that they are issue-comment commands rather than shell commands.",
 		"Use the same GitHub comment structure for every non-terminal milestone comment: a short header with the current stage and optional emoji, a 10-cell progress bar with percentage, an `ETA: ~N minutes` line, 1-3 concise bullets covering what just happened and what is next, and an optional short playful quote or tagline.",
 		"Use the issue as the source of truth for the requested behavior and keep the implementation minimal.",
@@ -625,6 +625,14 @@ func displayProviderName(name string) string {
 		parts[i] = strings.ToUpper(part[:1]) + strings.ToLower(part[1:])
 	}
 	return strings.Join(parts, " ")
+}
+
+func displayProviderNameWithModel(provider string, model string) string {
+	name := displayProviderName(provider)
+	if model = strings.TrimSpace(model); model != "" {
+		return fmt.Sprintf("%s (%s)", name, model)
+	}
+	return name
 }
 
 func BuildConflictResolutionPromptForRuntime(runtime string, target state.WatchTarget, session state.Session, pr ghcli.PullRequest) string {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -141,6 +141,38 @@ func TestBuildIssuePrompt(t *testing.T) {
 	}
 }
 
+func TestBuildIssuePromptLaunchTitleIncludesSelectedModel(t *testing.T) {
+	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo"}
+	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}
+	tests := []struct {
+		name     string
+		provider string
+		model    string
+		want     string
+	}{
+		{name: "Claude Sonnet", provider: "claude", model: "sonnet", want: "Coding Agent Launched: Claude Code (sonnet)"},
+		{name: "Claude Opus", provider: "claude", model: "opus", want: "Coding Agent Launched: Claude Code (opus)"},
+		{name: "Claude Fable", provider: "claude", model: "fable", want: "Coding Agent Launched: Claude Code (fable)"},
+		{name: "Claude Without Model", provider: "claude", want: "Coding Agent Launched: Claude Code`"},
+		{name: "Codex Without Model", provider: "codex", want: "Coding Agent Launched: Codex`"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session := state.Session{
+				WorktreePath: "/tmp/worktree",
+				Branch:       "vigilante/issue-12",
+				Provider:     tt.provider,
+				Model:        tt.model,
+			}
+			prompt := BuildIssuePromptForRuntime(RuntimeCodex, target, issue, session)
+			if !strings.Contains(prompt, tt.want) {
+				t.Fatalf("prompt missing %q: %s", tt.want, prompt)
+			}
+		})
+	}
+}
+
 func TestBuildIssuePromptIncludesReusedRemoteBranchContext(t *testing.T) {
 	target := state.WatchTarget{Path: "/tmp/repo", Repo: "owner/repo", Branch: "main"}
 	issue := ghcli.Issue{Number: 12, Title: "Fix bug", URL: "https://example.com/issues/12"}

--- a/skills/vigilante-issue-implementation/SKILL.md
+++ b/skills/vigilante-issue-implementation/SKILL.md
@@ -104,7 +104,7 @@ Service dependencies:
 ## GitHub Commenting Rules
 - Use `vigilante gh issue comment` for all issue updates.
 - Always comment when the session starts.
-- For the coding-agent start comment, use a distinct launch title such as `## 🕹️ Coding Agent Launched: Codex` instead of a generic `Session Start` header.
+- For the coding-agent start comment, use the distinct launch title supplied by Vigilante, such as `## 🕹️ Coding Agent Launched: Codex` or `## 🕹️ Coding Agent Launched: Claude Code (fable)`, instead of a generic `Session Start` header. When Vigilante supplies a model alias, preserve it in the title.
 - Always add a short implementation plan comment before substantial coding work begins.
 - Add progress comments for non-trivial implementations as milestones are reached.
 - Comment when the PR is opened.


### PR DESCRIPTION
## Summary
- include the persisted Claude model alias in the coding-agent launch title
- preserve provider-only titles when no model is selected
- document the visible alias and cover all supported aliases with tests

## Validation
- `go test -race -count=1 ./internal/skill/...`
- `go test -count=1 ./...`
- `go vet ./...`
- `golangci-lint run`

Closes #509