### PR TITLE
Distribute vigilante via npm (prebuilt-binary packages)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Release
 
 # Builds, signs, and notarizes the macOS binaries with GoReleaser, then publishes
-# the GitHub release and the Homebrew cask.
+# the GitHub release and the Homebrew cask, and finally repackages the released
+# binaries into prebuilt npm packages (see the npm job below).
 #
 # Runs on macOS because signing needs Apple's native codesign/notarytool. The
 # Linux artifacts cross-compile from the same runner (everything is
@@ -102,3 +103,79 @@ jobs:
             echo "::warning::Apple notary credentials are not configured; the release will be signed but NOT notarized."
           fi
           goreleaser release --clean
+
+  # Repackages the already-published release archives into npm packages
+  # (packaging/npm/). Runs after `release`, so the GitHub release and the
+  # Homebrew cask are live before npm is attempted: an npm-registry outage
+  # degrades to "this version is missing from npm" instead of blocking a
+  # signed release, while a failed publish still fails the workflow loudly.
+  #
+  # The Go binary is NEVER rebuilt here — a rebuild would be unsigned, not
+  # notarized, and would lack the ldflags version stamp and telemetry
+  # configuration. This job only needs to download, repackage, and upload, so
+  # it runs on ubuntu-latest with no Apple or OTEL secrets.
+  npm:
+    needs: release
+    runs-on: ubuntu-latest
+    environment: main
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      # npm provenance (Sigstore attestation of this workflow run) needs
+      # OIDC. Publishing itself still authenticates with NPM_TOKEN below.
+      id-token: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download release archives
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          gh release download "$TAG_NAME" --repo "$GITHUB_REPOSITORY" \
+            --pattern 'vigilante_*.tar.gz' --dir release-archives
+
+      - name: Stage npm packages from released archives
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          node packaging/npm/build_packages.js \
+            --version "${TAG_NAME#v}" \
+            --archives release-archives
+
+      # The pre-publish gate: exact os/cpu per platform package, the binary
+      # present with the executable bit, no stray files or install scripts in
+      # a platform package, and optionalDependencies pinned to this version.
+      # A platform package silently missing its os/cpu fields is the worst
+      # regression here — npm would install it on every platform.
+      - name: Verify npm package contents
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          node packaging/npm/check_packages.js --version "${TAG_NAME#v}"
+
+      # Platform packages first, then the main package: the main package's
+      # optionalDependencies reference these exact versions, so publishing it
+      # first would let a freshly-published main package resolve to a
+      # missing platform package.
+      - name: Publish platform packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          for pkg in vigilante-cli-darwin-arm64 vigilante-cli-darwin-x64 vigilante-cli-linux-x64; do
+            npm publish --provenance --access public "packaging/npm/$pkg"
+          done
+
+      - name: Publish main package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm publish --provenance --access public packaging/npm/vigilante-cli

--- a/DOCS.md
+++ b/DOCS.md
@@ -55,6 +55,16 @@ Install with Homebrew:
 brew install --cask aliengiraffe/spaceship/vigilante
 ```
 
+Or from npm (macOS arm64/x64, Linux x64) — the package ships the same
+prebuilt `vigilante` binary, and the command name is unchanged:
+
+```sh
+npm install -g vigilante-cli   # or: npx vigilante-cli --help
+```
+
+Either way, `git`, an authenticated `gh`, and a coding-agent CLI must be
+installed separately — see the requirements below.
+
 Prepare the local machine. `--provider` defaults to `claude`, so pass the flag only when you want a different coding agent:
 
 ```sh
@@ -239,6 +249,25 @@ Upgrade later with:
 ```sh
 brew upgrade --cask vigilante
 ```
+
+Or install from npm:
+
+```sh
+npm install -g vigilante-cli
+npx vigilante-cli --help
+```
+
+The npm distribution is named `vigilante-cli` because `vigilante` on npm
+belongs to an unrelated project; the installed command is still `vigilante`.
+The package contains no JavaScript reimplementation of Vigilante — it embeds
+the prebuilt (and, on macOS, signed and notarized) release binary as an
+`optionalDependency`, resolved and placed on `PATH` through npm's own
+platform-matching machinery. Packages are published for macOS arm64, macOS
+x64, and Linux x64. On unsupported platforms (Windows, Linux arm64) the
+install fails with instructions pointing at Homebrew and the GitHub releases
+page rather than installing a broken package. npm installs the binary only:
+`git`, an authenticated `gh`, and a coding-agent CLI remain prerequisites, and
+`vigilante setup -d` is still the bootstrap step.
 
 ### `vigilante watch [--assignee <value>] [--max-parallel <value>] [--provider <codex|claude|gemini|opencode>] [--issue-tracker <github|linear>] [--issue-tracker-stage <value>] [--branch <name> | --track-default-branch] <path>`
 
@@ -562,6 +591,7 @@ Tagged releases are built and published with GoReleaser. Pushing a version tag t
 - `linux/amd64`
 - a `checksums.txt` file for the published archives
 - an updated Homebrew cask in the `aliengiraffe/homebrew-spaceship` tap so `brew install --cask aliengiraffe/spaceship/vigilante` installs the tagged release
+- prebuilt-binary npm packages published as `vigilante-cli`, repackaged from the published release archives after the GitHub release and cask are live (see [docs/releasing.md](docs/releasing.md))
 
 The release workflow requires a GitHub App that can write to the tap repository:
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,29 @@ Upgrading through Homebrew restarts the managed service for you, so
 `vigilante setup -d` yet there is no service to restart and the install still
 succeeds.
 
+Or install from npm. The package ships the same prebuilt `vigilante` binary
+the GitHub release carries — no Go toolchain and no JavaScript
+reimplementation involved:
+
+```sh
+npm install -g vigilante-cli
+```
+
+or run it once with `npx` (no global install needed):
+
+```sh
+npx vigilante-cli --help
+```
+
+The distribution is named `vigilante-cli` (the `vigilante` name on npm
+belongs to an unrelated project); the installed command is still `vigilante`.
+Prebuilt binaries exist for macOS arm64, macOS x64, and Linux x64 — on other
+platforms (Windows, Linux arm64) the install fails with pointers to Homebrew
+and the [releases page](https://github.com/aliengiraffe/vigilante/releases).
+Homebrew remains the recommended path on macOS; npm suits Node-centric teams,
+CI images that already have Node, and one-off `npx` usage. Note that npm
+delivers the binary only — the requirements below still apply.
+
 Requirements:
 
 - `git`

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -21,6 +21,7 @@ day-to-day release flow, and how to verify a published artifact.
 | `vigilante_<version>_Linux_amd64.tar.gz` | unsigned, unchanged |
 | `gh-sandbox_<version>_Linux_{amd64,arm64}.tar.gz` | unsigned, unchanged |
 | `checksums.txt` | covers all of the above |
+| `vigilante-cli`, `vigilante-cli-{darwin-arm64,darwin-x64,linux-x64}` (npm) | repackage the three `vigilante` archives above |
 
 macOS binaries are signed with our **Apple Developer ID Application**
 certificate under the hardened runtime and notarized by Apple's notary service,
@@ -275,10 +276,129 @@ git push origin v1.2.0
 ```
 
 The `Release` workflow runs on `macos-latest`, signs and notarizes, publishes the
-GitHub release, and updates the `vigilante` Homebrew cask.
+GitHub release, and updates the `vigilante` Homebrew cask. A second job then
+publishes the npm packages (next section).
 
 Nightlies need no action: every push to `main` republishes the rolling
-`main-nightly` prerelease and the `vigilante-nightly` cask.
+`main-nightly` prerelease and the `vigilante-nightly` cask. Nightlies do not
+publish to npm — only tagged releases do.
+
+## npm packages (`vigilante-cli`)
+
+Every tagged release also publishes **prebuilt-binary npm packages** so
+`npm install -g vigilante-cli` and `npx vigilante-cli` place the `vigilante`
+binary on `PATH` with no Go toolchain and no JavaScript reimplementation. The
+machinery lives in [`packaging/npm/`](../packaging/npm/) and the `npm` job of
+[`release.yml`](../.github/workflows/release.yml).
+
+The distribution is named **`vigilante-cli`** because the `vigilante` name on
+npm belongs to an unrelated project (see issue #520, where the decision is
+recorded, matching the PyPI name for consistency). The command users run is
+still `vigilante`.
+
+Layout, following the `optionalDependencies` prebuilt-binary pattern used by
+`esbuild`, `@swc/core`, and `rollup`:
+
+- `packaging/npm/vigilante-cli/` — the thin main package. `bin/vigilante.js`
+  resolves the platform package that matched at install time and `spawn`s the
+  real binary, forwarding argv/stdio/exit code. It declares
+  `optionalDependencies` on the three platform packages below; npm installs
+  only the one whose `os`/`cpu` match the current machine.
+- `packaging/npm/vigilante-cli-{darwin-arm64,darwin-x64,linux-x64}/` — each
+  declares its `os`/`cpu` pair and contains nothing but the extracted,
+  already-signed `vigilante` binary under `bin/`.
+
+How the job works, and the invariants it protects:
+
+- It runs **after** the `release` job, on `ubuntu-latest`, and downloads the
+  **already-published archives** with `gh release download`. The Go binary is
+  **never rebuilt** during packaging: a rebuild would be unsigned, not
+  notarized, and would lack the ldflags version stamp and telemetry
+  configuration, and the packaging job deliberately has no access to those
+  secrets.
+- Ordering is intentional: by the time npm is attempted, the GitHub release
+  and the Homebrew cask are live. An npm-registry outage therefore degrades to
+  "this version is missing from npm" — it can never abort a signed release.
+  The failed job still fails the workflow run, so it is visible, and it can be
+  re-run from the Actions UI once npm recovers.
+- `packaging/npm/build_packages.js` stages one binary per GoReleaser target
+  into its platform package and patches the version fields in place. The npm
+  version for a release is the tag with the leading `v` stripped and must
+  match the version embedded in the downloaded archive names, so a
+  tag/artifact mismatch fails the job instead of publishing a mislabeled
+  package.
+- `packaging/npm/check_packages.js` gates the publish: each platform package
+  must declare the exact `os`/`cpu` pair, contain the binary with the
+  executable bit set and nothing else, and declare neither `bin` nor
+  `scripts` (only the main package registers a command or runs install-time
+  code). The main package's `optionalDependencies` must be pinned to the
+  exact version being published. The worst regression this guards against is
+  a platform package silently missing its `os`/`cpu` fields, which would make
+  npm install it on every platform.
+- Publish order is platform packages first, then the main package: the main
+  package's `optionalDependencies` reference these exact versions, so
+  publishing it first could let a freshly-published main package resolve to
+  a platform package version that does not exist yet.
+- **`scripts/postinstall.js`** in the main package is the install-time
+  failure path for unsupported platforms (Windows, Linux arm64): npm silently
+  skips any `optionalDependency` whose `os`/`cpu` doesn't match, which would
+  otherwise install `vigilante-cli` with no binary and no error. The script
+  only checks whether the matching platform package resolved — it never
+  touches the network, so it is safe under `--ignore-scripts` audits and
+  offline installs alike (it simply doesn't run under `--ignore-scripts`,
+  which then leaves the install-time check to `bin/vigilante.js` at first
+  run).
+
+### Credential: npm token and provenance
+
+The job authenticates with an npm automation token stored as `NPM_TOKEN` in
+the `main` GitHub environment, wired through `actions/setup-node`'s
+`registry-url` into `NODE_AUTH_TOKEN`. Publishes also pass `--provenance`,
+which needs the job-level `id-token: write` permission (workflow-level
+permissions stay `contents: write`, untouched) — this attaches a Sigstore
+attestation proving the package was built by this exact workflow run, visible
+on the npm package page. Generate the token at
+<https://www.npmjs.com/settings/~/tokens> as an **Automation** token scoped to
+publish `vigilante-cli` and its platform packages, then:
+
+```bash
+gh secret set NPM_TOKEN --env main --repo aliengiraffe/vigilante
+```
+
+### Rehearsing and verifying
+
+The packaging machinery can be rehearsed locally without publishing anything:
+
+```bash
+gh release download v1.2.3 --pattern 'vigilante_*.tar.gz' --dir /tmp/archives
+node packaging/npm/build_packages.js --version 1.2.3 --archives /tmp/archives
+node packaging/npm/check_packages.js --version 1.2.3
+
+mkdir -p /tmp/npm-test/node_modules
+cp -R packaging/npm/vigilante-cli /tmp/npm-test/node_modules/
+cp -R packaging/npm/vigilante-cli-darwin-arm64 /tmp/npm-test/node_modules/   # match your machine
+node /tmp/npm-test/node_modules/vigilante-cli/bin/vigilante.js --help
+```
+
+Before the first production tag, also do one real end-to-end install from a
+`npm pack` tarball (or a scoped/private registry) on each of macOS arm64,
+macOS x64, and Linux x64: confirm `which vigilante`, `file $(which vigilante)`
+reports the right executable format, the executable bit is set, and
+`vigilante --version` matches the tag — the same rule as for the release
+archives, since a bare CLI binary's notarization is validated online (see the
+stapling note above), so execution is the only conclusive check. Also confirm
+`npm install -g vigilante-cli` fails with the unsupported-platform message on
+a platform with no matching package (Windows or Linux arm64), and that an
+install on one platform never downloads the `optionalDependencies` for the
+other two.
+
+### Platform coverage
+
+Packages exist only for the current GoReleaser matrix (macOS arm64/x64, Linux
+x64). Adding `linux/arm64` or Windows packages requires adding those targets
+to `.goreleaser.yml` first and is deliberately out of scope here;
+`packaging/npm/targets.js` carries the target table that would need to grow
+with it.
 
 ## Local validation
 

--- a/packaging/npm/.gitignore
+++ b/packaging/npm/.gitignore
@@ -1,0 +1,8 @@
+# The binary staged by build_packages.js from a release archive; nothing
+# under bin/ is ever committed for the platform packages — the payload comes
+# from the published GoReleaser archives at publish time.
+vigilante-cli-darwin-arm64/bin/vigilante
+vigilante-cli-darwin-x64/bin/vigilante
+vigilante-cli-linux-x64/bin/vigilante
+
+node_modules/

--- a/packaging/npm/build_packages.js
+++ b/packaging/npm/build_packages.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+'use strict';
+
+// Assemble the vigilante npm packages from already-released archives.
+//
+// Stages the binary extracted from each published GitHub release archive
+// into its platform package and patches the version fields in place. Never
+// builds Go: the released binaries carry the Developer ID signature,
+// notarization, and the ldflags version stamp, and a rebuild here would
+// silently lose all three.
+//
+// The expected archive filenames embed the release version, so looking them
+// up by name doubles as a tag/artifact consistency check: a mismatch fails
+// the release instead of publishing a mislabeled package.
+//
+// Usage: build_packages.js --version <version, no leading v> --archives <dir>
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const { TARGETS, mainPackageDir, platformPackageDir } = require('./targets');
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--version' || arg === '--archives') {
+      args[arg.slice(2)] = argv[(i += 1)];
+    } else {
+      throw new Error(`build_packages: unknown argument ${arg}`);
+    }
+  }
+  if (!args.version || !args.archives) {
+    throw new Error('build_packages: --version and --archives are required');
+  }
+  return args;
+}
+
+function extractBinary(archivePath, destPath) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vigilante-npm-'));
+  try {
+    execFileSync('tar', ['xzf', archivePath, '-C', tmpDir, 'vigilante']);
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+    fs.copyFileSync(path.join(tmpDir, 'vigilante'), destPath);
+    fs.chmodSync(destPath, 0o755);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function writeVersion(packageJsonPath, version, optionalDependencyVersion) {
+  const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  pkg.version = version;
+  if (optionalDependencyVersion && pkg.optionalDependencies) {
+    for (const name of Object.keys(pkg.optionalDependencies)) {
+      pkg.optionalDependencies[name] = optionalDependencyVersion;
+    }
+  }
+  fs.writeFileSync(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.version.startsWith('v')) {
+    throw new Error('build_packages: --version must not carry the leading v');
+  }
+
+  const archivesDir = path.resolve(args.archives);
+
+  for (const target of TARGETS) {
+    const archiveName = `vigilante_${args.version}_${target.archiveSuffix}.tar.gz`;
+    const archivePath = path.join(archivesDir, archiveName);
+    if (!fs.existsSync(archivePath)) {
+      const present = fs.existsSync(archivesDir)
+        ? fs.readdirSync(archivesDir).sort().join(', ') || 'none'
+        : 'none (directory missing)';
+      throw new Error(
+        `build_packages: expected release archive ${archiveName} not found ` +
+          `(downloaded: ${present}) — tag/artifact version mismatch?`
+      );
+    }
+
+    const pkgDir = platformPackageDir(target);
+    const binaryPath = path.join(pkgDir, 'bin', 'vigilante');
+    extractBinary(archivePath, binaryPath);
+    writeVersion(path.join(pkgDir, 'package.json'), args.version, null);
+    console.log(`staged ${target.npmPackage}@${args.version} from ${archiveName}`);
+  }
+
+  writeVersion(path.join(mainPackageDir(), 'package.json'), args.version, args.version);
+  console.log(`staged vigilante-cli@${args.version} with pinned optionalDependencies`);
+}
+
+main();

--- a/packaging/npm/check_packages.js
+++ b/packaging/npm/check_packages.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+'use strict';
+
+// Pre-publish gate for the vigilante npm packages.
+//
+// Inspects every package built by build_packages.js and fails the release
+// when any invariant is broken. The regression that matters most is a
+// platform package missing its os/cpu fields: npm would then install it on
+// every platform, including ones the binary cannot run on. The other checks
+// catch a lost executable bit, stray code shipped in a platform package, and
+// version skew between the main package and its optionalDependencies.
+//
+// Usage: check_packages.js --version <version, no leading v>
+
+const fs = require('fs');
+const path = require('path');
+
+const { TARGETS, mainPackageDir, platformPackageDir } = require('./targets');
+
+const NETWORK_TOKENS = [
+  "require('http')",
+  'require("http")',
+  "require('https')",
+  'require("https")',
+  'fetch(',
+  'XMLHttpRequest',
+];
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--version') {
+      args.version = argv[(i += 1)];
+    } else {
+      throw new Error(`check_packages: unknown argument ${arg}`);
+    }
+  }
+  if (!args.version) {
+    throw new Error('check_packages: --version is required');
+  }
+  return args;
+}
+
+function readPackageJson(dir) {
+  return JSON.parse(fs.readFileSync(path.join(dir, 'package.json'), 'utf8'));
+}
+
+function checkPlatformPackage(target, version, failures) {
+  const dir = platformPackageDir(target);
+  const label = target.npmPackage;
+
+  const pkg = readPackageJson(dir);
+  if (pkg.version !== version) {
+    failures.push(`${label}: version is ${pkg.version}, expected ${version}`);
+  }
+  if (JSON.stringify(pkg.os) !== JSON.stringify([target.os])) {
+    failures.push(`${label}: "os" is ${JSON.stringify(pkg.os)}, expected ["${target.os}"]`);
+  }
+  if (JSON.stringify(pkg.cpu) !== JSON.stringify([target.cpu])) {
+    failures.push(`${label}: "cpu" is ${JSON.stringify(pkg.cpu)}, expected ["${target.cpu}"]`);
+  }
+  if (pkg.bin) {
+    failures.push(`${label}: must not declare "bin" — only the main package registers a command`);
+  }
+  if (pkg.scripts) {
+    failures.push(`${label}: must not declare "scripts" — platform packages run no install-time code`);
+  }
+
+  const binaryPath = path.join(dir, 'bin', 'vigilante');
+  if (!fs.existsSync(binaryPath)) {
+    failures.push(`${label}: missing staged binary at bin/vigilante`);
+  } else {
+    const mode = fs.statSync(binaryPath).mode;
+    if ((mode & 0o111) !== 0o111) {
+      failures.push(`${label}: bin/vigilante is not executable (mode ${(mode & 0o777).toString(8)})`);
+    }
+  }
+
+  const strayFiles = fs
+    .readdirSync(path.join(dir, 'bin'))
+    .filter((name) => name !== 'vigilante');
+  if (strayFiles.length > 0) {
+    failures.push(`${label}: unexpected files in bin/: ${strayFiles.join(', ')}`);
+  }
+}
+
+function checkMainPackage(version, failures) {
+  const dir = mainPackageDir();
+  const pkg = readPackageJson(dir);
+
+  if (pkg.version !== version) {
+    failures.push(`vigilante-cli: version is ${pkg.version}, expected ${version}`);
+  }
+
+  const expectedOptional = TARGETS.map((t) => t.npmPackage).sort();
+  const actualOptional = Object.keys(pkg.optionalDependencies || {}).sort();
+  if (JSON.stringify(actualOptional) !== JSON.stringify(expectedOptional)) {
+    failures.push(
+      `vigilante-cli: optionalDependencies keys are ${JSON.stringify(actualOptional)}, expected ${JSON.stringify(expectedOptional)}`
+    );
+  }
+  for (const name of expectedOptional) {
+    const pinned = (pkg.optionalDependencies || {})[name];
+    if (pinned !== version) {
+      failures.push(`vigilante-cli: optionalDependencies["${name}"] is ${pinned}, expected ${version}`);
+    }
+  }
+
+  if (!pkg.scripts || pkg.scripts.postinstall !== 'node scripts/postinstall.js') {
+    failures.push('vigilante-cli: missing the non-network postinstall platform check');
+  }
+
+  for (const relFile of ['bin/vigilante.js', 'lib/platforms.js', 'scripts/postinstall.js']) {
+    const filePath = path.join(dir, relFile);
+    if (!fs.existsSync(filePath)) {
+      failures.push(`vigilante-cli: missing ${relFile}`);
+      continue;
+    }
+    const contents = fs.readFileSync(filePath, 'utf8');
+    for (const token of NETWORK_TOKENS) {
+      if (contents.includes(token)) {
+        failures.push(`vigilante-cli: ${relFile} contains a networking call (${token}) — must never fetch over the network`);
+      }
+    }
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const failures = [];
+
+  for (const target of TARGETS) {
+    checkPlatformPackage(target, args.version, failures);
+  }
+  checkMainPackage(args.version, failures);
+
+  if (failures.length > 0) {
+    console.error('check_packages: FAILED');
+    for (const failure of failures) {
+      console.error(`  - ${failure}`);
+    }
+    process.exit(1);
+  }
+
+  console.log('check_packages: all packages OK');
+}
+
+main();

--- a/packaging/npm/targets.js
+++ b/packaging/npm/targets.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const path = require('path');
+
+const ROOT = __dirname;
+
+// GoReleaser archive suffix -> npm platform package. Mirrors the release
+// build matrix in .goreleaser.yml (darwin/linux x amd64/arm64, minus
+// linux/arm64) and the mapping in vigilante-cli/lib/platforms.js.
+const TARGETS = [
+  { archiveSuffix: 'macOS_arm64', npmPackage: 'vigilante-cli-darwin-arm64', os: 'darwin', cpu: 'arm64' },
+  { archiveSuffix: 'macOS_amd64', npmPackage: 'vigilante-cli-darwin-x64', os: 'darwin', cpu: 'x64' },
+  { archiveSuffix: 'Linux_amd64', npmPackage: 'vigilante-cli-linux-x64', os: 'linux', cpu: 'x64' },
+];
+
+function mainPackageDir() {
+  return path.join(ROOT, 'vigilante-cli');
+}
+
+function platformPackageDir(target) {
+  return path.join(ROOT, target.npmPackage);
+}
+
+module.exports = { TARGETS, mainPackageDir, platformPackageDir };

--- a/packaging/npm/vigilante-cli-darwin-arm64/README.md
+++ b/packaging/npm/vigilante-cli-darwin-arm64/README.md
@@ -1,0 +1,6 @@
+# vigilante-cli-darwin-arm64
+
+Prebuilt `vigilante` binary for macOS arm64, published as an
+`optionalDependency` of [`vigilante-cli`](https://www.npmjs.com/package/vigilante-cli).
+Do not install this package directly — run `npm install -g vigilante-cli`
+instead.

--- a/packaging/npm/vigilante-cli-darwin-arm64/package.json
+++ b/packaging/npm/vigilante-cli-darwin-arm64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "vigilante-cli-darwin-arm64",
+  "version": "0.0.0-placeholder",
+  "description": "vigilante prebuilt binary for darwin/arm64 (installed automatically as an optionalDependency of vigilante-cli; do not install directly)",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/aliengiraffe/vigilante",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aliengiraffe/vigilante.git"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin"
+  ]
+}

--- a/packaging/npm/vigilante-cli-darwin-x64/README.md
+++ b/packaging/npm/vigilante-cli-darwin-x64/README.md
@@ -1,0 +1,6 @@
+# vigilante-cli-darwin-x64
+
+Prebuilt `vigilante` binary for macOS x64, published as an
+`optionalDependency` of [`vigilante-cli`](https://www.npmjs.com/package/vigilante-cli).
+Do not install this package directly — run `npm install -g vigilante-cli`
+instead.

--- a/packaging/npm/vigilante-cli-darwin-x64/package.json
+++ b/packaging/npm/vigilante-cli-darwin-x64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "vigilante-cli-darwin-x64",
+  "version": "0.0.0-placeholder",
+  "description": "vigilante prebuilt binary for darwin/x64 (installed automatically as an optionalDependency of vigilante-cli; do not install directly)",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/aliengiraffe/vigilante",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aliengiraffe/vigilante.git"
+  },
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin"
+  ]
+}

--- a/packaging/npm/vigilante-cli-linux-x64/README.md
+++ b/packaging/npm/vigilante-cli-linux-x64/README.md
@@ -1,0 +1,6 @@
+# vigilante-cli-linux-x64
+
+Prebuilt `vigilante` binary for Linux x64, published as an
+`optionalDependency` of [`vigilante-cli`](https://www.npmjs.com/package/vigilante-cli).
+Do not install this package directly — run `npm install -g vigilante-cli`
+instead.

--- a/packaging/npm/vigilante-cli-linux-x64/package.json
+++ b/packaging/npm/vigilante-cli-linux-x64/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "vigilante-cli-linux-x64",
+  "version": "0.0.0-placeholder",
+  "description": "vigilante prebuilt binary for linux/x64 (installed automatically as an optionalDependency of vigilante-cli; do not install directly)",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/aliengiraffe/vigilante",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aliengiraffe/vigilante.git"
+  },
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin"
+  ]
+}

--- a/packaging/npm/vigilante-cli/README.md
+++ b/packaging/npm/vigilante-cli/README.md
@@ -1,0 +1,33 @@
+# vigilante-cli
+
+Prebuilt-binary distribution of [Vigilante](https://github.com/aliengiraffe/vigilante),
+the autonomous GitHub issue runner for headless coding agents.
+
+This package contains no JavaScript reimplementation of Vigilante — it places
+the already-signed `vigilante` Go binary for your platform on `PATH`:
+
+```sh
+npm install -g vigilante-cli
+vigilante --help
+```
+
+or run it once with `npx`:
+
+```sh
+npx vigilante-cli --help
+```
+
+Prebuilt binaries exist for macOS arm64, macOS x64, and Linux x64. On other
+platforms (Windows, Linux arm64) installation fails with instructions; use
+Homebrew, pip, or a [GitHub release archive](https://github.com/aliengiraffe/vigilante/releases)
+instead:
+
+```sh
+brew install --cask aliengiraffe/spaceship/vigilante
+pipx install vigilante-cli
+```
+
+Installing this package delivers the binary only. Vigilante still requires
+`git`, an authenticated `gh`, and a locally installed coding-agent CLI
+(`claude` by default, or `codex`, `gemini`, `opencode`) — see the
+[README](https://github.com/aliengiraffe/vigilante#install) for setup.

--- a/packaging/npm/vigilante-cli/bin/vigilante.js
+++ b/packaging/npm/vigilante-cli/bin/vigilante.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+'use strict';
+
+// Forwards argv/stdio/exit code to the prebuilt vigilante binary shipped by
+// the platform-specific optionalDependency package (see lib/platforms.js).
+// This file never fetches anything over the network: the binary is already
+// on disk by the time this shim runs, staged by npm's own optionalDependency
+// resolution at install time.
+
+const { spawnSync } = require('child_process');
+const { platformPackage, UNSUPPORTED_PLATFORM_MESSAGE } = require('../lib/platforms');
+
+function resolveBinary() {
+  const pkgName = platformPackage();
+  if (!pkgName) {
+    return null;
+  }
+  try {
+    return require.resolve(`${pkgName}/bin/vigilante`);
+  } catch (err) {
+    return null;
+  }
+}
+
+function main() {
+  const binaryPath = resolveBinary();
+  if (!binaryPath) {
+    process.stderr.write(UNSUPPORTED_PLATFORM_MESSAGE);
+    process.exit(1);
+  }
+
+  const result = spawnSync(binaryPath, process.argv.slice(2), { stdio: 'inherit' });
+  if (result.error) {
+    process.stderr.write(`vigilante-cli: failed to launch ${binaryPath}: ${result.error.message}\n`);
+    process.exit(1);
+  }
+  process.exit(result.status === null ? 1 : result.status);
+}
+
+main();

--- a/packaging/npm/vigilante-cli/lib/platforms.js
+++ b/packaging/npm/vigilante-cli/lib/platforms.js
@@ -1,0 +1,35 @@
+'use strict';
+
+// Single source of truth for the platform-package mapping, shared by the
+// bin/ shim (runtime dispatch) and scripts/postinstall.js (install-time
+// check). Mirrors the GoReleaser build matrix in .goreleaser.yml
+// (darwin/linux x amd64/arm64, minus linux/arm64) and packaging/npm/*.
+
+const PLATFORM_PACKAGES = {
+  'darwin-arm64': 'vigilante-cli-darwin-arm64',
+  'darwin-x64': 'vigilante-cli-darwin-x64',
+  'linux-x64': 'vigilante-cli-linux-x64',
+};
+
+const UNSUPPORTED_PLATFORM_MESSAGE = `
+*** No prebuilt vigilante binary is available for this platform. ***
+
+vigilante-cli ships prebuilt binaries for macOS (arm64 and x64) and Linux
+(x64) only. On other platforms, install Vigilante with Homebrew:
+
+    brew install --cask aliengiraffe/spaceship/vigilante
+
+or with pip:
+
+    pipx install vigilante-cli
+
+or download a release archive for your platform directly:
+
+    https://github.com/aliengiraffe/vigilante/releases
+`;
+
+function platformPackage() {
+  return PLATFORM_PACKAGES[`${process.platform}-${process.arch}`] || null;
+}
+
+module.exports = { PLATFORM_PACKAGES, UNSUPPORTED_PLATFORM_MESSAGE, platformPackage };

--- a/packaging/npm/vigilante-cli/package.json
+++ b/packaging/npm/vigilante-cli/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "vigilante-cli",
+  "version": "0.0.0-placeholder",
+  "description": "Autonomous GitHub issue runner for headless coding agents (prebuilt vigilante binary)",
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/aliengiraffe/vigilante",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aliengiraffe/vigilante.git"
+  },
+  "bugs": {
+    "url": "https://github.com/aliengiraffe/vigilante/issues"
+  },
+  "bin": {
+    "vigilante": "bin/vigilante.js"
+  },
+  "files": [
+    "bin",
+    "lib",
+    "scripts"
+  ],
+  "scripts": {
+    "postinstall": "node scripts/postinstall.js"
+  },
+  "optionalDependencies": {
+    "vigilante-cli-darwin-arm64": "0.0.0-placeholder",
+    "vigilante-cli-darwin-x64": "0.0.0-placeholder",
+    "vigilante-cli-linux-x64": "0.0.0-placeholder"
+  },
+  "engines": {
+    "node": ">=16"
+  }
+}

--- a/packaging/npm/vigilante-cli/scripts/postinstall.js
+++ b/packaging/npm/vigilante-cli/scripts/postinstall.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+'use strict';
+
+// Install-time gate: npm silently skips any optionalDependency whose os/cpu
+// doesn't match, so an unsupported platform would otherwise install this
+// package with no binary and no error. This script makes that failure loud
+// instead, without ever touching the network — it only checks whether the
+// matching platform package resolved.
+
+const { platformPackage, UNSUPPORTED_PLATFORM_MESSAGE } = require('../lib/platforms');
+
+function main() {
+  const pkgName = platformPackage();
+  if (pkgName) {
+    try {
+      require.resolve(`${pkgName}/package.json`);
+      return;
+    } catch (err) {
+      // fall through to the failure message below
+    }
+  }
+
+  process.stderr.write(UNSUPPORTED_PLATFORM_MESSAGE);
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

Makes Vigilante installable with `npm install -g vigilante-cli` (also `npx vigilante-cli`) by publishing platform-specific prebuilt-binary packages to npm on every tagged release. No JavaScript reimplementation of Vigilante: the packages place the existing, already-signed GoReleaser `vigilante` binary on `PATH`, mirroring the pip distribution approach (#518) for the npm ecosystem.

**Distribution name:** `vigilante-cli`, per the maintainer decision recorded on #520 (`vigilante` on npm belongs to an unrelated project). The installed command is still `vigilante`.

## What changed

- **`packaging/npm/vigilante-cli/`** — thin main package: `bin/vigilante.js` resolves whichever platform package npm's `optionalDependencies` resolution installed for the current `os`/`cpu`, then `spawn`s the real binary, forwarding argv/stdio/exit code. `scripts/postinstall.js` fails loudly (no network) when no platform package matched, so an unsupported platform (Windows, Linux arm64) fails `npm install` itself instead of silently installing a broken package. `lib/platforms.js` is the single source of truth for the platform map, shared by both.
- **`packaging/npm/vigilante-cli-{darwin-arm64,darwin-x64,linux-x64}/`** — each declares the matching `os`/`cpu` pair and ships nothing but the extracted, already-signed binary under `bin/`.
- **`packaging/npm/build_packages.js`** — stages the binary from each already-published release archive (`gh release download`, never rebuilt) into its platform package and patches the version fields in place; the expected archive names double as a tag/artifact version-consistency gate.
- **`packaging/npm/check_packages.js`** — pre-publish gate: exact `os`/`cpu` per platform package, executable bit set, no stray files or install scripts in a platform package, and `optionalDependencies` in the main package pinned to the exact version being published.
- **`.github/workflows/release.yml`** — new `npm` job: `needs: release`, `ubuntu-latest`, `timeout-minutes: 15`, job-level `permissions: contents: read` + `id-token: write` for npm provenance (workflow-level permissions untouched). Downloads archives, builds, verifies, and publishes platform packages before the main package with `npm publish --provenance`, authenticated via an `NPM_TOKEN` automation token in the `main` environment.
- **Docs** — npm/npx install paths in `README.md` and `DOCS.md` (npm delivers the binary only; `git`, authenticated `gh`, and a coding-agent CLI remain prerequisites; Homebrew stays the recommended macOS path), and a full npm section in `docs/releasing.md` covering the job, the credential setup, rehearsal steps, and platform coverage.

## Validation

- `node packaging/npm/build_packages.js` / `check_packages.js` rehearsed locally against a synthetic release archive (the built `vigilante` binary repackaged as `vigilante_9.9.9_{macOS_arm64,macOS_amd64,Linux_amd64}.tar.gz`): all three platform packages plus the main package staged and passed the gate.
- Simulated an npm install layout (`node_modules/vigilante-cli` + the matching platform package) and ran `bin/vigilante.js` directly: it resolved and executed the real binary, forwarding `--version`/exit code correctly.
- Removed the matching platform package and re-ran both `scripts/postinstall.js` and `bin/vigilante.js`: both fail with exit code 1 and the Homebrew/pip/releases-page message — the same failure path an unsupported platform (Windows, Linux arm64) would hit.
- `node --check` on every new `.js` file; `JSON.parse` on every new `package.json`.
- `actionlint .github/workflows/release.yml`: clean.
- `goreleaser check`: clean (no `.goreleaser.yml` changes — the npm job only repackages already-published archives).
- No Go code changed, so no Go tests were affected.

## Maintainer prerequisites before the first release using this path

1. Register `vigilante-cli` on npm (and the platform package names).
2. Generate an npm **Automation** token scoped to publish `vigilante-cli` and its platform packages, store it as `NPM_TOKEN` in the `main` GitHub environment (`gh secret set NPM_TOKEN --env main --repo aliengiraffe/vigilante`).
3. Before the first production tag, do one real end-to-end install (from `npm pack` tarballs or a scoped registry) on macOS arm64, macOS x64, and Linux x64, and confirm the pip-adjacent Gatekeeper behavior for a fresh macOS install per `docs/releasing.md`.

Explicitly out of scope, per the issue: new GoReleaser targets (Windows, Linux arm64), `gh-sandbox` on npm, any JavaScript reimplementation of Vigilante's behavior, and an install-time network download of the binary.

Closes #520