### PR TITLE
Distribute vigilante via pip (prebuilt-binary wheels)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Release
 
 # Builds, signs, and notarizes the macOS binaries with GoReleaser, then publishes
-# the GitHub release and the Homebrew cask.
+# the GitHub release and the Homebrew cask, and finally repackages the released
+# binaries into prebuilt PyPI wheels (see the pypi job below).
 #
 # Runs on macOS because signing needs Apple's native codesign/notarytool. The
 # Linux artifacts cross-compile from the same runner (everything is
@@ -102,3 +103,68 @@ jobs:
             echo "::warning::Apple notary credentials are not configured; the release will be signed but NOT notarized."
           fi
           goreleaser release --clean
+
+  # Repackages the already-published release archives into PyPI wheels
+  # (packaging/pypi/). Runs after `release`, so the GitHub release and the
+  # Homebrew cask are live before PyPI is attempted: a PyPI outage degrades to
+  # "this version is missing from PyPI" instead of blocking a signed release,
+  # while a failed upload still fails the workflow loudly.
+  #
+  # The Go binary is NEVER rebuilt here — a rebuild would be unsigned, not
+  # notarized, and would lack the ldflags version stamp and telemetry
+  # configuration. This job only needs to download, repackage, and upload, so
+  # it runs on ubuntu-latest with no Apple or OTEL secrets.
+  pypi:
+    needs: release
+    runs-on: ubuntu-latest
+    environment: main
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      # PyPI Trusted Publishing (OIDC). The trusted publisher on PyPI is
+      # scoped to this repository, this workflow file, and the `main`
+      # environment — see docs/releasing.md.
+      id-token: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.12'
+
+      - name: Download release archives
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          gh release download "$TAG_NAME" --repo "$GITHUB_REPOSITORY" \
+            --pattern 'vigilante_*.tar.gz' --dir release-archives
+
+      - name: Build wheels and sdist from released archives
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          python -m pip install --upgrade build
+          python packaging/pypi/build_wheels.py \
+            --version "${TAG_NAME#v}" \
+            --archives release-archives \
+            --out packaging/pypi/dist
+
+      # The pre-upload gate: exact py3-none-<platform> tags, the binary under
+      # <dist>.data/scripts/ with the executable bit, zero .py files, and
+      # Root-Is-Purelib: false. A wheel that silently reverted to
+      # py3-none-any would install a non-functional binary on every platform.
+      - name: Verify wheel and sdist contents
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          python packaging/pypi/check_wheel.py \
+            --dist packaging/pypi/dist \
+            --version "${TAG_NAME#v}"
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: packaging/pypi/dist

--- a/DOCS.md
+++ b/DOCS.md
@@ -55,6 +55,16 @@ Install with Homebrew:
 brew install --cask aliengiraffe/spaceship/vigilante
 ```
 
+Or from PyPI (macOS arm64/x86_64, Linux x86_64) — the wheel ships the same
+prebuilt `vigilante` binary, and the command name is unchanged:
+
+```sh
+pipx install vigilante-cli   # or: pip install vigilante-cli / uv tool install vigilante-cli
+```
+
+Either way, `git`, an authenticated `gh`, and a coding-agent CLI must be
+installed separately — see the requirements below.
+
 Prepare the local machine. `--provider` defaults to `claude`, so pass the flag only when you want a different coding agent:
 
 ```sh
@@ -239,6 +249,25 @@ Upgrade later with:
 ```sh
 brew upgrade --cask vigilante
 ```
+
+Or install from PyPI with a Python package manager:
+
+```sh
+pip install vigilante-cli
+pipx install vigilante-cli
+uv tool install vigilante-cli
+```
+
+The PyPI distribution is named `vigilante-cli` because `vigilante` on PyPI
+belongs to an unrelated project; the installed command is still `vigilante`.
+Each wheel contains no Python code — it embeds the prebuilt (and, on macOS,
+signed and notarized) release binary, which pip places on `PATH`. Wheels are
+published for macOS arm64, macOS x86_64, and Linux x86_64. On unsupported
+platforms (Windows, Linux arm64) the install fails with instructions pointing
+at Homebrew and the GitHub releases page rather than installing a broken
+package. pip installs the binary only: `git`, an authenticated `gh`, and a
+coding-agent CLI remain prerequisites, and `vigilante setup -d` is still the
+bootstrap step.
 
 ### `vigilante watch [--assignee <value>] [--max-parallel <value>] [--provider <codex|claude|gemini|opencode>] [--issue-tracker <github|linear>] [--issue-tracker-stage <value>] [--branch <name> | --track-default-branch] <path>`
 
@@ -562,6 +591,7 @@ Tagged releases are built and published with GoReleaser. Pushing a version tag t
 - `linux/amd64`
 - a `checksums.txt` file for the published archives
 - an updated Homebrew cask in the `aliengiraffe/homebrew-spaceship` tap so `brew install --cask aliengiraffe/spaceship/vigilante` installs the tagged release
+- prebuilt-binary wheels and an sdist on PyPI as `vigilante-cli`, repackaged from the published release archives after the GitHub release and cask are live (see [docs/releasing.md](docs/releasing.md))
 
 The release workflow requires a GitHub App that can write to the tap repository:
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,23 @@ Upgrading through Homebrew restarts the managed service for you, so
 `vigilante setup -d` yet there is no service to restart and the install still
 succeeds.
 
+Or install from PyPI with `pip`, `pipx`, or `uv`. The wheels ship the same
+prebuilt (and, on macOS, signed) `vigilante` binary the GitHub release
+carries — no Go toolchain and no Python wrapper involved:
+
+```sh
+pipx install vigilante-cli   # or: pip install vigilante-cli / uv tool install vigilante-cli
+```
+
+The distribution is named `vigilante-cli` (the `vigilante` name on PyPI
+belongs to an unrelated project); the installed command is still `vigilante`.
+Wheels exist for macOS arm64, macOS x86_64, and Linux x86_64 — on other
+platforms (Windows, Linux arm64) the install fails with pointers to Homebrew
+and the [releases page](https://github.com/aliengiraffe/vigilante/releases).
+Homebrew remains the recommended path on macOS; pip/pipx suit Linux hosts,
+containers, and Python-managed toolchains. Note that pip delivers the binary
+only — the requirements below still apply.
+
 Requirements:
 
 - `git`

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -21,6 +21,8 @@ day-to-day release flow, and how to verify a published artifact.
 | `vigilante_<version>_Linux_amd64.tar.gz` | unsigned, unchanged |
 | `gh-sandbox_<version>_Linux_{amd64,arm64}.tar.gz` | unsigned, unchanged |
 | `checksums.txt` | covers all of the above |
+| `vigilante_cli-<version>-py3-none-{macosx_11_0_arm64,macosx_10_13_x86_64,manylinux2014_x86_64}.whl` | PyPI wheels repackaging the three `vigilante` archives above |
+| `vigilante_cli-<version>.tar.gz` (sdist) | PyPI fallback that fails loudly on unsupported platforms |
 
 macOS binaries are signed with our **Apple Developer ID Application**
 certificate under the hardened runtime and notarized by Apple's notary service,
@@ -275,10 +277,117 @@ git push origin v1.2.0
 ```
 
 The `Release` workflow runs on `macos-latest`, signs and notarizes, publishes the
-GitHub release, and updates the `vigilante` Homebrew cask.
+GitHub release, and updates the `vigilante` Homebrew cask. A second job then
+publishes the PyPI artifacts (next section).
 
 Nightlies need no action: every push to `main` republishes the rolling
-`main-nightly` prerelease and the `vigilante-nightly` cask.
+`main-nightly` prerelease and the `vigilante-nightly` cask. Nightlies do not
+publish to PyPI — only tagged releases do.
+
+## PyPI wheels (`vigilante-cli`)
+
+Every tagged release also publishes **prebuilt-binary wheels** to PyPI so
+`pip install vigilante-cli`, `pipx install vigilante-cli`, and
+`uv tool install vigilante-cli` place the `vigilante` binary on `PATH` with no
+Go toolchain and no Python shim. The machinery lives in
+[`packaging/pypi/`](../packaging/pypi/) and the `pypi` job of
+[`release.yml`](../.github/workflows/release.yml).
+
+The distribution is named **`vigilante-cli`** because the `vigilante` name on
+PyPI belongs to an unrelated project (see issue #516, where the decision is
+recorded). The command users run is still `vigilante` — the wheel stages the
+binary in `vigilante_cli-<version>.data/scripts/`, the standard wheel location
+pip copies onto `PATH` with the executable bit set.
+
+How the job works, and the invariants it protects:
+
+- It runs **after** the `release` job, on `ubuntu-latest`, and downloads the
+  **already-published archives** with `gh release download`. The Go binary is
+  **never rebuilt** during packaging: a rebuild would be unsigned, not
+  notarized, and would lack the ldflags version stamp and telemetry
+  configuration, and the packaging job deliberately has no access to those
+  secrets.
+- Ordering is intentional: by the time PyPI is attempted, the GitHub release
+  and the Homebrew cask are live. A PyPI outage therefore degrades to "this
+  version is missing from PyPI" — it can never abort a signed release. The
+  failed job still fails the workflow run, so it is visible, and it can be
+  re-run from the Actions UI once PyPI recovers.
+- `packaging/pypi/build_wheels.py` builds one sdist plus one wheel per
+  GoReleaser target (`macosx_11_0_arm64`, `macosx_10_13_x86_64`,
+  `manylinux2014_x86_64` — honest because the binary is `CGO_ENABLED=0` and
+  fully static). The PyPI version is the tag with the leading `v` stripped and
+  must match the version embedded in the downloaded archive names, so a
+  tag/artifact mismatch fails the job instead of publishing a mislabeled wheel.
+- `packaging/pypi/check_wheel.py` gates the upload: each wheel must carry
+  exactly its `py3-none-<platform>` tag, contain the binary under
+  `.data/scripts/` with the executable bit recorded, contain **zero `.py`
+  files** and no entry points, and say `Root-Is-Purelib: false`. The worst
+  regression this guards against is a wheel silently reverting to
+  `py3-none-any`, which pip would serve to every platform.
+- The **sdist is a loud-failure fallback**, not a build path. On platforms
+  with no matching wheel (Windows, Linux arm64) pip falls back to the sdist,
+  whose build aborts with a message naming the Homebrew cask command and the
+  GitHub releases page. It never installs a no-op package and never tries to
+  compile Go.
+
+### Credential: PyPI Trusted Publishing
+
+The job authenticates with **Trusted Publishing** (OIDC) — no long-lived PyPI
+token is stored anywhere. One-time maintainer setup on
+<https://pypi.org/manage/account/publishing/> (or the project's *Publishing*
+settings once it exists): add a trusted publisher for
+
+| Field | Value |
+|---|---|
+| Owner / repository | `aliengiraffe/vigilante` |
+| Workflow filename | `release.yml` |
+| Environment | `main` |
+
+That is why the `pypi` job carries `id-token: write` in a job-level
+`permissions` block (the workflow default stays `contents: write` untouched)
+and runs in the `main` environment. If Trusted Publishing ever has to be
+replaced with an API token, store it as a `PYPI_API_TOKEN` secret in the
+`main` environment and pass it to the publish action — do not widen workflow
+permissions for it.
+
+### Rehearsing and verifying
+
+Rehearse against **Test PyPI** before the first production tag (and after any
+change to `packaging/pypi/`): add a second trusted publisher on
+<https://test.pypi.org>, point the publish step at it temporarily
+(`repository-url: https://test.pypi.org/legacy/`), and run the install matrix
+against the uploaded artifacts. Remember that a published PyPI version can
+never be reused — a botched upload costs a new patch version, not a
+re-upload.
+
+The packaging machinery itself can be rehearsed locally without touching any
+index:
+
+```bash
+python3 -m venv /tmp/venv && /tmp/venv/bin/pip install build
+gh release download v1.2.3 --pattern 'vigilante_*.tar.gz' --dir /tmp/archives
+/tmp/venv/bin/python packaging/pypi/build_wheels.py \
+  --version 1.2.3 --archives /tmp/archives --out /tmp/pypi-dist
+/tmp/venv/bin/python packaging/pypi/check_wheel.py \
+  --dist /tmp/pypi-dist --version 1.2.3
+/tmp/venv/bin/pip install /tmp/pypi-dist/vigilante_cli-1.2.3-py3-none-macosx_11_0_arm64.whl
+file /tmp/venv/bin/vigilante   # Mach-O/ELF executable, not a Python script
+/tmp/venv/bin/vigilante --help
+```
+
+On a macOS machine that has never seen the binary, also confirm the
+pip-installed `vigilante` runs without a Gatekeeper prompt: the Developer ID
+signature travels inside the wheel byte-for-byte, but a bare CLI binary's
+notarization is validated online (see the stapling note above), so execution
+is the only conclusive check — the same rule as for the release archives.
+
+### Platform coverage
+
+Wheels exist only for the current GoReleaser matrix (macOS arm64/x86_64,
+Linux x86_64). Adding `linux/arm64` or Windows wheels requires adding those
+targets to `.goreleaser.yml` first and is deliberately out of scope here;
+`packaging/pypi/check_wheel.py` carries the target table that would need to
+grow with it.
 
 ## Local validation
 

--- a/packaging/pypi/.gitignore
+++ b/packaging/pypi/.gitignore
@@ -1,0 +1,6 @@
+# Build outputs and the binary staged by build_wheels.py; nothing under
+# scripts/ is ever committed — the wheel payload comes from release archives.
+/build/
+/dist/
+/*.egg-info/
+/scripts/

--- a/packaging/pypi/MANIFEST.in
+++ b/packaging/pypi/MANIFEST.in
@@ -1,0 +1,3 @@
+# The sdist must never carry a staged binary: it exists only to fail loudly
+# on platforms with no prebuilt wheel (see setup.py).
+exclude scripts/vigilante

--- a/packaging/pypi/README.md
+++ b/packaging/pypi/README.md
@@ -1,0 +1,26 @@
+# vigilante-cli
+
+Prebuilt-binary distribution of [Vigilante](https://github.com/aliengiraffe/vigilante),
+the autonomous GitHub issue runner for headless coding agents.
+
+Each wheel contains no Python code — it ships the already-signed `vigilante`
+Go binary for its platform, which pip places on `PATH`:
+
+```sh
+pipx install vigilante-cli   # or: pip install / uv tool install
+vigilante --help
+```
+
+Prebuilt wheels exist for macOS arm64, macOS x86_64, and Linux x86_64. On
+other platforms (Windows, Linux arm64) installation fails with instructions;
+use Homebrew or a [GitHub release archive](https://github.com/aliengiraffe/vigilante/releases)
+instead:
+
+```sh
+brew install --cask aliengiraffe/spaceship/vigilante
+```
+
+Installing the package delivers the binary only. Vigilante still requires
+`git`, an authenticated `gh`, and a locally installed coding-agent CLI
+(`claude` by default, or `codex`, `gemini`, `opencode`) — see the
+[README](https://github.com/aliengiraffe/vigilante#install) for setup.

--- a/packaging/pypi/build_wheels.py
+++ b/packaging/pypi/build_wheels.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Assemble the vigilante PyPI artifacts from already-released archives.
+
+Builds one sdist plus one platform wheel per GoReleaser target, staging the
+binary extracted from each published release archive. It never compiles Go:
+the released binaries carry the Developer ID signature, notarization, and the
+ldflags version stamp, and a rebuild here would silently lose all three.
+
+The expected archive filenames embed the release version, so looking them up
+by name doubles as the tag/artifact consistency check: a mismatch fails the
+release instead of publishing a mislabeled wheel.
+
+Usage: build_wheels.py --version <pep440-version> --archives <dir> --out <dir>
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from check_wheel import TARGETS, dist_name  # noqa: E402
+
+HERE = Path(__file__).resolve().parent
+STAGED_BINARY = HERE / "scripts" / "vigilante"
+
+
+def run_build(kind, out_dir, env_extra):
+    env = dict(os.environ)
+    env.update(env_extra)
+    subprocess.run(
+        [sys.executable, "-m", "build", "--{}".format(kind), "--outdir", str(out_dir)],
+        cwd=str(HERE),
+        env=env,
+        check=True,
+    )
+
+
+def extract_binary(archive):
+    """Extract the vigilante binary from a release archive to the staging path."""
+    STAGED_BINARY.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(archive) as tf:
+        member = tf.getmember("vigilante")
+        with tf.extractfile(member) as src, open(STAGED_BINARY, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+    STAGED_BINARY.chmod(0o755)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, help="release version, no leading v")
+    parser.add_argument("--archives", required=True, type=Path)
+    parser.add_argument("--out", required=True, type=Path)
+    args = parser.parse_args()
+
+    if args.version.startswith("v"):
+        sys.exit("build_wheels: --version must not carry the leading v (PEP 440)")
+
+    # Version-consistency gate: every expected archive must exist under the
+    # exact tag-derived name before anything is built.
+    archives = {}
+    for suffix, plat in TARGETS:
+        archive = args.archives / "vigilante_{}_{}.tar.gz".format(args.version, suffix)
+        if not archive.is_file():
+            present = ", ".join(sorted(p.name for p in args.archives.iterdir())) or "none"
+            sys.exit(
+                "build_wheels: expected release archive {} not found "
+                "(downloaded: {}) — tag/artifact version mismatch?".format(
+                    archive.name, present
+                )
+            )
+        archives[plat] = archive
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    version_env = {"VIGILANTE_VERSION": args.version}
+
+    # The sdist is built first, with no binary staged, so it can never
+    # accidentally contain one (MANIFEST.in excludes it as well).
+    if STAGED_BINARY.exists():
+        STAGED_BINARY.unlink()
+    run_build("sdist", args.out, version_env)
+
+    name_norm = dist_name().replace("-", "_")
+    for suffix, plat in TARGETS:
+        extract_binary(archives[plat])
+        try:
+            run_build("wheel", args.out, dict(version_env, VIGILANTE_PLAT_NAME=plat))
+        finally:
+            STAGED_BINARY.unlink()
+        wheel = args.out / "{}-{}-py3-none-{}.whl".format(name_norm, args.version, plat)
+        if not wheel.is_file():
+            sys.exit("build_wheels: expected wheel {} was not produced".format(wheel.name))
+        print("built {} from {}".format(wheel.name, archives[plat].name))
+
+    print("built sdist and {} wheels into {}".format(len(TARGETS), args.out))
+
+
+if __name__ == "__main__":
+    main()

--- a/packaging/pypi/check_wheel.py
+++ b/packaging/pypi/check_wheel.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Pre-upload gate for the vigilante PyPI artifacts.
+
+Inspects every wheel built by build_wheels.py and fails the release when any
+invariant is broken. The regression that matters most is a wheel silently
+reverting to py3-none-any: pip would serve it to every platform, including
+ones the binary cannot run on. The other checks catch a lost executable bit,
+a stray .py file, a console-script shim, and purelib metadata.
+
+Usage: check_wheel.py --dist <dir> --version <pep440-version>
+"""
+
+import argparse
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+# GoReleaser archive suffix -> wheel platform tag. Mirrors the release build
+# matrix in .goreleaser.yml (darwin/linux x amd64/arm64, minus linux/arm64).
+# manylinux2014 is honest for the Linux binary because it is CGO_ENABLED=0
+# and therefore fully static. The macOS tags are permissive floors.
+TARGETS = [
+    ("macOS_arm64", "macosx_11_0_arm64"),
+    ("macOS_amd64", "macosx_10_13_x86_64"),
+    ("Linux_amd64", "manylinux2014_x86_64"),
+]
+
+
+def dist_name():
+    """The distribution name, read from pyproject.toml (its single source)."""
+    pyproject = Path(__file__).resolve().parent / "pyproject.toml"
+    match = re.search(r'^name = "([^"]+)"', pyproject.read_text(encoding="utf-8"), re.M)
+    if not match:
+        sys.exit("check_wheel: could not read `name` from pyproject.toml")
+    return match.group(1)
+
+
+def check_wheel(wheel, name_norm, version, plat):
+    """Return a list of problems with one wheel (empty when it is sound)."""
+    problems = []
+    data_script = "{}-{}.data/scripts/vigilante".format(name_norm, version)
+    dist_info = "{}-{}.dist-info".format(name_norm, version)
+
+    with zipfile.ZipFile(wheel) as zf:
+        names = zf.namelist()
+
+        py_files = [n for n in names if n.endswith(".py")]
+        if py_files:
+            problems.append("contains Python files: {}".format(", ".join(py_files)))
+
+        if any(n.endswith("entry_points.txt") for n in names):
+            problems.append("declares entry points; the binary must not be shimmed")
+
+        if data_script not in names:
+            problems.append("missing binary at {}".format(data_script))
+        else:
+            mode = zf.getinfo(data_script).external_attr >> 16
+            if mode & 0o111 != 0o111:
+                problems.append(
+                    "binary mode {:o} lacks the executable bit".format(mode)
+                )
+
+        wheel_meta = "{}/WHEEL".format(dist_info)
+        if wheel_meta not in names:
+            problems.append("missing {}".format(wheel_meta))
+        else:
+            meta = zf.read(wheel_meta).decode("utf-8")
+            if "Root-Is-Purelib: false" not in meta:
+                problems.append("WHEEL metadata is not Root-Is-Purelib: false")
+            expected_tag = "Tag: py3-none-{}".format(plat)
+            if expected_tag not in meta:
+                problems.append(
+                    "WHEEL metadata lacks '{}' (got: {})".format(
+                        expected_tag,
+                        ", ".join(l for l in meta.splitlines() if l.startswith("Tag:")),
+                    )
+                )
+
+    return problems
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dist", required=True, type=Path)
+    parser.add_argument("--version", required=True)
+    args = parser.parse_args()
+
+    name_norm = dist_name().replace("-", "_")
+    failures = []
+
+    for _, plat in TARGETS:
+        wheel = args.dist / "{}-{}-py3-none-{}.whl".format(name_norm, args.version, plat)
+        if not wheel.is_file():
+            failures.append("{}: wheel not found".format(wheel.name))
+            continue
+        for problem in check_wheel(wheel, name_norm, args.version, plat):
+            failures.append("{}: {}".format(wheel.name, problem))
+        print("checked {}".format(wheel.name))
+
+    sdist = args.dist / "{}-{}.tar.gz".format(name_norm, args.version)
+    if not sdist.is_file():
+        failures.append("{}: sdist not found".format(sdist.name))
+    else:
+        print("checked {}".format(sdist.name))
+
+    extras = sorted(
+        p.name
+        for p in args.dist.iterdir()
+        if p.suffix in (".whl", ".gz") and "py3-none-any" in p.name
+    )
+    for extra in extras:
+        failures.append("{}: unexpected py3-none-any artifact".format(extra))
+
+    if failures:
+        print("check_wheel: FAILED", file=sys.stderr)
+        for failure in failures:
+            print("  - {}".format(failure), file=sys.stderr)
+        sys.exit(1)
+    print("check_wheel: all artifacts OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -1,0 +1,35 @@
+# PyPI packaging for the prebuilt vigilante binary. The wheels contain no
+# Python code: each one embeds the matching GoReleaser-built binary under
+# <dist>.data/scripts/ so pip places it on PATH. See docs/releasing.md.
+#
+# The distribution name below is the single source of truth for it; the
+# packaging scripts read it from this file. `vigilante` itself is taken on
+# PyPI by an unrelated project, hence `vigilante-cli`. The installed command
+# is still `vigilante`.
+
+[build-system]
+requires = ["setuptools>=70.1", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vigilante-cli"
+description = "Autonomous GitHub issue runner for headless coding agents (prebuilt vigilante binary)"
+readme = "README.md"
+license = { text = "Apache-2.0" }
+# No Python code runs at runtime, so the floor is only what pip needs.
+requires-python = ">=3.8"
+dynamic = ["version"]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
+    "Topic :: Software Development",
+]
+
+[project.urls]
+Homepage = "https://github.com/aliengiraffe/vigilante"
+Releases = "https://github.com/aliengiraffe/vigilante/releases"
+
+[tool.setuptools]
+# The wheel intentionally ships zero importable Python.
+packages = []

--- a/packaging/pypi/setup.py
+++ b/packaging/pypi/setup.py
@@ -1,0 +1,120 @@
+"""Wheel builder for the prebuilt vigilante binary.
+
+One setup.py builds every platform wheel: the release pipeline stages the
+already-released, already-signed Go binary at scripts/vigilante, sets
+VIGILANTE_VERSION and VIGILANTE_PLAT_NAME, and runs the build. The binary is
+declared through the classic `scripts` argument so it lands in
+<dist>-<version>.data/scripts/vigilante inside the wheel — the standard
+mechanism pip uses to copy a file onto PATH with the executable bit set. No
+console-script entry point and no Python launcher shim: the installed
+`vigilante` is the Go binary itself.
+
+The sdist is a deliberate loud-failure fallback. It contains no binary, so
+building a wheel from it (what pip does on platforms with no matching wheel,
+e.g. Windows or Linux arm64) aborts with instructions instead of installing a
+broken or no-op package. It intentionally does not build from Go source: a
+local rebuild would lack the release signing and the ldflags version stamp.
+"""
+
+import os
+from pathlib import Path
+
+# setuptools must be imported first: it installs the distutils shim that the
+# next import resolves to on Python >= 3.12, where stdlib distutils is gone.
+from setuptools import setup
+from setuptools.command.bdist_wheel import bdist_wheel
+
+from distutils.command.build_scripts import build_scripts
+
+HERE = Path(__file__).resolve().parent
+BINARY = HERE / "scripts" / "vigilante"
+
+UNSUPPORTED_PLATFORM_MESSAGE = """
+*** No prebuilt vigilante binary is available for this platform. ***
+
+vigilante-cli ships prebuilt wheels for macOS (arm64 and x86_64) and
+Linux (x86_64) only. On other platforms, install Vigilante with Homebrew:
+
+    brew install --cask aliengiraffe/spaceship/vigilante
+
+or download a release archive for your platform directly:
+
+    https://github.com/aliengiraffe/vigilante/releases
+"""
+
+
+def dist_version():
+    """Return the release version: from the pipeline env, or from the
+    sdist's recorded metadata so metadata preparation works during the
+    (intentionally failing) install-from-sdist path."""
+    version = os.environ.get("VIGILANTE_VERSION")
+    if version:
+        return version
+    pkg_info = HERE / "PKG-INFO"
+    if pkg_info.is_file():
+        for line in pkg_info.read_text(encoding="utf-8").splitlines():
+            if line.startswith("Version:"):
+                return line.split(":", 1)[1].strip()
+    return "0.0.0"
+
+
+def target_platform(cmd):
+    """The wheel platform tag: VIGILANTE_PLAT_NAME, or --plat-name."""
+    env_plat = os.environ.get("VIGILANTE_PLAT_NAME")
+    if env_plat:
+        return env_plat
+    if cmd.plat_name_supplied:
+        return cmd.plat_name
+    return None
+
+
+class BinaryScripts(build_scripts):
+    """build_scripts that copies the binary verbatim.
+
+    The stock implementation tokenizes each script to rewrite a Python
+    shebang and raises SyntaxError on a Mach-O/ELF binary. There is no
+    shebang to rewrite here — copy the bytes untouched (rewriting them
+    would also invalidate the macOS code signature).
+    """
+
+    def copy_scripts(self):
+        self.mkpath(self.build_dir)
+        outfiles = []
+        for script in self.scripts:
+            outfile = os.path.join(self.build_dir, os.path.basename(script))
+            self.copy_file(script, outfile)
+            os.chmod(outfile, 0o755)
+            outfiles.append(outfile)
+        return outfiles, outfiles
+
+
+class BinaryWheel(bdist_wheel):
+    """bdist_wheel that emits a py3-none-<platform> wheel around the binary."""
+
+    def finalize_options(self):
+        super().finalize_options()
+        # The payload is a compiled binary, not pure Python; without this the
+        # wheel would be tagged py3-none-any and served to every platform.
+        self.root_is_pure = False
+
+    def run(self):
+        if not BINARY.is_file() or target_platform(self) is None:
+            raise SystemExit(UNSUPPORTED_PLATFORM_MESSAGE)
+        # bdist_wheel records the mode it finds on disk; make sure the
+        # executable bit survives the wheel round trip.
+        BINARY.chmod(0o755)
+        super().run()
+
+    def get_tag(self):
+        plat = target_platform(self)
+        if plat is None:
+            raise SystemExit(UNSUPPORTED_PLATFORM_MESSAGE)
+        return "py3", "none", plat.replace("-", "_").replace(".", "_")
+
+
+setup(
+    version=dist_version(),
+    cmdclass={"bdist_wheel": BinaryWheel, "build_scripts": BinaryScripts},
+    # Present only while the pipeline builds a wheel; absent in the sdist.
+    scripts=["scripts/vigilante"] if BINARY.is_file() else [],
+)


### PR DESCRIPTION
## Summary

Makes Vigilante installable with `pip install vigilante-cli` (also `pipx` / `uv tool`) by publishing platform-specific prebuilt-binary wheels to PyPI on every tagged release. Each wheel contains zero Python code: it embeds the matching already-released, already-signed GoReleaser binary under `vigilante_cli-<version>.data/scripts/vigilante`, so pip places the Go binary itself on `PATH` — no Go toolchain at install time, no Python launcher shim, no console-script entry point.

**Distribution name:** `vigilante-cli` (the issue's recommended option; `vigilante` on PyPI belongs to an unrelated project). The installed command is still `vigilante`. The name has a single source of truth in `packaging/pypi/pyproject.toml` — trivially changeable before first publish if a maintainer prefers another option.

## What changed

- **`packaging/pypi/`** — `pyproject.toml` + `setup.py`: one `setup.py` builds all three wheels. A `bdist_wheel` subclass overrides `get_tag()` to `py3-none-<platform>` and sets `root_is_pure = False`; a `build_scripts` subclass copies the binary verbatim (the stock implementation tokenizes scripts for shebang rewriting and would both crash on and corrupt a signed Mach-O). Platform comes from `VIGILANTE_PLAT_NAME` (or `--plat-name`), version from `VIGILANTE_VERSION` (tag with `v` stripped, matching GoReleaser/Homebrew exactly).
- **Sdist = loud-failure fallback.** On platforms with no wheel (Windows, Linux arm64), pip falls back to the sdist, whose wheel build aborts with a message naming the Homebrew cask command and the GitHub releases URL. It never installs a no-op package and never compiles Go (a local rebuild would lose signing and the ldflags version stamp).
- **`packaging/pypi/build_wheels.py`** — assembles sdist + 3 wheels from the published release archives; expected archive filenames embed the tag-derived version, doubling as the tag/artifact version-consistency gate.
- **`packaging/pypi/check_wheel.py`** — pre-upload gate: exact `py3-none-<platform>` tag per wheel, binary present under `.data/scripts/` with the executable bit recorded, zero `.py` files, no entry points, `Root-Is-Purelib: false`, and no stray `py3-none-any` artifact (the worst regression — it would be served to every platform).
- **`.github/workflows/release.yml`** — new `pypi` job: `needs: release`, `ubuntu-latest`, `timeout-minutes: 15`, job-level `permissions: contents: read` + `id-token: write` for PyPI Trusted Publishing (OIDC, `main` environment; workflow-level permissions untouched). Downloads archives with `gh release download`, builds, verifies, publishes with SHA-pinned `pypa/gh-action-pypi-publish`. Ordering is intentional: GitHub release and cask are live before PyPI is attempted, so a PyPI outage can't block a signed release, while a failed upload still fails the run.
- **Docs** — pip/pipx/uv install paths in `README.md` and `DOCS.md` (explicit that pip delivers the binary only; `git`, authenticated `gh`, and a coding-agent CLI remain prerequisites; Homebrew stays the recommended macOS path), and a full PyPI section in `docs/releasing.md` covering the job, Trusted Publishing setup, Test PyPI rehearsal, and local verification.

## Validation

Local end-to-end rehearsal (macOS arm64, clean venvs, simulated release archives from a locally built binary):

- `build_wheels.py` + `check_wheel.py`: 3 wheels + 1 sdist built, all gate checks green.
- `pip install` of the matching wheel: `vigilante` lands in `venv/bin` as a Mach-O 64-bit executable (verified with `file`), **byte-identical** to the archive's binary (`cmp`), executable bit set, `vigilante --help` runs. Also verified with a stock pip 21.2 to cover old installers.
- `pip install --force-reinstall` of the wrong-platform (manylinux) wheel: refused by pip ("not a supported wheel on this platform").
- `pip install` of the sdist: fails with the Homebrew + releases-page message; `pip show` confirms nothing was installed.
- `actionlint` on `release.yml`: clean. No Go code changed, so no Go tests were affected.

## Maintainer prerequisites before the first release using this path

1. Register `vigilante-cli` on PyPI (verified available in the issue as of 2026-08-10).
2. Configure a Trusted Publisher: `aliengiraffe/vigilante` / `release.yml` / environment `main` (documented in `docs/releasing.md`).
3. Rehearse against Test PyPI per `docs/releasing.md` before the first production tag, and verify Gatekeeper behavior of a pip-installed binary on a fresh Mac — a bare CLI binary's notarization is validated online, so execution is the only conclusive check.

Explicitly out of scope, per the issue: new GoReleaser targets (Windows, Linux arm64), `gh-sandbox` on PyPI, any importable Python, Test PyPI publishing on every commit.

Closes #516