### PR TITLE
Restart the managed service automatically after a Homebrew upgrade

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -95,6 +95,22 @@ homebrew_casks:
     license: "Apache-2.0"
     binaries:
       - vigilante
+    # Homebrew performs an upgrade as uninstall-old + install-new, so this
+    # postflight runs after both a fresh install and an upgrade. Restarting
+    # through the newly staged binary points an already-installed launchd or
+    # systemd service at the new build instead of leaving the old process
+    # running until someone notices. On a machine that never ran
+    # `vigilante setup -d` there is no service to restart, so the command
+    # exits nonzero and `must_succeed: false` keeps the cask operation green.
+    hooks:
+      post:
+        install: |
+          vigilante_binary = "#{staged_path}/vigilante"
+          if File.executable?(vigilante_binary)
+            system_command vigilante_binary,
+                           args:         ["service", "restart"],
+                           must_succeed: false
+          end
 
 changelog:
   use: github-native

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Install with Homebrew:
 brew install --cask aliengiraffe/spaceship/vigilante
 ```
 
+Upgrading through Homebrew restarts the managed service for you, so
+`brew upgrade --cask vigilante` alone is enough — no follow-up
+`vigilante service restart` is needed. On a machine that has not run
+`vigilante setup -d` yet there is no service to restart and the install still
+succeeds.
+
 Requirements:
 
 - `git`

--- a/scripts/update-nightly-cask.sh
+++ b/scripts/update-nightly-cask.sh
@@ -63,6 +63,14 @@ cask "vigilante-nightly" do
       system_command "/usr/bin/codesign",
                      args:         ["--force", "--sign", "-", "#{staged_path}/vigilante"],
                      must_succeed: false
+      # Homebrew upgrades uninstall then reinstall, so this also runs on upgrade:
+      # point an already-installed managed service at the freshly staged binary.
+      vigilante_binary = "#{staged_path}/vigilante"
+      if File.executable?(vigilante_binary)
+        system_command vigilante_binary,
+                       args:         ["service", "restart"],
+                       must_succeed: false
+      end
     end
   end
 
@@ -70,6 +78,17 @@ cask "vigilante-nightly" do
     on_intel do
       url "https://github.com/aliengiraffe/vigilante/releases/download/${NIGHTLY_TAG}/${linux_amd64_archive}"
       sha256 "${linux_amd64_sha}"
+    end
+
+    postflight do
+      # Homebrew upgrades uninstall then reinstall, so this also runs on upgrade:
+      # point an already-installed managed service at the freshly staged binary.
+      vigilante_binary = "#{staged_path}/vigilante"
+      if File.executable?(vigilante_binary)
+        system_command vigilante_binary,
+                       args:         ["service", "restart"],
+                       must_succeed: false
+      end
     end
   end
 

--- a/scripts/update_nightly_cask_test.go
+++ b/scripts/update_nightly_cask_test.go
@@ -56,4 +56,19 @@ func TestUpdateNightlyCaskIncludesMacOSPostflightRemediation(t *testing.T) {
 			t.Fatalf("generated cask missing %q\n%s", want, body)
 		}
 	}
+
+	// Both platform blocks must restart the managed service so an upgrade never
+	// leaves the daemon running the previous binary, and the restart must be
+	// tolerant of a machine that never ran `vigilante setup -d`.
+	restart := strings.Join([]string{
+		`      vigilante_binary = "#{staged_path}/vigilante"`,
+		`      if File.executable?(vigilante_binary)`,
+		`        system_command vigilante_binary,`,
+		`                       args:         ["service", "restart"],`,
+		`                       must_succeed: false`,
+		`      end`,
+	}, "\n")
+	if got := strings.Count(body, restart); got != 2 {
+		t.Fatalf("generated cask has %d service restart blocks, want 2 (macOS and Linux)\n%s", got, body)
+	}
 }


### PR DESCRIPTION
## Summary

Homebrew implements an upgrade as uninstall-old + install-new, but neither Vigilante cask had a lifecycle hook that touched the running service — so after `brew upgrade --cask vigilante` the launchd/systemd user service kept executing the previous in-memory binary until someone ran `vigilante service restart` by hand, and `vigilante status`'s "daemon version" line silently disagreed with the installed binary.

This adds a post-install restart to both publication paths, invoking the already OS-aware `vigilante service restart` entrypoint rather than duplicating `launchctl`/`systemctl` calls in cask Ruby, so the restart logic stays in `internal/service/service.go`.

- **Stable cask** — `.goreleaser.yml`'s `homebrew_casks:` entry gains a `hooks.post.install` snippet. GoReleaser renders it as a single top-level `postflight do ... end`, so it covers macOS and Linux.
- **Nightly cask** — `scripts/update-nightly-cask.sh` gains the equivalent call in the existing macOS `postflight` (after the `codesign` step) plus a new `on_linux` `postflight`, so nightly matches stable on both platforms rather than being macOS-only.

The restart is guarded by `File.executable?` and uses `must_succeed: false`, mirroring the existing `xattr`/`codesign` convention. A fresh install on a machine that never ran `vigilante setup -d` has nothing to restart, so `Restart()` returns its `service is not installed` error, the nonzero exit is tolerated, and the cask operation completes without surfacing anything to the user.

`vigilante service restart` invoked directly by a user is untouched — no Go source behavior changed.

## Rendered stable cask

`goreleaser release --snapshot` now emits:

```ruby
  binary "vigilante"

  postflight do
    vigilante_binary = "#{staged_path}/vigilante"
    if File.executable?(vigilante_binary)
      system_command vigilante_binary,
                     args:         ["service", "restart"],
                     must_succeed: false
    end
  end
```

## Testing

- `goreleaser check` — passes.
- `goreleaser release --snapshot --clean` — confirmed the hook renders into `dist/homebrew/Casks/vigilante.rb` as shown above.
- `ruby -c` on both generated casks — Syntax OK.
- `brew style --cask` on both generated casks in a throwaway tap — **no new offenses**. The nightly cask reports 18 offenses both before and after this change (all pre-existing `Cask/StanzaOrder`/`StanzaGrouping` findings on the `on_intel`/`on_arm`/`url`/`sha256` stanzas); the stable cask's 4 offenses are likewise GoReleaser template layout artifacts, none touching the new `postflight`.
- `go test ./scripts/... -race -count=1` — passes. `scripts/update_nightly_cask_test.go` now asserts the generated nightly cask contains exactly two of the restart blocks (macOS and Linux), including `must_succeed: false`.
- `go vet ./...`, `gofmt -l`, `golangci-lint run ./scripts/...` — all clean.
- `govulncheck` not run: this change adds no dependencies and touches no Go source outside a test assertion.

Full end-to-end verification against a real `brew upgrade` of a published cask can only happen once a release ships, since it needs the generated cask in the tap.

## Notes

- The issue's implementation notes suggested putting the nightly restart only in the existing macOS `postflight`. I also added an `on_linux` `postflight`, because the nightly cask ships a Linux artifact and the GoReleaser-generated stable hook is platform-agnostic — without it, acceptance criterion 3 ("the same restart behavior is present for both") would not hold on Homebrew-on-Linux. Flag if you'd rather keep the nightly path macOS-only.
- `README.md`'s install section now notes the automatic restart, replacing the `brew upgrade --cask vigilante && vigilante service restart` two-step.

Closes #514