### PR TITLE
Implement CLI version reporting

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -34,6 +34,7 @@ import (
 	githubbackend "github.com/nicobistolfi/vigilante/internal/backend/github"
 	linearbackend "github.com/nicobistolfi/vigilante/internal/backend/linear"
 	"github.com/nicobistolfi/vigilante/internal/blocking"
+	"github.com/nicobistolfi/vigilante/internal/build"
 	"github.com/nicobistolfi/vigilante/internal/environment"
 	forkmode "github.com/nicobistolfi/vigilante/internal/fork"
 	ghcli "github.com/nicobistolfi/vigilante/internal/github"
@@ -108,13 +109,14 @@ const statusCommandUsage = "usage: vigilante status [--plain] [-w]"
 var cloneIntoPattern = regexp.MustCompile(`Cloning into (?:bare repository )?'([^']+)'`)
 
 type App struct {
-	stdin  io.Reader
-	stdout io.Writer
-	stderr io.Writer
-	state  *state.Store
-	logger *slog.Logger
-	clock  func() time.Time
-	env    *environment.Environment
+	stdin   io.Reader
+	stdout  io.Writer
+	stderr  io.Writer
+	state   *state.Store
+	logger  *slog.Logger
+	clock   func() time.Time
+	env     *environment.Environment
+	version string
 
 	issueTracker  backend.IssueTracker
 	labelManager  backend.LabelManager
@@ -212,6 +214,7 @@ func New() *App {
 		state:        store,
 		logger:       logger,
 		clock:        func() time.Time { return time.Now().UTC() },
+		version:      build.Version,
 		issueTracker: ghBackend,
 		labelManager: ghBackend,
 		prManager:    ghBackend,
@@ -680,6 +683,9 @@ func (a *App) runCommand(ctx context.Context, args []string) error {
 	}
 
 	switch args[0] {
+	case "version", "--version":
+		fmt.Fprintln(a.stdout, a.version)
+		return nil
 	case "commit":
 		return a.runCommitCommand(ctx, args[1:])
 	case "start":

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -297,6 +297,37 @@ func TestRunSupportsTopLevelHelpFlags(t *testing.T) {
 	}
 }
 
+func TestRunSupportsVersionCommands(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		arg     string
+		version string
+	}{
+		{name: "flag with stable version", arg: "--version", version: "1.2.0"},
+		{name: "command with nightly version", arg: "version", version: "0.0.0-nightly.20260814120000.abc123456789"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			app := New()
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			app.stdout = &stdout
+			app.stderr = &stderr
+			app.version = tt.version
+
+			exitCode := app.Run(context.Background(), []string{tt.arg})
+			if exitCode != 0 {
+				t.Fatalf("expected success exit code, got %d", exitCode)
+			}
+			if got, want := stdout.String(), tt.version+"\n"; got != want {
+				t.Fatalf("stdout = %q, want %q", got, want)
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("expected empty stderr, got %q", stderr.String())
+			}
+		})
+	}
+}
+
 func TestRunProxiesSupportedToolCommands(t *testing.T) {
 	app := New()
 	var stdout bytes.Buffer

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -48,6 +48,7 @@ type Status struct {
 	DaemonVersion string
 }
 
+var daemonNightlyVersionPattern = regexp.MustCompile(`\b0\.0\.0-nightly\.\d{14}\.([0-9a-fA-F]{12})\b`)
 var daemonVersionPattern = regexp.MustCompile(`\b(v?\d+\.\d+\.\d+)\b`)
 var launchdProgramArgumentsPattern = regexp.MustCompile(`(?s)<key>\s*ProgramArguments\s*</key>\s*<array>\s*<string>([^<]+)</string>`)
 
@@ -415,6 +416,9 @@ func normalizeDaemonVersionOutput(output string) string {
 	trimmed := strings.TrimSpace(output)
 	if trimmed == "" {
 		return ""
+	}
+	if match := daemonNightlyVersionPattern.FindStringSubmatch(trimmed); len(match) == 2 {
+		return match[1]
 	}
 	if match := daemonVersionPattern.FindStringSubmatch(trimmed); len(match) == 2 {
 		return strings.TrimPrefix(match[1], "v")

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -259,6 +259,28 @@ func TestServiceStatusReportsLaunchdRunning(t *testing.T) {
 	}
 }
 
+func TestNormalizeDaemonVersionOutput(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{name: "stable", output: "vigilante 1.2.3\n", want: "1.2.3"},
+		{name: "stable with v prefix", output: "vigilante v1.2.3\n", want: "1.2.3"},
+		{
+			name:   "nightly",
+			output: "0.0.0-nightly.20260814120000.abc123456789\n",
+			want:   "abc123456789",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeDaemonVersionOutput(tt.output); got != tt.want {
+				t.Fatalf("normalizeDaemonVersionOutput(%q) = %q, want %q", tt.output, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestServiceStatusReportsLaunchdStoppedWhenServiceIsUnloaded(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Summary

- implement top-level `vigilante --version` and `vigilante version` output using the link-time build version
- preserve stable semantic-version detection while surfacing nightly builds by their trailing short commit hash
- add focused coverage for stable and nightly CLI output and daemon-version normalization

## Validation

- `go test -count=1 ./internal/app ./internal/service`
- `go test -race -count=1 ./internal/app ./internal/service`
- `go test -count=1 ./...`
- `go vet ./...`
- `golangci-lint run`
- link-time `go run` smoke checks for stable and nightly version stamps

Closes #512