### PR TITLE
Resolve --out to an absolute path in build_wheels.py

### DIFF
--- a/packaging/pypi/build_wheels.py
+++ b/packaging/pypi/build_wheels.py
@@ -56,6 +56,12 @@ def main():
     parser.add_argument("--out", required=True, type=Path)
     args = parser.parse_args()
 
+    # Resolved to absolute: run_build() launches `python -m build` with
+    # cwd=HERE, so a relative --out would resolve against the wrong
+    # directory there while the existence check below still resolves it
+    # against this process's cwd, silently doubling the path.
+    args.out = args.out.resolve()
+
     if args.version.startswith("v"):
         sys.exit("build_wheels: --version must not carry the leading v (PEP 440)")
 


### PR DESCRIPTION
## Summary
- The pypi release job in [run 32300845929](https://github.com/aliengiraffe/vigilante/actions/runs/32300845929/job/96223261974) failed with `build_wheels: expected wheel ... was not produced`, even though the log shows the wheel was built successfully.
- Root cause: `run_build()` launches `python -m build --outdir <out>` with `cwd=HERE` (`packaging/pypi`), but the release workflow passes `--out packaging/pypi/dist`, a path relative to the repo root. That mismatch made the wheel land in a doubled `packaging/pypi/packaging/pypi/dist` directory, so the later existence check in `main()` — which resolves `args.out` relative to the script's own cwd — couldn't find it and failed the job.
- Fix: resolve `args.out` to an absolute path once, right after argument parsing, so both the subprocess call and the existence check agree on the same location.

## Test plan
- [ ] `python3 -m py_compile packaging/pypi/build_wheels.py` (done locally, passes)
- [ ] Re-run the release/pypi workflow (or a manual dry run) to confirm wheels are produced and found at the expected path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYJb7ABtEQ1CATVgBPbFf2